### PR TITLE
add note on other SDKs

### DIFF
--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -13,6 +13,8 @@ Ready to build? [Install the Temporal server](/docs/install-temporal-server/) an
 - [Go SDK](/docs/go-quick-start/)
 - [Java SDK](/docs/java-quick-start/)
 
+[Other SDKs](/docs/other-sdks) are in the works, please get in touch.
+
 ## Learn about Temporal
 
 Temporal enables developers to write highly reliable applications without having to worry about all the edge cases, but getting started can be paradigm shift for some. If you are new to Temporal, or workflow applications in general, get caught up on the [core concepts](/docs/overview/).

--- a/docs/other-sdks.md
+++ b/docs/other-sdks.md
@@ -13,5 +13,5 @@ Looking for SDKs in other languages? There are plans to support many other SDKs,
 - Node.js SDK - please get in touch with us
 - Rust SDK - please get in touch with us
 - C++ SDK - please get in touch with us
-
+- [PHP](https://github.com/temporalio/php-sdk) - maintained by Temporal, but not officially launched, please get in touch
 If you are interested in using an unofficial SDK, we recommend that you reach out to any of us at Temporal. We are very excited by the community's enthusiasm and strongly believe in collaborating on open source projects. Our goal is to make sure there is maintenance leadership in place to care for the developer experience over the long term.

--- a/docs/other-sdks.md
+++ b/docs/other-sdks.md
@@ -4,7 +4,7 @@ title: Other SDKs
 sidebar_label: Other SDKs
 ---
 
-There is demand for other Temporal SDKs other than Go and Java. The user community has taken initiative to build some of these, but please note that they are not officially supported or endorsed by Temporal unless explicitly mentioned:
+Looking for SDKs in other languages? There are plans to support many other SDKs, but currently we only support Go and Java. This is a list of ones that are in the works but are not yet officially endorsed:
 
 - [Ruby SDK by Coinbase](https://github.com/coinbase/temporal-ruby)
 - Python SDK - please get in touch with us

--- a/docs/other-sdks.md
+++ b/docs/other-sdks.md
@@ -14,4 +14,4 @@ There is demand for other Temporal SDKs other than Go and Java. The user communi
 - Rust SDK - please get in touch with us
 - C++ SDK - please get in touch with us
 
-We are very excited by the interest of the community, but please don't go too far without getting in touch with us! Collaboration via open source is something we strongly believe in, but we also care about the long term developer experience and therefore likely will want to take on maintenance leadership of SDKs in key languages.
+If you are interested in using an unofficial SDK, we recommend that you reach out to any of us at Temporal. We are very excited by the community's enthusiasm and strongly believe in collaborating on open source projects. Our goal is to make sure there is maintenance leadership in place to care for the developer experience over the long term.

--- a/docs/other-sdks.md
+++ b/docs/other-sdks.md
@@ -9,7 +9,7 @@ There is demand for other Temporal SDKs other than Go and Java. The user communi
 - [Ruby SDK by Coinbase](https://github.com/coinbase/temporal-ruby)
 - Python SDK - please get in touch with us
 - Swift SDK - please get in touch with us
-- C#/dotNet SDK - please get in touch with us
+- C#/.Net SDK - please get in touch with us
 - Node.js SDK - please get in touch with us
 - Rust SDK - please get in touch with us
 - C++ SDK - please get in touch with us

--- a/docs/other-sdks.md
+++ b/docs/other-sdks.md
@@ -1,0 +1,17 @@
+---
+id: other-sdks
+title: Other SDKs
+sidebar_label: Other SDKs
+---
+
+There is demand for other Temporal SDKs other than Go and Java. The user community has taken initiative to build some of these, but please note that they are not officially supported or endorsed by Temporal unless explicitly mentioned:
+
+- [Ruby SDK by Coinbase](https://github.com/coinbase/temporal-ruby)
+- Python SDK - please get in touch with us
+- Swift SDK - please get in touch with us
+- C#/dotNet SDK - please get in touch with us
+- Node.js SDK - please get in touch with us
+- Rust SDK - please get in touch with us
+- C++ SDK - please get in touch with us
+
+We are very excited by the interest of the community, but please don't go too far without getting in touch with us! Collaboration via open source is something we strongly believe in, but we also care about the long term developer experience and therefore likely will want to take on maintenance leadership of SDKs in key languages.

--- a/sidebars.js
+++ b/sidebars.js
@@ -84,5 +84,6 @@ module.exports = {
         'java-distributed-cron',
       ],
     },
+    'other-sdks',
   ],
 };


### PR DESCRIPTION
to start organizing non Go/JavaSDKs and strongly indicate our desire to own the developer experience in core strategic languages