### PR TITLE
New "How to route Tasks" guide

### DIFF
--- a/docs/route-tasks.md
+++ b/docs/route-tasks.md
@@ -18,7 +18,7 @@ Task routing is the development technique that pairs Tasks with Workers using Ta
 2. Register Workflow and/or Activity Tasks with the Worker.
 3. Configure Workflows and Activities to send Tasks to the Task Queue.
 
-Let's look a simple "Hello World" sample to see how this is done. In the following code snippet, we [create a new Worker](https://github.com/temporalio/go-samples/blob/master/helloworld/worker/main.go#L26) that is subscribed to the "hello-world" Task Queue and is registered to handle the `helloworld.Workflow` and `helloworld.Activity`:
+Let's look a simple "Hello World" sample to see how this is done. In the following code snippet we create a new Worker, subscribe it to the "hello-world" Task Queue, and register it to handle "Hello World" Workflow and "Hello World" Activity implementations:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -33,6 +33,7 @@ import TabItem from '@theme/TabItem';
 
 <TabItem value="java">
 
+[Sample source reference](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/hello/HelloActivity.java#L91-L99)
 ```java
 // Worker is created and subscribed to the "hello-world" Task Queue 
 Worker worker = factory.newWorker("hello-world");
@@ -45,8 +46,7 @@ worker.registerActivityImplementationTypes(HelloWorldActivityImpl)
 </TabItem>
 <TabItem value="go">
 
-[source](https://github.com/temporalio/temporal-go-samples/tree/master/helloworld)
-
+[Sample source reference](https://github.com/temporalio/go-samples/blob/master/helloworld/worker/main.go#L20-L23)
 ```go
 // Worker is created and subscribed to the "hello-world" Task Queue
 w := worker.New(c, "hello-world", worker.Options{})
@@ -60,7 +60,7 @@ w.RegisterActivity(helloworld.Activity)
 </TabItem>
 </Tabs>
 
-In the next code snippet, we [start the `helloworld.Workflow`](https://github.com/temporalio/go-samples/blob/master/helloworld/starter/main.go#L25):
+In the next code snippet, we start the "Hello World" Workflow:
 
 <Tabs
     defaultValue="go"
@@ -72,6 +72,7 @@ In the next code snippet, we [start the `helloworld.Workflow`](https://github.co
 
 <TabItem value="java">
 
+[Sample source reference](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/hello/HelloActivity.java#L91-L99)
 ```java
 HelloWorldWorkflow workflow =
     client.newWorkflowStub(
@@ -85,8 +86,9 @@ WorkflowExecution workflowExecution =
 ```
 
 </TabItem>
-<TabItem value="go"> 
+<TabItem value="go">
 
+[Sample source reference](https://github.com/temporalio/go-samples/blob/master/helloworld/starter/main.go#L20-L25)
 ```go
 // Workflow Options specify the "hello-world" Task Queue
 // Which is the Task Queue that the Workflow will send its Tasks to
@@ -114,13 +116,11 @@ If a Worker pulls a Task that it has not been registered to run, an "unknown wor
 
 ## Task routing for Activity dependencies
 
-The Temporal service will persist Activity results as long as the results are less than 2MB in size and can be serialized for storage (which happens to be true for most Activity results). However, there are some scenarios where an Activity execution will do something that results in data, such as a large file, being stored directly on the host where the Worker is running. It is also possible that the next Activity in the Workflow has a dependency on that data and needs to run on the same host.
+The Temporal service will persist Activity results as long as the results are less than 2MB in size and can be serialized for storage (which happens to be true for most Activity results). However, there are some scenarios where an Activity execution will do something that results in data or files being stored directly on the host where the Worker is running. It is also possible that the next Activity in the Workflow has a dependency on that data and needs to run on the same host.
 
 Let's look at a file processing Workflow example where files are downloaded, processed in some way, and then uploaded to some other location. If a large video file is being processed only the name of the file can persist normally. The file itself must persist locally on the Worker host, as it is too big for normal Temporal storage. This means that any future Activities that act on the video file must also take place on the host where the Worker downloaded it.
 
-So, how do we ensure that a Worker on the correct host will execute the next Activity that depends on the video file?
-
-This is accomplished in different ways depending on the SDK.
+So, how do we ensure that a Worker on the correct host will execute the next Activity that depends on the video file? This is accomplished in different ways depending on the SDK.
 
 ### Java
 

--- a/docs/route-tasks.md
+++ b/docs/route-tasks.md
@@ -13,6 +13,7 @@ The question is how do we make sure a specific Worker is executing a specific Ta
 ## Task routing with Task Queues
 
 Task Queues are what enable "Task routing". Task routing is the development technique that pairs Tasks with Workers. The basics of it can be broken down into 3 steps:
+
 1. Create a Worker that is registered to handle Workflow and/or Activity Tasks.
 2. Subscribe the Worker to listen to a Task Queue.
 3. Configure Workflows and Activities to send Tasks to the Task Queue.
@@ -67,7 +68,7 @@ This is accomplished in different ways depending on the SDK.
 
 ### Java
 
-Consider the [file processing sample in Java](https://github.com/temporalio/java-samples/tree/master/src/main/java/io/temporal/samples/fileprocessing), the paradigm is to create two Workers. Each will run on the same host and thus have access to the same file system, but one will listen to a global (shared) Task Queue, which it will use to start the Workflow, and the other will listen to its own host-specific (private) Task Queue. 
+Consider the [file processing sample in Java](https://github.com/temporalio/java-samples/tree/master/src/main/java/io/temporal/samples/fileprocessing). The paradigm is to create two Workers. Each will run on the same host and thus have access to the same file system, but one will listen to a global (shared) Task Queue, which it will use to start the Workflow, and the other will listen to its own host-specific (private) Task Queue. 
 
 The following code snippet is stripped down from the [FileProcessingWorker.java sample](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorker.java) and highlights the creation of two workers for this purpose:
 
@@ -118,21 +119,14 @@ The host-specific Task Queue is then set on [subsequent Activities](https://gith
 
 ```java
 private void processFileImpl(URL source, URL destination) {
-    StoreActivities.TaskQueueFileNamePair downloaded = defaultTaskQueueStore.download(source);
-
     // Initialize stubs that are specific to the returned task queue.
     ActivityOptions hostActivityOptions =
         ActivityOptions.newBuilder()
-        .setTaskQueue(downloaded.getHostTaskQueue())
+        // Set the host-specific Task Queue
+        .setTaskQueue(hostSpecificTaskQueue)
         .build();
-    StoreActivities hostSpecificStore =
-        Workflow.newActivityStub(StoreActivities.class, hostActivityOptions);
 
-    // Call processFile activity to zip the file.
     // Call the Activity to process the file using worker-specific task queue.
-    String processed = hostSpecificStore.process(downloaded.getFileName());
-    // Call upload activity to upload the zipped file.
-    hostSpecificStore.upload(processed, destination);
 }
 ```
 

--- a/docs/route-tasks.md
+++ b/docs/route-tasks.md
@@ -14,13 +14,38 @@ The question is how can we ensure a specific Worker will execute a given Task? W
 
 Task routing is the development technique that pairs Tasks with Workers using Task Queues. At the basic level it consists of 3 steps:
 
-1. Create a Worker that is registered to handle Workflow and/or Activity Tasks.
-2. Subscribe the Worker to listen to a Task Queue.
+1. Subscribe a Worker to a Task Queue.
+2. Register Workflow and/or Activity Tasks with the Worker.
 3. Configure Workflows and Activities to send Tasks to the Task Queue.
 
-Let's look at the ["Hello World" sample in Go](https://github.com/temporalio/temporal-go-samples/tree/master/helloworld) to see how this is done.
+Let's look a simple "Hello World" sample to see how this is done. In the following code snippet, we [create a new Worker](https://github.com/temporalio/go-samples/blob/master/helloworld/worker/main.go#L26) that is subscribed to the "hello-world" Task Queue and is registered to handle the `helloworld.Workflow` and `helloworld.Activity`:
 
-In the following code snippet, we [create a new Worker](https://github.com/temporalio/go-samples/blob/master/helloworld/worker/main.go#L26) that is subscribed to the "hello-world" Task Queue and is registered to handle the `helloworld.Workflow` and `helloworld.Activity`:
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+    defaultValue="java"
+    values={[
+        { label: 'Java', value: 'java', },
+        { label: 'Go', value: 'go', },
+    ]
+}>
+
+<TabItem value="java">
+
+```java
+// Worker is created and subscribed to the "hello-world" Task Queue 
+Worker worker = factory.newWorker("hello-world");
+// Worker is registered to handle helloworld Workflow
+worker.registerWorkflowImplementationTypes(HelloWorldWorkflowImpl.class)
+// Worker is registered to handle helloworld Activity
+worker.registerActivityImplementationTypes(HelloWorldActivityImpl)
+```
+
+</TabItem>
+<TabItem value="go">
+
+[source](https://github.com/temporalio/temporal-go-samples/tree/master/helloworld)
 
 ```go
 // Worker is created and subscribed to the "hello-world" Task Queue
@@ -32,7 +57,35 @@ w.RegisterWorkflow(helloworld.Workflow)
 w.RegisterActivity(helloworld.Activity)
 ```
 
+</TabItem>
+</Tabs>
+
 In the next code snippet, we [start the `helloworld.Workflow`](https://github.com/temporalio/go-samples/blob/master/helloworld/starter/main.go#L25):
+
+<Tabs
+    defaultValue="go"
+    values={[
+        { label: 'Java', value: 'java'},
+        { label: 'Go', value: 'go' },
+    ]           
+}>
+
+<TabItem value="java">
+
+```java
+HelloWorldWorkflow workflow =
+    client.newWorkflowStub(
+        HelloWorldWorkflow.class,
+        // Workflow Options specify the "hello-world"" Task Queue
+        // Which is the Task Queue that the Workflow will send its Tasks to
+        WorkflowOptions.newBuilder().setTaskQueue("hello_world").build());
+// Workflow is executed
+WorkflowExecution workflowExecution =
+    WorkflowClient.start(workflow::helloWorld);
+```
+
+</TabItem>
+<TabItem value="go"> 
 
 ```go
 // Workflow Options specify the "hello-world" Task Queue
@@ -49,6 +102,9 @@ we, err := c.ExecuteWorkflow(
   "Temporal",
 )
 ```
+
+</TabItem>
+</Tabs>
 
 :::caution
 

--- a/docs/route-tasks.md
+++ b/docs/route-tasks.md
@@ -4,8 +4,15 @@ title: How to route Tasks
 sidebar_label: Route Tasks
 ---
 
+## Overview
+
+This guide covers the recommended techniques to ensure that a Workflow and/or Activity will be executed by an appropriate Worker. In this guide we will look at two examples:
+
+1. A basic example that illustrates the fundamentals of routing a Task to a Worker.
+2. A more complex example involving Activities with host-specific file dependencies.
+
 Consider the specifications of a Worker:
-- A Worker only handles [Activity](docs/learn-activities) and [Workflow](docs/learn-workflows) Tasks that it is registered to handle. This means that a Task must be paired with a Worker that is registered to handle that Task.
+- A Worker only handles [Activity](activities) and [Workflow](workflows) Tasks that it is registered to handle. This means that a Task must be paired with a Worker that is registered to handle that Task.
 - A Worker runs on a specific host. This means that Activity Tasks that depend on host-specific resources, such as a local file, must be executed by a Worker on that host.
 
 The question is how can we ensure a specific Worker will execute a given Task? We do this through "Task routing".
@@ -18,7 +25,7 @@ Task routing is the development technique that pairs Tasks with Workers using Ta
 2. Register Workflow and/or Activity Tasks with the Worker.
 3. Configure Workflows and Activities to send Tasks to the Task Queue.
 
-Let's look a simple "Hello World" sample to see how this is done. In the following code snippet we create a new Worker, subscribe it to the "hello-world" Task Queue, and register it to handle "Hello World" Workflow and "Hello World" Activity implementations:
+Let's look at a simple "Hello World" sample to see how this is done. In the following code snippet we create a new Worker, subscribe it to the "hello-world" Task Queue, and register it to handle "Hello World" Workflow and "Hello World" Activity implementations:
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -60,7 +67,7 @@ w.RegisterActivity(helloworld.Activity)
 </TabItem>
 </Tabs>
 
-In the next code snippet, we start the "Hello World" Workflow:
+In the next code snippet, we configure the "Hello World" Workflow to send its Tasks to the "hello-world" Task Queue and then start its execution:
 
 <Tabs
     defaultValue="go"
@@ -110,21 +117,23 @@ we, err := c.ExecuteWorkflow(
 
 :::caution
 
-If a Worker pulls a Task that it has not been registered to run, an "unknown workflow type" error will occur.
+If a Worker pulls a Task that it has not been registered to execute, an "unknown workflow type" error will occur.
 
 :::
 
+The above examples illustrate the fundamental approach to pairing Tasks with Workers. In the next section we look at a more complex scenario involving Activities with host-specific file dependencies.
+
 ## Task routing for Activity dependencies
 
-The Temporal service will persist Activity results as long as the results are less than 2MB in size and can be serialized for storage (which happens to be true for most Activity results). However, there are some scenarios where an Activity execution will do something that results in data or files being stored directly on the host where the Worker is running. It is also possible that the next Activity in the Workflow has a dependency on that data and needs to run on the same host.
+The Temporal service will persist Activity results as long as the results are less than 2MB in size and can be serialized for storage (which happens to be true for most Activity results). However, there are some scenarios where an Activity execution will do something that results in files being stored directly on the host where the Worker is running. It is also possible that the next Activity in the Workflow has a dependency on those files and needs to run on the same host.
 
-Let's look at a file processing Workflow example where files are downloaded, processed in some way, and then uploaded to some other location. If a large video file is being processed only the name of the file can persist normally. The file itself must persist locally on the Worker host, as it is too big for normal Temporal storage. This means that any future Activities that act on the video file must also take place on the host where the Worker downloaded it.
+Let's look at a file processing Workflow example where files are downloaded, transcoded in some way, and then uploaded to some other location. If a large video file is being transcoded Temporal can only persist the name of the file. The file itself must persist locally on the Worker host as it is too big for Temporal to store. This means that any future Activities that act on the video file must also take place on the host where the Worker downloaded it.
 
 So, how do we ensure that a Worker on the correct host will execute the next Activity that depends on the video file? This is accomplished in different ways depending on the SDK.
 
 ### Java
 
-Consider the [file processing sample in Java](https://github.com/temporalio/java-samples/tree/master/src/main/java/io/temporal/samples/fileprocessing). The paradigm is to create two Workers. Each will run on the same host and thus have access to the same file system, but one will listen to a global (shared) Task Queue, which it will use to start the Workflow, and the other will listen to its own host-specific (private) Task Queue. 
+Consider the [file processing sample in Java](https://github.com/temporalio/java-samples/tree/master/src/main/java/io/temporal/samples/fileprocessing). The paradigm is to create two Workers. Each will run on the same host and thus have access to the same file system, but one will listen to a global (shared) Task Queue, which it will use to start the Workflow, and the other will listen to its own host-specific (private) Task Queue. A practical approach to naming host-specific (private) Task Queues is to use the MAC address or other unique identifier of the host. 
 
 The following code snippet is stripped down from the [FileProcessingWorker.java sample](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorker.java) and highlights the creation of two workers for this purpose:
 
@@ -139,7 +148,7 @@ final Worker workerForHostSpecificTaskList = factory.newWorker(hostSpecifiTaskQu
 // Register activities
 ```
 
-In the [Workflow](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorkflowImpl.java#L42), the first Activity Task is executed by the Worker listening to the global Task Queue:
+Within the [Workflow code](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorkflowImpl.java#L42), the first Activity Task is sent to the global Task Queue and is executed by the Worker listening to the same global Task Queue.
 
 ```java
 public FileProcessingWorkflowImpl() {
@@ -153,13 +162,13 @@ public FileProcessingWorkflowImpl() {
 }
 ```
 
-The Activities should be designed to [return an object](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/StoreActivities.java) that includes both the Activity result and the name of the host-specific Task Queue to which the next Activity Task will be sent.
+The Activities should be designed to [return an object](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/StoreActivities.java) that includes both the Activity result and the name of the host-specific Task Queue to which the next Activity Task should be sent.
 
 ```java
 public interface StoreActivities {
 
   final class ResultAndTaskQueuePair {
-    // Name of the host-specific  Task Qeueu
+    // Name of the host-specific  Task Queue
     private final String hostspecificTaskQueue;
     // This is the Activity result (e.g. the name or location of the file)
     private final String activityResult;
@@ -171,7 +180,7 @@ public interface StoreActivities {
 }
 ```
 
-The host-specific Task Queue is then set on [subsequent Activities](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorkflowImpl.java#L63):
+The host-specific Task Queue is then configured for [subsequent Activity executions](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorkflowImpl.java#L63):
 
 ```java
 private void processFileImpl(URL source, URL destination) {
@@ -192,9 +201,7 @@ In Go, you have two options.
 
 **Option 1**: Implement the same design as you would in Java, which is to create two Workers (one listens to the shared Task Qeue and the other listens to the private Task Queue) and return the name of the private Task Queue back to the Workflow as an Activity result.
 
-**Option 2**: Create a Workflow Session which automatically ties any remaining Workflow Activity executions to the Worker that started the Workflow. The [FileProcessing sample in Go](https://github.com/temporalio/temporal-go-samples/tree/master/fileprocessing) is a good example of sessions being used for this purpose.
-
-The Worker must be [configured to support sessions](https://github.com/temporalio/go-samples/blob/master/fileprocessing/worker/main.go#L27).
+**Option 2**: Create a Workflow Session which automatically ties Activity executions to the Worker that started the Workflow. The [FileProcessing sample in Go](https://github.com/temporalio/temporal-go-samples/tree/master/fileprocessing) is a good example of sessions being used for this purpose. The Worker must be [configured to support sessions](https://github.com/temporalio/go-samples/blob/master/fileprocessing/worker/main.go#L27).
 
 ```go
 workerOptions := worker.Options{
@@ -224,4 +231,8 @@ defer workflow.CompleteSession(sessionCtx)
 ```
 
 The session will ensure that all Activities are executed on the same host.
+
+## Summary
+
+It is up to the developer to pair a given Task (Workflow and/or Activity) with an appropriate Worker. Task Queues make that possible with a great degree of flexibility. Read the [Task Queues concept page](task-queues) to learn more about Task Queues and why they exist in comparison to directly calling upon a Worker for execution.
 

--- a/docs/route-tasks.md
+++ b/docs/route-tasks.md
@@ -5,39 +5,42 @@ sidebar_label: Route Tasks
 ---
 
 Consider the specifications of a Worker:
-- A Worker is meant to handle only the Tasks that it is registered to handle. This means that Workers registered to handle Tasks for Workflow A are not capable of handling Tasks for Workflow B, and vice versa. 
-- A Worker runs on a speicific host. This means that Activity Tasks that depend on resources specific to a particular host must be executed by a Worker on that host.
+- A Worker only handles [Activity](docs/learn-activities) and [Workflow](docs/learn-workflows) Tasks that it is registered to handle. This means that a Task must be paired with a Worker that is registered to handle that Task.
+- A Worker runs on a specific host. This means that Activity Tasks that depend on host-specific resources, such as a local file, must be executed by a Worker on that host.
 
-So, for any given Temporal Workflow, how do we make sure a specific Worker is executing a specific Task? 
+The question is how do we make sure a specific Worker is executing a specific Task? We do this through "Task routing".
 
-## Use Task Queues
+## Task routing with Task Queues
 
-"Task Routing" is the development technique that makes use of Task Queues to orchestrate the execution of Tasks by specific Workers.
+Task Queues are what enable "Task routing". Task routing is the development technique that pairs Tasks with Workers. The basics of it can be broken down into 3 steps:
+1. Create a Worker that is registered to handle Workflow and/or Activity Tasks.
+2. Subscribe the Worker to listen to a Task Queue.
+3. Configure Workflows and Activities to send Tasks to the Task Queue.
 
 Let's look at the ["Hello World" sample in Go](https://github.com/temporalio/temporal-go-samples/tree/master/helloworld) to see how this is done.
 
-Here, we are creating a new Worker that is subscribed to the "hello-world" Task Queue, and is registered to handle the `helloworld.Workflow` and `helloworld.Activity`:
+In the following code snippet, we [create a new Worker](https://github.com/temporalio/go-samples/blob/master/helloworld/worker/main.go#L26) that is subscribed to the "hello-world" Task Queue and is registered to handle the `helloworld.Workflow` and `helloworld.Activity`:
 
 ```go
-// The Worker is created and subscribed to the "hello-world" Task Queue
+// Worker is created and subscribed to the "hello-world" Task Queue
 w := worker.New(c, "hello-world", worker.Options{})
 defer w.Stop()
-// The Worker is registered to handle the helloworld Workflow
+// Worker is registered to handle the helloworld Workflow
 w.RegisterWorkflow(helloworld.Workflow)
-// The Worker is registered to handle the helloworld Activity
+// Worker is registered to handle the helloworld Activity
 w.RegisterActivity(helloworld.Activity)
 ```
 
-And here, we are starting the `helloworld.Workflow`:
+In the next code snippet, we [start the `helloworld.Workflow`](https://github.com/temporalio/go-samples/blob/master/helloworld/starter/main.go#L25):
 
 ```go
-// The Workflow Options specify the "hello-world" Task Queue
-// This is the Task Queue that the Workflow will add its Tasks to
+// Workflow Options specify the "hello-world" Task Queue
+// Which is the Task Queue that the Workflow will send its Tasks to
 workflowOptions := client.StartWorkflowOptions{
   ID:        "hello_world_workflowID",
   TaskQueue: "hello-world",
 }
-// The Workflow Options are passed to the execution of the Workflow
+// Workflow Options are passed to the execution of the Workflow
 we, err := c.ExecuteWorkflow(
   context.Background(), 
   workflowOptions, 
@@ -45,8 +48,6 @@ we, err := c.ExecuteWorkflow(
   "Temporal",
 )
 ```
-
-Task routing can be as simple as making sure a Worker is subscribed to a Task Queue and Tasks are being added to it.
 
 :::caution
 
@@ -56,22 +57,24 @@ If a Worker pulls a Task that it has not been registered to run, an "unknown wor
 
 ## Task routing for Activity dependencies
 
-The Temporal service will persist Activity results as long as the results can be serialized and stored in a Cassandra or MySQL database (which happens to be true for most Activity results). However, there are some scenarios where an Activity execution will do something that results in data being stored on the host where the Worker is running. It is also possible that the next Activity in the Workflow has a dependency on that data.
+The Temporal service will persist Activity results as long as the results are less than 2MB in size and can be serialized for storage (which happens to be true for most Activity results). However, there are some scenarios where an Activity execution will do something that results in data, such as a large file, being stored directly on the host where the Worker is running. It is also possible that the next Activity in the Workflow has a dependency on that data and needs to run on the same host.
 
-Let's look at a file processing Workflow, as an example,  where files are downloaded, processed in some way, and then uploaded to some other location. If a large video file is being processed only the name of the file can persist normally. The file itself must persist locally on the Worker host. This means that any future Activities that act on the video file must also take place on the host where the Worker downloaded it.
+Let's look at a file processing Workflow example where files are downloaded, processed in some way, and then uploaded to some other location. If a large video file is being processed only the name of the file can persist normally. The file itself must persist locally on the Worker host, as it is too big for normal Temporal storage. This means that any future Activities that act on the video file must also take place on the host where the Worker downloaded it.
 
-So, how do we ensure that a Worker on the correct host will execute the next set of Activities that depends on the video file?
+So, how do we ensure that a Worker on the correct host will execute the next Activity that depends on the video file?
 
-Each SDK offers a slightly different way to handle this.
+This is accomplished in different ways depending on the SDK.
 
 ### Java
 
-In Java the paradigm is to create two Workers. Each will exist on the same host and thus have access to the same file system, but one will listen to a shared Task Queue, which it will poll to start the Workflow, and the other will listen to its own private Task Queue.
+Consider the [file processing sample in Java](https://github.com/temporalio/java-samples/tree/master/src/main/java/io/temporal/samples/fileprocessing), the paradigm is to create two Workers. Each will run on the same host and thus have access to the same file system, but one will listen to a global (shared) Task Queue, which it will use to start the Workflow, and the other will listen to its own host-specific (private) Task Queue. 
+
+The following code snippet is stripped down from the [FileProcessingWorker.java sample](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorker.java) and highlights the creation of two workers for this purpose:
 
 ```java
 // Initialize a WorkerFactory
 WorkerFactory factory = WorkerFactory.newInstance(client);
-// Create a Worker that is subscribed to a shared TaskQueue
+// Create a Worker that is subscribed to a shared Task Queue
 final Worker workerForCommonTaskList = factory.newWorker(globalTaskQueue);
 // Register Workflow and Activities
 // Create a Worker that is subscribed to a private TaskQueue
@@ -79,13 +82,27 @@ final Worker workerForHostSpecificTaskList = factory.newWorker(hostSpecifiTaskQu
 // Register activities
 ```
 
-Then, design your Workflow Activities to return an object that includes both the Activity result and the name of the private Task Queue to which the next Activity Task will be added.
+In the [Workflow](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorkflowImpl.java#L42), the first Activity Task is executed by the Worker listening to the global Task Queue:
+
+```java
+public FileProcessingWorkflowImpl() {
+    // Create activity clients.
+    ActivityOptions ao =
+        ActivityOptions.newBuilder()
+        // Send the Activity to the shared Task Queue
+        .setTaskQueue(globalTaskQueue)
+        .build();
+    this.defaultTaskQueueStore = Workflow.newActivityStub(StoreActivities.class, ao);
+}
+```
+
+The Activities should be designed to [return an object](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/StoreActivities.java) that includes both the Activity result and the name of the host-specific Task Queue to which the next Activity Task will be sent.
 
 ```java
 public interface StoreActivities {
 
   final class ResultAndTaskQueuePair {
-    // This is the name of the private Task Qeueu
+    // Name of the host-specific  Task Qeueu
     private final String hostspecificTaskQueue;
     // This is the Activity result (e.g. the name or location of the file)
     private final String activityResult;
@@ -97,15 +114,37 @@ public interface StoreActivities {
 }
 ```
 
-The [FileProcessing sample in Java](https://github.com/temporalio/temporal-java-samples/tree/143902cba3e14aa11f3b90784baf53406c329fd2/src/main/java/io/temporal/samples/fileprocessing) shows an example of this design.
+The host-specific Task Queue is then set on [subsequent Activities](https://github.com/temporalio/java-samples/blob/master/src/main/java/io/temporal/samples/fileprocessing/FileProcessingWorkflowImpl.java#L63):
+
+```java
+private void processFileImpl(URL source, URL destination) {
+    StoreActivities.TaskQueueFileNamePair downloaded = defaultTaskQueueStore.download(source);
+
+    // Initialize stubs that are specific to the returned task queue.
+    ActivityOptions hostActivityOptions =
+        ActivityOptions.newBuilder()
+        .setTaskQueue(downloaded.getHostTaskQueue())
+        .build();
+    StoreActivities hostSpecificStore =
+        Workflow.newActivityStub(StoreActivities.class, hostActivityOptions);
+
+    // Call processFile activity to zip the file.
+    // Call the Activity to process the file using worker-specific task queue.
+    String processed = hostSpecificStore.process(downloaded.getFileName());
+    // Call upload activity to upload the zipped file.
+    hostSpecificStore.upload(processed, destination);
+}
+```
 
 ### Go
 
-In Go, you actually have two options.
+In Go, you have two options.
 
-The first option is to do the same thing as you would do in Java, which is to create two Workers (one listens to the shared Task Qeue and the other listens to the private Task Queue) and return the name of the private Task Queue back to the Workflow as an Activity result.
+**Option 1**: Implement the same design as you would in Java, which is to create two Workers (one listens to the shared Task Qeue and the other listens to the private Task Queue) and return the name of the private Task Queue back to the Workflow as an Activity result.
 
-The second option is to create a Workflow Session which automatically ties any remaining Workflow Activity executions to the Worker that started the Workflow.
+**Option 2**: Create a Workflow Session which automatically ties any remaining Workflow Activity executions to the Worker that started the Workflow. The [FileProcessing sample in Go](https://github.com/temporalio/temporal-go-samples/tree/master/fileprocessing) is a good example of sessions being used for this purpose.
+
+The Worker must be [configured to support sessions](https://github.com/temporalio/go-samples/blob/master/fileprocessing/worker/main.go#L27).
 
 ```go
 workerOptions := worker.Options{
@@ -117,7 +156,7 @@ w := worker.New(c, "task_queue_name", workerOptions)
 defer w.Stop()
 ```
 
-Then within the Workflow invocation code, set the `SessionOptions` and create the Session.
+Within the [Workflow invocation code](https://github.com/temporalio/go-samples/blob/master/fileprocessing/workflow.go#L48), set the `SessionOptions` and create the Session.
 
 ```go
 // The Workflow SessionOptions are configured
@@ -134,5 +173,5 @@ defer workflow.CompleteSession(sessionCtx)
 // Execute activities...
 ```
 
-The [FileProcessing sample in Go](https://github.com/temporalio/temporal-go-samples/tree/master/fileprocessing) is a good example of Workflow Sessions in Go.
+The session will ensure that all Activities are executed on the same host.
 

--- a/docs/route-tasks.md
+++ b/docs/route-tasks.md
@@ -1,6 +1,7 @@
 ---
 id: route-tasks
-title: Route Tasks 
+title: How to route Tasks
+sidebar_label: Route Tasks
 ---
 
 Consider the specifications of a Worker:

--- a/docs/route-tasks.md
+++ b/docs/route-tasks.md
@@ -1,6 +1,6 @@
 ---
-id: routing-tasks
-title: Routing Tasks 
+id: route-tasks
+title: Route Tasks 
 ---
 
 Consider the specifications of a Worker:

--- a/docs/route-tasks.md
+++ b/docs/route-tasks.md
@@ -8,11 +8,11 @@ Consider the specifications of a Worker:
 - A Worker only handles [Activity](docs/learn-activities) and [Workflow](docs/learn-workflows) Tasks that it is registered to handle. This means that a Task must be paired with a Worker that is registered to handle that Task.
 - A Worker runs on a specific host. This means that Activity Tasks that depend on host-specific resources, such as a local file, must be executed by a Worker on that host.
 
-The question is how do we make sure a specific Worker is executing a specific Task? We do this through "Task routing".
+The question is how can we ensure a specific Worker will execute a given Task? We do this through "Task routing".
 
 ## Task routing with Task Queues
 
-Task Queues are what enable "Task routing". Task routing is the development technique that pairs Tasks with Workers. The basics of it can be broken down into 3 steps:
+Task routing is the development technique that pairs Tasks with Workers using Task Queues. At the basic level it consists of 3 steps:
 
 1. Create a Worker that is registered to handle Workflow and/or Activity Tasks.
 2. Subscribe the Worker to listen to a Task Queue.

--- a/docs/routing-tasks.md
+++ b/docs/routing-tasks.md
@@ -1,0 +1,137 @@
+---
+id: routing-tasks
+title: Routing Tasks 
+---
+
+Consider the specifications of a Worker:
+- A Worker is meant to handle only the Tasks that it is registered to handle. This means that Workers registered to handle Tasks for Workflow A are not capable of handling Tasks for Workflow B, and vice versa. 
+- A Worker runs on a speicific host. This means that Activity Tasks that depend on resources specific to a particular host must be executed by a Worker on that host.
+
+So, for any given Temporal Workflow, how do we make sure a specific Worker is executing a specific Task? 
+
+## Use Task Queues
+
+"Task Routing" is the development technique that makes use of Task Queues to orchestrate the execution of Tasks by specific Workers.
+
+Let's look at the ["Hello World" sample in Go](https://github.com/temporalio/temporal-go-samples/tree/master/helloworld) to see how this is done.
+
+Here, we are creating a new Worker that is subscribed to the "hello-world" Task Queue, and is registered to handle the `helloworld.Workflow` and `helloworld.Activity`:
+
+```go
+// The Worker is created and subscribed to the "hello-world" Task Queue
+w := worker.New(c, "hello-world", worker.Options{})
+defer w.Stop()
+// The Worker is registered to handle the helloworld Workflow
+w.RegisterWorkflow(helloworld.Workflow)
+// The Worker is registered to handle the helloworld Activity
+w.RegisterActivity(helloworld.Activity)
+```
+
+And here, we are starting the `helloworld.Workflow`:
+
+```go
+// The Workflow Options specify the "hello-world" Task Queue
+// This is the Task Queue that the Workflow will add its Tasks to
+workflowOptions := client.StartWorkflowOptions{
+  ID:        "hello_world_workflowID",
+  TaskQueue: "hello-world",
+}
+// The Workflow Options are passed to the execution of the Workflow
+we, err := c.ExecuteWorkflow(
+  context.Background(), 
+  workflowOptions, 
+  helloworld.Workflow, 
+  "Temporal",
+)
+```
+
+Task routing can be as simple as making sure a Worker is subscribed to a Task Queue and Tasks are being added to it.
+
+:::caution
+
+If a Worker pulls a Task that it has not been registered to run, an "unknown workflow type" error will occur.
+
+:::
+
+## Task routing for Activity dependencies
+
+The Temporal service will persist Activity results as long as the results can be serialized and stored in a Cassandra or MySQL database (which happens to be true for most Activity results). However, there are some scenarios where an Activity execution will do something that results in data being stored on the host where the Worker is running. It is also possible that the next Activity in the Workflow has a dependency on that data.
+
+Let's look at a file processing Workflow, as an example,  where files are downloaded, processed in some way, and then uploaded to some other location. If a large video file is being processed only the name of the file can persist normally. The file itself must persist locally on the Worker host. This means that any future Activities that act on the video file must also take place on the host where the Worker downloaded it.
+
+So, how do we ensure that a Worker on the correct host will execute the next set of Activities that depends on the video file?
+
+Each SDK offers a slightly different way to handle this.
+
+### Java
+
+In Java the paradigm is to create two Workers. Each will exist on the same host and thus have access to the same file system, but one will listen to a shared Task Queue, which it will poll to start the Workflow, and the other will listen to its own private Task Queue.
+
+```java
+// Initialize a WorkerFactory
+WorkerFactory factory = WorkerFactory.newInstance(client);
+// Create a Worker that is subscribed to a shared TaskQueue
+final Worker workerForCommonTaskList = factory.newWorker(globalTaskQueue);
+// Register Workflow and Activities
+// Create a Worker that is subscribed to a private TaskQueue
+final Worker workerForHostSpecificTaskList = factory.newWorker(hostSpecifiTaskQueue);
+// Register activities
+```
+
+Then, design your Workflow Activities to return an object that includes both the Activity result and the name of the private Task Queue to which the next Activity Task will be added.
+
+```java
+public interface StoreActivities {
+
+  final class ResultAndTaskQueuePair {
+    // This is the name of the private Task Qeueu
+    private final String hostspecificTaskQueue;
+    // This is the Activity result (e.g. the name or location of the file)
+    private final String activityResult;
+
+    // Get and set methods ...
+  }
+
+  // Interface methods ....
+}
+```
+
+The [FileProcessing sample in Java](https://github.com/temporalio/temporal-java-samples/tree/143902cba3e14aa11f3b90784baf53406c329fd2/src/main/java/io/temporal/samples/fileprocessing) shows an example of this design.
+
+### Go
+
+In Go, you actually have two options.
+
+The first option is to do the same thing as you would do in Java, which is to create two Workers (one listens to the shared Task Qeue and the other listens to the private Task Queue) and return the name of the private Task Queue back to the Workflow as an Activity result.
+
+The second option is to create a Workflow Session which automatically ties any remaining Workflow Activity executions to the Worker that started the Workflow.
+
+```go
+workerOptions := worker.Options{
+  // Sessions are enabled in the WorkerOptions
+  EnableSessionWorker: true,
+}
+// The Worker is subscribed to a Task Queue
+w := worker.New(c, "task_queue_name", workerOptions)
+defer w.Stop()
+```
+
+Then within the Workflow invocation code, set the `SessionOptions` and create the Session.
+
+```go
+// The Workflow SessionOptions are configured
+so := &workflow.SessionOptions{
+  CreationTimeout:  time.Minute,
+  ExecutionTimeout: time.Minute,
+}
+// The Workflow Session is created
+sessionCtx, err := workflow.CreateSession(ctx, so)
+if err != nil {
+  return err
+}
+defer workflow.CompleteSession(sessionCtx)
+// Execute activities...
+```
+
+The [FileProcessing sample in Go](https://github.com/temporalio/temporal-go-samples/tree/master/fileprocessing) is a good example of Workflow Sessions in Go.
+


### PR DESCRIPTION
New user guide that covers "Task routing" and how to do it using Task Queues.

This PR does not yet add the guide to sidebar navigation. To preview the guide, go here:
https://deploy-preview-58--mystifying-fermi-1bc096.netlify.app/docs/next/route-tasks/

