### PR TITLE
Support netlify links validation plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "prettier.singleQuote": true,
+  "prettier.jsxSingleQuote": true,
   "editor.formatOnSave": true
 }

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Refer to [Rob Allen's DevNotes](https://akrabat.com/the-beginners-guide-to-contr
 
 The website is built using [Docusaurus 2](https://v2.docusaurus.io/).
 
-Check out their [installation requirements](https://v2.docusaurus.io/docs/installation#requirements) for tooling prerequisites.
+Check out their [installation requirements](https://v2.docusaurus.io/docs/installation/#requirements) for tooling prerequisites.
 
 ### Initialize yarn
 

--- a/blog/2020-07-31-temporal-v0.28.0-changelog.md
+++ b/blog/2020-07-31-temporal-v0.28.0-changelog.md
@@ -1,8 +1,8 @@
 ---
 tags:
-- changelog
-- temporal
-- v1
+  - changelog
+  - temporal
+  - v1
 posted_on_: 2020-07-31T00:00:00
 id: temporal-v0.28.0-changelog
 title: Temporal v0.28.0 changelog
@@ -22,69 +22,69 @@ This changelog includes all of the changes since Temporal forked from Cadence, a
 
 - **Cadence Oct 2019** → **Temporal v0.28.0 Alpha**: The software version has bumped.
 - **Thrift/TChannel** → **[Protobuf](https://developers.google.com/protocol-buffers)/[gRPC](https://grpc.io/)** ⚡ :
-    - Server Thrift API → Protobuf [API](https://github.com/temporalio/api). Go import path is `go.temporal.io/api`.
-    - All communication over the wire can be encrypted via [TLS](/docs/configure-temporal-server#tls). Note: Support for TLS in `tctl` and `temporal-web` is still in-progress.
-    - Thrift errors have been converted to custom service errors backed by standard [gRPC error codes](https://pkg.go.dev/google.golang.org/grpc/codes).
-    - Errors are serialized using the Protobuf type `Failure`. They can now be chained together and passed across different SDKs in different languages.
-    - All payloads (Workflow input, Activity input, etc...) sent to Temporal now have headers and data fields.
-    - Standard [gRPC health service](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) is used for health checks.
-    - Standard Protobuf types are used for [time](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#timestamp) and [duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration).
-    - Uber YARPC library has been removed.
-- **Helm charts** ☸️  : [Deploy the Temporal server to a Kubernetes Cluster](https://github.com/temporalio/helm-charts).
+  - Server Thrift API → Protobuf [API](https://github.com/temporalio/api). Go import path is `go.temporal.io/api`.
+  - All communication over the wire can be encrypted via [TLS](/docs/configure-temporal-server/#tls). Note: Support for TLS in `tctl` and `temporal-web` is still in-progress.
+  - Thrift errors have been converted to custom service errors backed by standard [gRPC error codes](https://pkg.go.dev/google.golang.org/grpc/codes).
+  - Errors are serialized using the Protobuf type `Failure`. They can now be chained together and passed across different SDKs in different languages.
+  - All payloads (Workflow input, Activity input, etc...) sent to Temporal now have headers and data fields.
+  - Standard [gRPC health service](https://github.com/grpc/grpc/blob/master/doc/health-checking.md) is used for health checks.
+  - Standard Protobuf types are used for [time](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#timestamp) and [duration](https://developers.google.com/protocol-buffers/docs/reference/google.protobuf#google.protobuf.Duration).
+  - Uber YARPC library has been removed.
+- **Helm charts** ☸️ : [Deploy the Temporal server to a Kubernetes Cluster](https://github.com/temporalio/helm-charts).
 - **Entity renames** 🏷️ :
-    - `Decision` → `Command`.
-    - `DecisionTask` → `WorkflowTask`.
-    - `Decider` → `Workflow`.
-    - `Domain` → `Namespace`.
-    - `NamespaceStatus` → `NamespaceState`.
-    - `TaskList` → `TaskQueue`.
-    - `ArchivalStatus` → `ArchivalState`.
+  - `Decision` → `Command`.
+  - `DecisionTask` → `WorkflowTask`.
+  - `Decider` → `Workflow`.
+  - `Domain` → `Namespace`.
+  - `NamespaceStatus` → `NamespaceState`.
+  - `TaskList` → `TaskQueue`.
+  - `ArchivalStatus` → `ArchivalState`.
 - **Import path rename** 📦 : `go.uber.org/cadence` → `go.temporal.io/sdk`.
 - **Workflow timeout refactors** ⌛:
-    - Workflow timeouts are optional.
-    - Attempt counters start at 1.
-    - Workflow Executions have 3 timeouts available:
-        - Renamed:`ExecutionStartToCloseTimeout` → `WorkflowRunTimeout`.
-        - `WorkflowExecutionTimeout` is new. It limits the total Workflow execution time including retries and continue-as-new. It also enables limiting the total time of a cron job. The default is 10 years. `WorkflowRunTimeout` defaults to the value of `WorkflowExecutionTimeout`.
-        - Renamed:`DecisionTaskStartToCloseTimeout` → `WorkflowTaskTimeout`. Defaults to 10 seconds.
+  - Workflow timeouts are optional.
+  - Attempt counters start at 1.
+  - Workflow Executions have 3 timeouts available:
+    - Renamed:`ExecutionStartToCloseTimeout` → `WorkflowRunTimeout`.
+    - `WorkflowExecutionTimeout` is new. It limits the total Workflow execution time including retries and continue-as-new. It also enables limiting the total time of a cron job. The default is 10 years. `WorkflowRunTimeout` defaults to the value of `WorkflowExecutionTimeout`.
+    - Renamed:`DecisionTaskStartToCloseTimeout` → `WorkflowTaskTimeout`. Defaults to 10 seconds.
 - **Workflow retry refactors** 🔁 :
-    - `ExpirationInterval` has been removed from `RetryPolicy`. Instead, `WorkflowExecutionTimeout` is used to stop retries for Workflows.
-    - Attempt counters start at 1.
+  - `ExpirationInterval` has been removed from `RetryPolicy`. Instead, `WorkflowExecutionTimeout` is used to stop retries for Workflows.
+  - Attempt counters start at 1.
 - **Activity retry refactors** 🔁 :
-    - Temporal includes default `RetryOptions` for Activities.
-        - `initialInterval` = 1 second.
-        - `maximumInterval` = 100 * initialInterval.
-        - `backoffCoefficient` = 2.
-    - To disable Activity retries, configure Activities with `RetryOptions` that set `maximumAttempts` to 1.
-    - `ScheduleToClose` is used to stop retries for Activities.
+  - Temporal includes default `RetryOptions` for Activities.
+    - `initialInterval` = 1 second.
+    - `maximumInterval` = 100 \* initialInterval.
+    - `backoffCoefficient` = 2.
+  - To disable Activity retries, configure Activities with `RetryOptions` that set `maximumAttempts` to 1.
+  - `ScheduleToClose` is used to stop retries for Activities.
 - **CLI updates** 🧰 :
-    - New admin commands:
-        - List namespaces ([#463](https://github.com/temporalio/temporal/pull/463)): `./tctl admin namespace list`.
-        - Describe Shard ([#370](https://github.com/temporalio/temporal/pull/370)): `./tctl admin shard describe --shard_id ...` / `d -sid`.
-        - List Tasks ([#429](https://github.com/temporalio/temporal/pull/429)/[#433](https://github.com/temporalio/temporal/pull/433)): `./tctl admin shard list_tasks`.
-        - Describe Task ([#408](https://github.com/temporalio/temporal/pull/408), [#416](https://github.com/temporalio/temporal/pull/416), [#412](https://github.com/temporalio/temporal/pull/412)): `./tctl admin shard describe_task --task_type [timer, replication, transfer] ...` / `dt`.
-        - List Cluster memberships([#423](https://github.com/temporalio/temporal/pull/423/files)): `./tctl admin membership list_db`.
-        - List Ringpop members ([#426](https://github.com/temporalio/temporal/pull/426)): `./tctl admin membership list_gossip`.
-        - List Replication DLQ Tasks ([#456](https://github.com/temporalio/temporal/pull/456)): `./tctl admin kafka list_dlq`.
-    - Admin Command improvements:
-        - Filter Tasks from TaskQueue based on Workflow and run Ids  ([#462](https://github.com/temporalio/temporal/pull/462)).
-        - Consistent CLI admin command names ([#427](https://github.com/temporalio/temporal/pull/427)).
-        - Enum parameter flags changed from int to string ([#445](https://github.com/temporalio/temporal/pull/445), [#447](https://github.com/temporalio/temporal/pull/447)).
-        - Support `table-view` for list commands ([#444](https://github.com/temporalio/temporal/pull/444)).
+  - New admin commands:
+    - List namespaces ([#463](https://github.com/temporalio/temporal/pull/463)): `./tctl admin namespace list`.
+    - Describe Shard ([#370](https://github.com/temporalio/temporal/pull/370)): `./tctl admin shard describe --shard_id ...` / `d -sid`.
+    - List Tasks ([#429](https://github.com/temporalio/temporal/pull/429)/[#433](https://github.com/temporalio/temporal/pull/433)): `./tctl admin shard list_tasks`.
+    - Describe Task ([#408](https://github.com/temporalio/temporal/pull/408), [#416](https://github.com/temporalio/temporal/pull/416), [#412](https://github.com/temporalio/temporal/pull/412)): `./tctl admin shard describe_task --task_type [timer, replication, transfer] ...` / `dt`.
+    - List Cluster memberships([#423](https://github.com/temporalio/temporal/pull/423/files)): `./tctl admin membership list_db`.
+    - List Ringpop members ([#426](https://github.com/temporalio/temporal/pull/426)): `./tctl admin membership list_gossip`.
+    - List Replication DLQ Tasks ([#456](https://github.com/temporalio/temporal/pull/456)): `./tctl admin kafka list_dlq`.
+  - Admin Command improvements:
+    - Filter Tasks from TaskQueue based on Workflow and run Ids ([#462](https://github.com/temporalio/temporal/pull/462)).
+    - Consistent CLI admin command names ([#427](https://github.com/temporalio/temporal/pull/427)).
+    - Enum parameter flags changed from int to string ([#445](https://github.com/temporalio/temporal/pull/445), [#447](https://github.com/temporalio/temporal/pull/447)).
+    - Support `table-view` for list commands ([#444](https://github.com/temporalio/temporal/pull/444)).
 - **Simplified SQL Schemas** ➰ : Schemas are now less complex.
 - **All Queries are strongly consistent** 🔎 : The actual current state is always returned.
 - **SDKs** 🔌 : Significantly improved experience for both Java SDK and Go SDK.
 - **When using Docker** 🐳 :
-    - `BroadcastAddress` can be configured via the `TEMPORAL_BROADCAST_ADDRESS` environment variable.
-    - `MYSQL_TX_ISOLATION_COMPAT` environment variable can be set as `true` in order to support setting up schemas with pre-5.7.20 MySQL installations.
-    - Getting started experience has been simplified to have Docker pre baked with 'default' namespace.
+  - `BroadcastAddress` can be configured via the `TEMPORAL_BROADCAST_ADDRESS` environment variable.
+  - `MYSQL_TX_ISOLATION_COMPAT` environment variable can be set as `true` in order to support setting up schemas with pre-5.7.20 MySQL installations.
+  - Getting started experience has been simplified to have Docker pre baked with 'default' namespace.
 - **Other minor changes** 🔹 :
-    - Pass 127.0.0.1 explicitly to Cassandra in docker dependency ([#540](https://github.com/temporalio/temporal/pull/540)).
-    - Remove statsd from docker-compose files ([#536](https://github.com/temporalio/temporal/pull/536)).
-    - Expose Cassandra and serial consistency settings in configuration ([#533](https://github.com/temporalio/temporal/pull/533)).
-    - Adopt [Google api-linter](https://linter.aip.dev/) and [Buf](https://buf.build/) ([#526](https://github.com/temporalio/temporal/pull/526)).
-    - Support dynamic cluster IP addresses in failure scenarios ([#495](https://github.com/temporalio/temporal/pull/495)).
-    - Save last `RetryStatus` for retryable failures ([#432](https://github.com/temporalio/temporal/pull/432)).
+  - Pass 127.0.0.1 explicitly to Cassandra in docker dependency ([#540](https://github.com/temporalio/temporal/pull/540)).
+  - Remove statsd from docker-compose files ([#536](https://github.com/temporalio/temporal/pull/536)).
+  - Expose Cassandra and serial consistency settings in configuration ([#533](https://github.com/temporalio/temporal/pull/533)).
+  - Adopt [Google api-linter](https://linter.aip.dev/) and [Buf](https://buf.build/) ([#526](https://github.com/temporalio/temporal/pull/526)).
+  - Support dynamic cluster IP addresses in failure scenarios ([#495](https://github.com/temporalio/temporal/pull/495)).
+  - Save last `RetryStatus` for retryable failures ([#432](https://github.com/temporalio/temporal/pull/432)).
 
 ## **Docker images (use tag 0.28.0)**
 

--- a/docs/filter-workflows.md
+++ b/docs/filter-workflows.md
@@ -5,7 +5,7 @@ title: Filter Workflows
 
 Temporal supports creating workflows with customized key-value pairs, updating the information within the workflow code, and then listing/searching workflows with a SQL-like query. For example, you can create workflows with keys `city` and `age`, then search all workflows with `city = seattle and age > 22`.
 
-Also note that normal workflow properties like start time and workflow type can be queried as well. For example, the following query could be specified when [listing workflows from the CLI](/docs/tctl#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/sdk/client#Client))
+Also note that normal workflow properties like start time and workflow type can be queried as well. For example, the following query could be specified when [listing workflows from the CLI](/docs/tctl/#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/sdk/client#Client))
 
 ```sql
 WorkflowType = "main.Workflow" and Status != 0 and (StartTime > "2019-06-07T16:46:34-08:00" or CloseTime > "2019-06-07T16:46:34-08:00" order by StartTime desc)
@@ -35,9 +35,9 @@ In the Java client, the _WorkflowOptions.Builder_ has similar methods for [memo]
 
 Some important distinctions between memo and search attributes:
 
-* Memo can support all data types because it is not indexed. Search attributes only support basic data types (including String, Int, Float, Bool, Datetime) because it is indexed by Elasticsearch.
-* Memo does not restrict on key names. Search attributes require that keys are allowlisted before using them because Elasticsearch has a limit on indexed keys.
-* Memo doesn't require Temporal clusters to depend on Elasticsearch while search attributes only works with Elasticsearch.
+- Memo can support all data types because it is not indexed. Search attributes only support basic data types (including String, Int, Float, Bool, Datetime) because it is indexed by Elasticsearch.
+- Memo does not restrict on key names. Search attributes require that keys are allowlisted before using them because Elasticsearch has a limit on indexed keys.
+- Memo doesn't require Temporal clusters to depend on Elasticsearch while search attributes only works with Elasticsearch.
 
 ## Search Attributes (Go Client Usage)
 
@@ -81,12 +81,12 @@ tctl --namespace samples-namespace adm cl asa --search_attr_key NewKey --search_
 
 The possible values for **_search_attr_type_** are:
 
-* string
-* keyword
-* int
-* double
-* bool
-* datetime
+- string
+- keyword
+- int
+- double
+- bool
+- datetime
 
 #### Keyword vs String
 
@@ -94,19 +94,19 @@ Note that **Keyword** and **String** are concepts taken from Elasticsearch. Each
 
 For example, key RunId with value "2dd29ab7-2dd8-4668-83e0-89cae261cfb1"
 
-* as a **Keyword** will only be matched by RunId = "2dd29ab7-2dd8-4668-83e0-89cae261cfb1" (or in the future with [regular expressions](https://github.com/uber/cadence/issues/1137))
-* as a **String** will be matched by RunId = "2dd8", which may cause unwanted matches
+- as a **Keyword** will only be matched by RunId = "2dd29ab7-2dd8-4668-83e0-89cae261cfb1" (or in the future with [regular expressions](https://github.com/uber/cadence/issues/1137))
+- as a **String** will be matched by RunId = "2dd8", which may cause unwanted matches
 
 **Note:** String type can not be used in Order By query.
 
 There are some pre-allowlisted search attributes that are handy for testing:
 
-* CustomKeywordField
-* CustomIntField
-* CustomDoubleField
-* CustomBoolField
-* CustomDatetimeField
-* CustomStringField
+- CustomKeywordField
+- CustomIntField
+- CustomDoubleField
+- CustomBoolField
+- CustomDatetimeField
+- CustomStringField
 
 Their types are indicated in their names.
 
@@ -114,20 +114,20 @@ Their types are indicated in their names.
 
 Here are the Search Attribute value types and their correspondent Golang types:
 
-* Keyword = string
-* Int = int64
-* Double = float64
-* Bool = bool
-* Datetime = time.Time
-* String = string
+- Keyword = string
+- Int = int64
+- Double = float64
+- Bool = bool
+- Datetime = time.Time
+- String = string
 
 ### Limit
 
 We recommend limiting the number of Elasticsearch indexes by enforcing limits on the following:
 
-* Number of keys: 100 per workflow
-* Size of value: 2kb per value
-* Total size of key and values: 40kb per workflow
+- Number of keys: 100 per workflow
+- Size of value: 2kb per value
+- Total size of key and values: 40kb per workflow
 
 Temporal reserves keys like NamespaceId, WorkflowId, and RunId. These can only be used in list queries. The values are not updatable.
 
@@ -172,60 +172,60 @@ Use `workflow.GetInfo` to get current search attributes.
 
 ### ContinueAsNew and Cron
 
-When performing a [ContinueAsNew](/docs/go-continue-as-new) or using [Cron](/docs/go-distributed-cron), search attributes (and memo) will be carried over to the new run by default.
+When performing a [ContinueAsNew](/docs/go-continue-as-new/) or using [Cron](/docs/go-distributed-cron/), search attributes (and memo) will be carried over to the new run by default.
 
 ## Query Capabilities
 
-Query workflows by using a SQL-like where clause when [listing workflows from the CLI](/docs/tctl#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/sdk/client#Client), [Java](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/WorkflowService.Iface.html#ListWorkflowExecutions-com.uber.cadence.ListWorkflowExecutionsRequest-)).
+Query workflows by using a SQL-like where clause when [listing workflows from the CLI](/docs/tctl/#list-closed-or-open-workflow-executions) or using the list APIs ([Go](https://pkg.go.dev/go.temporal.io/sdk/client#Client), [Java](https://static.javadoc.io/com.uber.cadence/cadence-client/2.6.0/com/uber/cadence/WorkflowService.Iface.html#ListWorkflowExecutions-com.uber.cadence.ListWorkflowExecutionsRequest-)).
 
 Note that you will only see workflows from one namespace when querying.
 
 ### Supported Operators
 
-* AND, OR, ()
-* =, !=, >, >=, <, <=
-* IN
-* BETWEEN ... AND
-* ORDER BY
+- AND, OR, ()
+- =, !=, >, >=, <, <=
+- IN
+- BETWEEN ... AND
+- ORDER BY
 
 ### Default Attributes
 
 These can be found by using the CLI get-search-attr command or the GetSearchAttributes API. The names and types are as follows:
 
-| KEY | VALUE TYPE |
-| --- | --- |
-| Status | INT |
-| CloseTime | INT |
-| CustomBoolField | DOUBLE |
-| CustomDatetimeField | DATETIME |
-| CustomNamespace | KEYWORD |
-| CustomDoubleField | BOOL |
-| CustomIntField | INT |
-| CustomKeywordField | KEYWORD |
-| CustomStringField | STRING |
-| NamespaceId | KEYWORD |
-| ExecutionTime | INT |
-| HistoryLength | INT |
-| RunId | KEYWORD |
-| StartTime | INT |
-| WorkflowId | KEYWORD |
-| WorkflowType | KEYWORD |
+| KEY                 | VALUE TYPE |
+| ------------------- | ---------- |
+| Status              | INT        |
+| CloseTime           | INT        |
+| CustomBoolField     | DOUBLE     |
+| CustomDatetimeField | DATETIME   |
+| CustomNamespace     | KEYWORD    |
+| CustomDoubleField   | BOOL       |
+| CustomIntField      | INT        |
+| CustomKeywordField  | KEYWORD    |
+| CustomStringField   | STRING     |
+| NamespaceId         | KEYWORD    |
+| ExecutionTime       | INT        |
+| HistoryLength       | INT        |
+| RunId               | KEYWORD    |
+| StartTime           | INT        |
+| WorkflowId          | KEYWORD    |
+| WorkflowType        | KEYWORD    |
 
 There are some special considerations for these attributes:
 
-* Status, CloseTime, NamespaceId, ExecutionTime, HistoryLength, RunId, StartTime, WorkflowId, WorkflowType are reserved by Temporal and are read-only
-* Status is a mapping of int to state:
-  * 0 = unknown
-  * 1 = running
-  * 2 = completed
-  * 3 = failed
-  * 4 = canceled
-  * 5 = terminated
-  * 6 = continuedasnew
-  * 7 = timedout
-* StartTime, CloseTime and ExecutionTime are stored as INT, but support queries using both EpochTime in nanoseconds, and string in RFC3339 format (ex. "2006-01-02T15:04:05+07:00")
-* CloseTime, HistoryLength are only present in closed workflow
-* ExecutionTime is for Retry/Cron user to query a workflow that will run in the future
+- Status, CloseTime, NamespaceId, ExecutionTime, HistoryLength, RunId, StartTime, WorkflowId, WorkflowType are reserved by Temporal and are read-only
+- Status is a mapping of int to state:
+  - 0 = unknown
+  - 1 = running
+  - 2 = completed
+  - 3 = failed
+  - 4 = canceled
+  - 5 = terminated
+  - 6 = continuedasnew
+  - 7 = timedout
+- StartTime, CloseTime and ExecutionTime are stored as INT, but support queries using both EpochTime in nanoseconds, and string in RFC3339 format (ex. "2006-01-02T15:04:05+07:00")
+- CloseTime, HistoryLength are only present in closed workflow
+- ExecutionTime is for Retry/Cron user to query a workflow that will run in the future
 
 To list only open workflows, add `CloseTime = missing` to the end of the query.
 
@@ -233,13 +233,13 @@ If you use retry or the cron feature to query workflows that will start executio
 
 ### General Notes About Queries
 
-* Pagesize default is 1000, and cannot be larger than 10k
-* Range query on Temporal timestamp (StartTime, CloseTime, ExecutionTime) cannot be larger than 9223372036854775807 (maxInt64 - 1001)
-* Query by time range will have 1ms resolution
-* Query column names are case sensitive
-* ListWorkflow may take longer when retrieving a large number of workflows (10M+)
-* To retrieve a large number of workflows without caring about order, use the ScanWorkflow API
-* To efficiently count the number of workflows, use the CountWorkflow API
+- Pagesize default is 1000, and cannot be larger than 10k
+- Range query on Temporal timestamp (StartTime, CloseTime, ExecutionTime) cannot be larger than 9223372036854775807 (maxInt64 - 1001)
+- Query by time range will have 1ms resolution
+- Query column names are case sensitive
+- ListWorkflow may take longer when retrieving a large number of workflows (10M+)
+- To retrieve a large number of workflows without caring about order, use the ScanWorkflow API
+- To efficiently count the number of workflows, use the CountWorkflow API
 
 ## Tools Support
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -31,7 +31,7 @@ Want to master Temporal Workflows? Our guides will bring you up to speed on Temp
 - [How to install Temporal](/docs/install-temporal-server/)
 - [How to configure Temporal](/docs/configure-temporal-server/)
 - [How to filter Workflows](/docs/filter-workflows/)
-- [How to use the CLI (tctl)](/docs/tctl)
+- [How to use the CLI (tctl)](/docs/tctl/)
 
 ## Contribute
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -8,16 +8,16 @@ Temporal reimagines state-dependent service-orchestrated application development
 
 ## Get started
 
-Ready to build? [Install the Temporal server](/docs/install-temporal-server) and choose your SDK.
+Ready to build? [Install the Temporal server](/docs/install-temporal-server/) and choose your SDK.
 
-- [Go SDK](/docs/go-quick-start)
-- [Java SDK](/docs/java-quick-start)
+- [Go SDK](/docs/go-quick-start/)
+- [Java SDK](/docs/java-quick-start/)
 
 ## Learn about Temporal
 
-Temporal enables developers to write highly reliable applications without having to worry about all the edge cases, but getting started can be paradigm shift for some. If you are new to Temporal, or workflow applications in general, get caught up on the [core concepts](/docs/overview).
+Temporal enables developers to write highly reliable applications without having to worry about all the edge cases, but getting started can be paradigm shift for some. If you are new to Temporal, or workflow applications in general, get caught up on the [core concepts](/docs/overview/).
 
-Wondering if Temporal is a good fit for your use case? Check out our [use cases section](/docs/use-cases-orchestration) or visit the [community forum](https://community.temporal.io/tag/use-case-validation).
+Wondering if Temporal is a good fit for your use case? Check out our [use cases section](/docs/use-cases-orchestration/) or visit the [community forum](https://community.temporal.io/tag/use-case-validation).
 
 Prefer to jump right in? Try out some of our examples.
 
@@ -28,9 +28,9 @@ Prefer to jump right in? Try out some of our examples.
 
 Want to master Temporal Workflows? Our guides will bring you up to speed on Temporal development best practices.
 
-- [How to install Temporal](/docs/install-temporal-server)
-- [How to configure Temporal](/docs/configure-temporal-server)
-- [How to filter Workflows](/docs/filter-workflows)
+- [How to install Temporal](/docs/install-temporal-server/)
+- [How to configure Temporal](/docs/configure-temporal-server/)
+- [How to filter Workflows](/docs/filter-workflows/)
 - [How to use the CLI (tctl)](/docs/tctl)
 
 ## Contribute

--- a/docs/go-quick-start.md
+++ b/docs/go-quick-start.md
@@ -7,7 +7,7 @@ This topic helps you install the Temporal server and implement a workflow.
 
 ## Install Temporal Server Locally
 
-To run samples locally you need to run Temporal server locally using [instructions](/docs/install-temporal-server).
+To run samples locally you need to run Temporal server locally using [instructions](/docs/install-temporal-server/).
 
 ## Start with an empty directory
 

--- a/docs/install-temporal-server.md
+++ b/docs/install-temporal-server.md
@@ -65,6 +65,6 @@ At this point Temporal Server is running! You can also see the web interface on 
 
 ## Write Workflows and Activities using Client SDK
 
-Try out [Java SDK](/docs/java-quick-start).
+Try out [Java SDK](/docs/java-quick-start/).
 
-Try out [Go SDK](/docs/go-quick-start).
+Try out [Go SDK](/docs/go-quick-start/).

--- a/docs/java-quick-start.md
+++ b/docs/java-quick-start.md
@@ -7,7 +7,7 @@ This topic helps you install the Temporal server and implement a workflow.
 
 ## Install Temporal Server Locally
 
-To run samples locally you need to run Temporal server locally using [instructions](/docs/install-temporal-server).
+To run samples locally you need to run Temporal server locally using [instructions](/docs/install-temporal-server/).
 
 ## Implement Hello World Java Workflow
 

--- a/docs/learn-glossary.md
+++ b/docs/learn-glossary.md
@@ -63,6 +63,7 @@ Any action requested by the [**Workflow**](#workflow) durable function is called
 ### Event
 
 There are two types of Events that Temporal tracks for each workflow:
+
 1. [**Command**](#command) Events.
 2. Everything else.
 
@@ -90,7 +91,7 @@ Temporal is backed by a multi-tenant service and the unit of isolation is called
 - By default a Temporal service is provisioned with a "default" Namespace. All APIs and tools, such as the UI and CLI, default to the "default" Namespace if it is not specified. So, if you are not planning to use multiple Namespaces, we recommend using the default one.
 - [**Task Queue**](#task-queue) names as well as [**Workflow Ids**](#workflow-id) correspond to a specific Namespace. For example, when a Workflow is started, it is started within a specific Namespace.
 - Temporal guarantees a unique [**Workflow Id**](#workflow-id) within a Namespace, and supports running [**Workflow Executions**](#workflow-execution) to use the same [**Workflow Id**](#workflow-id) if they are in different Namespaces.
-- Various configuration options like the retention period or Archival destination are configured per Namespace as well through a special CRUD API or through [`tctl`](/docs/tctl).
+- Various configuration options like the retention period or Archival destination are configured per Namespace as well through a special CRUD API or through [`tctl`](/docs/tctl/).
 - In a multi-cluster deployment, Namespace is a unit of fail-over.
 - Each Namespace can only be active on a single Temporal cluster at a time. However, different Namespaces can be active in different clusters and can fail-over independently.
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -13,7 +13,7 @@ The usual approach to building such applications is a hodgepodge of stateless se
 databases, cron jobs, and queuing systems. This negatively impacts the developer productivity as most of the code is
 dedicated to plumbing, obscuring the actual business logic behind a myriad of low-level details. Such systems frequently have availability problems as it is hard to keep all the components healthy.
 
-The Temporal solution is a [_fault-oblivious stateful_ programming model](/docs/workflows) that obscures most of the complexities of building scalable distributed applications. In essence, Temporal provides a durable virtual memory that is not
+The Temporal solution is a [_fault-oblivious stateful_ programming model](/docs/workflows/) that obscures most of the complexities of building scalable distributed applications. In essence, Temporal provides a durable virtual memory that is not
 linked to a specific process, and preserves the full application state, including function stacks, with local variables across all sorts of host and software failures.
 This allows you to write code using the full power of a programming language while Temporal takes care of durability, availability, and scalability of the application.
 

--- a/docs/task-queues.md
+++ b/docs/task-queues.md
@@ -3,9 +3,9 @@ id: task-queues
 title: Task Queues
 ---
 
-When a workflow invokes an activity, it sends the `ScheduleActivityTask` [decision](/docs/learn-glossary#decision) to the
+When a workflow invokes an activity, it sends the `ScheduleActivityTask` [decision](/docs/learn-glossary/#decision) to the
 Temporal service. As a result, the service updates the workflow state and dispatches
-an [activity task](/docs/learn-glossary#activity-task) to a worker that implements the activity.
+an [activity task](/docs/learn-glossary/#activity-task) to a worker that implements the activity.
 Instead of calling the worker directly, an intermediate queue is used. So the service adds an _activity task_ to this
 queue and a worker receives the task using a long poll request.
 Temporal calls this queue used to dispatch activity tasks an _activity task queue_.

--- a/docs/tctl.md
+++ b/docs/tctl.md
@@ -137,7 +137,7 @@ Use option `--workflowidreusepolicy` or `--wrp` to configure the workflow id reu
 
 Memos are immutable key/value pairs that can be attached to a workflow run when starting the workflow. These are
 visible when listing workflows. More information on memos can be found
-[here](/docs/filter-workflows#memo-vs-search-attributes).
+[here](/docs/filter-workflows/#memo-vs-search-attributes).
 
 ```
 tctl wf start -tq hello-world -wt Workflow -et 60 -i '"temporal"' -memo_key ‘“Service” “Env” “Instance”’ -memo ‘“serverName1” “test” 5’

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -81,7 +81,7 @@ To understand the Temporal execution model as well as the recovery mechanism, wa
 
 Workflow Id is assigned by a client when starting a workflow. It is usually a business level Id like customer Id or order Id.
 
-Temporal guarantees that there could be only one workflow (across all workflow types) with a given Id open per [namespace](/docs/learn-glossary#namespace) at any time. An attempt to start a workflow with the same Id is going to fail with `WorkflowExecutionAlreadyStarted` error.
+Temporal guarantees that there could be only one workflow (across all workflow types) with a given Id open per [namespace](/docs/learn-glossary/#namespace) at any time. An attempt to start a workflow with the same Id is going to fail with `WorkflowExecutionAlreadyStarted` error.
 
 An attempt to start a workflow if there is a completed workflow with the same Id depends on a `WorkflowIdReusePolicy` option:
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,11 +66,11 @@ module.exports = {
             },
             {
               label: 'Java SDK',
-              to: 'docs/java-quick-start',
+              to: 'docs/java-quick-start/',
             },
             {
               label: 'Go SDK',
-              to: 'docs/go-quick-start',
+              to: 'docs/go-quick-start/',
             },
             {
               label: 'About',

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -27,7 +27,7 @@ module.exports = {
       },
       items: [
         {
-          to: 'docs/get-started',
+          to: 'docs/get-started/',
           activeBasePath: 'docs',
           label: 'Docs',
           position: 'right',
@@ -62,7 +62,7 @@ module.exports = {
           items: [
             {
               label: 'Getting Started',
-              to: 'docs/get-started',
+              to: 'docs/get-started/',
             },
             {
               label: 'Java SDK',
@@ -182,5 +182,5 @@ module.exports = {
       async: true,
       defer: true,
     },
-  ]
+  ],
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -58,7 +58,7 @@ function Feature({ imageUrl, title, description }) {
 function Home() {
   const context = useDocusaurusContext();
   const { siteConfig = {} } = context;
-  return <Redirect to='/docs/get-started' />;
+  return <Redirect to='/docs/get-started/' />;
   return (
     <Layout
       title={`Hello from ${siteConfig.title}`}

--- a/versioned_docs/version-0.28.0-docs-1/learn-glossary.md
+++ b/versioned_docs/version-0.28.0-docs-1/learn-glossary.md
@@ -40,7 +40,7 @@ A Task that contains invocation information for an [**Activity**](#activity) tha
 Archival is a feature that automatically moves [**Event Histories**](#event-history) from normal persistence to a blob store after the [**Workflow**](#workflow) retention period.
 
 - The purpose of Archival is to be able to keep [**Event Histories**](#event-history) as long as needed while not overwhelming the persistence store.
-- There are two reasons why you may want to keep [**Event Histories**]((#event-history)) after the retention period has passed:
+- There are two reasons why you may want to keep [**Event Histories**](#event-history) after the retention period has passed:
   1. Compliance: For legal reasons, [**Event Histories**](#event-history) may need to be stored for a long period of time.
   2. Debugging: Older [**Event Histories**](#event-history) can be referenced to help with debugging.
 
@@ -63,6 +63,7 @@ Any action requested by the [**Workflow**](#workflow) durable function is called
 ### Event
 
 There are two types of Events that Temporal tracks for each workflow:
+
 1. [**Command**](#command) Events.
 2. Everything else.
 
@@ -90,7 +91,7 @@ Temporal is backed by a multi-tenant service and the unit of isolation is called
 - By default a Temporal service is provisioned with a "default" Namespace. All APIs and tools, such as the UI and CLI, default to the "default" Namespace if it is not specified. So, if you are not planning to use multiple Namespaces, we recommend using the default one.
 - [**Task Queue**](#task-queue) names as well as [**Workflow Ids**](#workflow-id) correspond to a specific Namespace. For example, when a Workflow is started, it is started within a specific Namespace.
 - Temporal guarantees a unique [**Workflow Id**](#workflow-id) within a Namespace, and supports running [**Workflow Executions**](#workflow-execution) to use the same [**Workflow Id**](#workflow-id) if they are in different Namespaces.
-- Various configuration options like the retention period or Archival destination are configured per Namespace as well through a special CRUD API or through [`tctl`](/docs/learn-cli).
+- Various configuration options like the retention period or Archival destination are configured per Namespace as well through a special CRUD API or through [`tctl`](/docs/learn-cli/).
 - In a multi-cluster deployment, Namespace is a unit of fail-over.
 - Each Namespace can only be active on a single Temporal cluster at a time. However, different Namespaces can be active in different clusters and can fail-over independently.
 
@@ -149,7 +150,7 @@ A Worker is a service that hosts the [**Workflow**](#workflow) and [**Activity**
 A fault-oblivious stateful function that orchestrates activities.
 
 - A Workflow has full control over which [**Activities**](#activity) are executed, and in which order.
-- A Workflow must not affect the external world directly, only through [**Activities**]((#activity)).
+- A Workflow must not affect the external world directly, only through [**Activities**](#activity).
 - What makes Workflow code a Workflow is that its state is preserved by Temporal. Therefore any failure of a [**Worker**](#worker) process that hosts the Workflow code does not affect the [**Workflow Execution**](#workflow-execution). The Workflow continues as if these failures did not happen. At the same time, [**Activities**](#activity) can fail any moment for any reason.
 - Because Workflow code is fully fault-oblivious, it is guaranteed to get notifications about [**Activity**](#activity) failures or timeouts and act accordingly.
 - There is no limit to the duration of a Workflow.


### PR DESCRIPTION
## What
For links, adds slash symbol `/` to the end of internal doc urls 
Adds slash before the hash symbol `#` if there is any

Before `[here](/docs/filter-workflows#memo-vs-search-attributes)`
After `[here](/docs/filter-workflows/#memo-vs-search-attributes)`


## Why
Netlify links validation plugin expects links to have a slash `/` before the hash part of urls.

## How
Regex used to update `.md` links:
```(\[[\w\s]+\]\(.*\/docs\/[\w-]*)(#?)([\w-]*\))```
Replace with
`$1/$2$3`