### PR TITLE
Remove global namespace flag from tctl

### DIFF
--- a/docs/tctl.md
+++ b/docs/tctl.md
@@ -59,9 +59,9 @@ Setting environment variables for repeated parameters can shorten the CLI comman
 - Register a new namespace named "samples-namespace":
 
 ```
-./tctl --namespace samples-namespace namespace register --global_namespace false
+./tctl --namespace samples-namespace namespace register
 # OR using short alias
-./tctl --ns samples-namespace n re --gd false
+./tctl --ns samples-namespace n re
 ```
 
 - View "samples-namespace" details:


### PR DESCRIPTION
Global namespaces are disabled by default. Not sure if it is helpful to have it or it might just confuse people if they try to set it to true?