### PR TITLE
Fixing Java starting workflow samples

### DIFF
--- a/docs/java-run-your-first-app.md
+++ b/docs/java-run-your-first-app.md
@@ -74,7 +74,7 @@ There are two ways to start a Workflow with Temporal, either via the SDK or via 
 <!--SNIPSTART money-transfer-project-template-java-workflow-initiator-->
 <!--SNIPEND-->
 
-The call to the Temporal server can be done synchronously or asynchronously. Here we do it asynchronously, so you will see the program run, tell you the transaction is processing, and exit.
+The call to the Temporal server can be done [synchronously or asynchronously](/docs/java-starting-workflow-executions). Here we do it asynchronously, so you will see the program run, tell you the transaction is processing, and exit.
 
 ### State visibility
 

--- a/docs/java-starting-workflow-executions.md
+++ b/docs/java-starting-workflow-executions.md
@@ -12,21 +12,18 @@ An asynchronous start initiates a Workflow execution and immediately returns to 
 <!--SNIPSTART money-transfer-project-template-java-workflow-initiator-->
 <!--SNIPEND-->
 
+If you need to wait for the completion of a Workflow after an asynchronous start, the most straightforward way is to call the blocking Workflow instance again. If `WorkflowOptions.WorkflowIdReusePolicy` is not set to `AllowDuplicate`, then instead of throwing `DuplicateWorkflowException`, it reconnects to an existing Workflow and waits for its completion. The following example shows how to do this from a different process than the one that started the Workflow. All this process needs is a `WorkflowId`.
+
+```java
+WorkflowExecution we = new WorkflowExecution().setWorkflowId(workflowId);
+YourWorkflow workflow = client.newWorkflowStub(YourWorkflow.class, we);
+// Returns the result after waiting for the Workflow to complete.
+String result = workflow.yourMethod();
+```
+
 ## Synchronous start
 
 A Synchronous start initiates a Workflow and then waits for its completion. The started Workflow will not rely on the invocation process and will continue executing even if the waiting process crashes or was stops.
 
 <!--SNIPSTART hello-world-project-template-java-workflow-initiator-->
 <!--SNIPEND-->
-
-If you need to wait for the completion of a Workflow after an asynchronous start, the most straightforward way is to call the blocking Workflow instance again. If `WorkflowOptions.WorkflowIdReusePolicy` is not set to `AllowDuplicate`, then instead of throwing `DuplicateWorkflowException`, it reconnects to an existing Workflow and waits for its completion.
-
-The following example shows how to do this from a different process than the one that started the Workflow. All this process
-needs is a `WorkflowId`.
-
-```java
-WorkflowExecution we = new WorkflowExecution().setWorkflowId(workflowId);
-HelloWorldWorkflow workflow = client.newWorkflowStub(HelloWorldWorkflow.class, we);
-// Returns result potentially waiting for Workflow to complete.
-String greeting = workflow.getGreeting("World");
-```

--- a/docs/java-starting-workflow-executions.md
+++ b/docs/java-starting-workflow-executions.md
@@ -3,48 +3,30 @@ id: java-starting-workflow-executions
 title: Starting workflow executions
 ---
 
-A Workflow interface that executes a Workflow requires initializing a `WorkflowClient` instance, creating
-a client side stub to the Workflow, and then calling a method annotated with @WorkflowMethod.
+In Java, Workflows can be started both synchronously and asynchronously in Java. To do either, you must initialize an instance of a `WorkflowClient`, create a client side Workflow stub, and then call a method that is annotated with `@WorkflowMethod`.
 
-```java
-    // service and client are heavyweight objects that should be created once per process lifetime.
-    WorkflowServiceStubs service = WorkflowServiceStubs.newInstance();
-    WorkflowClient client = WorkflowClient.newInstance(service);
-    // Create a new Workflow stub per each Workflow start
-    FileProcessingWorkflow workflow = workflowClient.newWorkflowStub(FileProcessingWorkflow.class);
-```
+## Asynchronous start
 
