### PR TITLE
Prettify cli help commands

### DIFF
--- a/docs/tctl.md
+++ b/docs/tctl.md
@@ -47,11 +47,10 @@ Setting environment variables for repeated parameters can shorten the CLI comman
 
 ## Quick Start
 
-Run `./tctl` for help on top level commands and global options
-Run `./tctl namespace` for help on namespace operations
-Run `./tctl workflow` for help on workflow operations
-Run `./tctl taskqueue` for help on task queue operations
-(`./tctl help`, `./tctl help [namespace|workflow]` will also print help messages)
+- Run `./tctl -h` for help on top level commands and global options
+- Run `./tctl namespace -h` for help on namespace operations
+- Run `./tctl workflow -h` for help on workflow operations
+- Run `./tctl taskqueue -h` for help on task queue operations
 
 **Note:** make sure you have a Temporal server running before using CLI
 


### PR DESCRIPTION
before: 1) no dots between the sentences. 2) explicit `-h` i i think is clearer when referring to help commands 3) last sentence about other ways to execute `help` is unnecessary imo
![image](https://user-images.githubusercontent.com/11838981/95917398-0dd43f80-0d5f-11eb-9184-77f04f2d6a50.png)

after:
![image](https://user-images.githubusercontent.com/11838981/95917518-3ceab100-0d5f-11eb-925f-db301ae8fd94.png)
