### PR TITLE
 Converting bullet points to arrows

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -23,3 +23,11 @@
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
+
+.markdown ul {
+  list-style-type: none;
+}
+
+.markdown li:before{
+  content: '→ ';
+}

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -24,10 +24,10 @@
   padding: 0 var(--ifm-pre-padding);
 }
 
-.markdown ul {
+.markdown > ul {
   list-style-type: none;
 }
 
-.markdown li:before{
+.markdown > ul > li:before{
   content: '→ ';
 }


### PR DESCRIPTION
This PR adds some custom css that coverts unordered list items to use arrows instead of bullet points.
This change only affects doc files.
Looks like this:

![Screen Shot 2020-08-11 at 3 21 46 PM](https://user-images.githubusercontent.com/34380806/89950242-729bde00-dbe6-11ea-8fe6-3aa9e5636cbe.png)

nested will look like this:

![Screen Shot 2020-08-11 at 3 25 41 PM](https://user-images.githubusercontent.com/34380806/89950502-f81f8e00-dbe6-11ea-8852-5cfc9a47635b.png)