-There are two ways to start Workflow execution: asynchronously and synchronously.
+An asynchronous start initiates a Workflow execution and immediately returns to the caller. This is the most common way to start Workflows in a live environment.
 
-Asynchronous start initiates a Workflow execution and immediately returns to the caller. This is the most common way to start Workflows in production.
+<!--SNIPSTART money-transfer-project-template-java-workflow-initiator-->
+<!--SNIPEND-->
 
-Synchronous invocation starts a Workflow and then waits for its completion. The started Workflow will not rely on the invocation process and will continue executing even if the process crashed or was stopped.
+## Synchronous start
 
-Asynchronous start:
-```java
-// Returns as soon as the Workflow starts.
-WorkflowExecution workflowExecution = WorkflowClient.start(workflow::processFile, workflowArgs);
+A Synchronous start initiates a Workflow and then waits for its completion. The started Workflow will not rely on the invocation process and will continue executing even if the waiting process crashes or was stops.
 
-System.out.println("Started process file workflow with workflowId=\"" + workflowExecution.getWorkflowId()
-                    + "\" and runId=\"" + workflowExecution.getRunId() + "\"");
-```
+<!--SNIPSTART hello-world-project-template-java-workflow-initiator-->
+<!--SNIPEND-->
 
-Synchronous start:
-```java
-// Start a Workflow and then wait for a result.
-// Note that if the waiting process is killed, the Workflow will continue execution.
-String result = workflow.processFile(workflowArgs);
-```
+If you need to wait for the completion of a Workflow after an asynchronous start, the most straightforward way is to call the blocking Workflow instance again. If `WorkflowOptions.WorkflowIdReusePolicy` is not set to `AllowDuplicate`, then instead of throwing `DuplicateWorkflowException`, it reconnects to an existing Workflow and waits for its completion.
 
-If you need to wait for a Workflow completion after an asynchronous start, the most straightforward way
-is to call the blocking version again. If `WorkflowOptions.WorkflowIdReusePolicy` is not `AllowDuplicate`, then instead
-of throwing `DuplicateWorkflowException`, it reconnects to an existing Workflow and waits for its completion.
 The following example shows how to do this from a different process than the one that started the Workflow. All this process
 needs is a `WorkflowId`.
 
 ```java
-WorkflowExecution execution = new WorkflowExecution().setWorkflowId(workflowId);
-FileProcessingWorkflow workflow = workflowClient.newWorkflowStub(execution);
+WorkflowExecution we = new WorkflowExecution().setWorkflowId(workflowId);
+HelloWorldWorkflow workflow = client.newWorkflowStub(HelloWorldWorkflow.class, we);
 // Returns result potentially waiting for Workflow to complete.
-String result = workflow.processFile(workflowArgs);
+String greeting = workflow.getGreeting("World");
 ```

--- a/snipsync.config.yaml
+++ b/snipsync.config.yaml
@@ -1,13 +1,13 @@
 origins:
   - owner: temporalio
     repo: money-transfer-project-template-java
-    ref: 28a0eef72ffab7e29901242063ea66561404937d
+    ref: 2d4de50bfad5b12add81b0069e73b4d2fe00f94d
   - owner: temporalio
     repo: hello-world-project-template-java
     ref: 36145d28d5dade98b54ec11057a3296cdd52cbde
   - owner: temporalio
     repo: money-transfer-project-template-go
-    ref: 7a512d04d39f85e2241fd6b8225634ee1ba218da
+    ref: 33c23e3b19444cd5c7df59fb7e29bc0ee5c92cc5
   - owner: temporalio
     repo: hello-world-project-template-go
     ref: 51ba6c9ef7eeabc7c86624e4f60058ae57ab1a5d


### PR DESCRIPTION
View changes here: https://deploy-preview-166--mystifying-fermi-1bc096.netlify.app/docs/java-starting-workflow-executions

This PR changes the Java SDK page about starting workflow executions.
The code samples have been adjusted to more recent examples from template repos and are now injected via [Snipsync](https://github.com/temporalio/snipsync)
