### PR TITLE
Set prettier extension in vscode as recommended

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,9 @@
+{
+  // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+  // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+  // List of extensions which should be recommended for users of this workspace.
+  "recommendations": ["esbenp.prettier-vscode"],
+  // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+  "unwantedRecommendations": []
+}


### PR DESCRIPTION
Opening project in VSCode will also show a popup recommending to install Prettier.
![image](https://user-images.githubusercontent.com/11838981/90451016-c6536f00-e09f-11ea-85d7-9fe545d5cf88.png)

This tool helps to format markdown documents. 
To use it just save a file and Prettier will automatically format the document

Example:

![image](https://user-images.githubusercontent.com/11838981/90451198-234f2500-e0a0-11ea-8dcb-80335fb996c7.png)
