### PR TITLE
Have sample code call set HostPort explicitly

### DIFF
--- a/docs/go-quick-start.md
+++ b/docs/go-quick-start.md
@@ -141,7 +141,8 @@ import (
 
 func main() {
 	// The client is a heavyweight object that should be created once
-	serviceClient, err := client.NewClient(client.Options{})
+	clientOptions := client.Options{HostPort: "localhost:7233"}
+	serviceClient, err := client.NewClient(clientOptions)
 
 	if err != nil {
 		log.Fatalf("Unable to create client.  Error: %v", err)


### PR DESCRIPTION
Every dev playing with this code will likely wonder "how do I tell this thing where my server is running?", and this tweak provides an "at-a-glance" answer.

(I tested that this code compiles and runs, by first copy-pasting this from a compiling / working app, and then by copying this code into a sample that I then compiled and ran.)