### PR TITLE
Nightmode fix sorta

### DIFF
--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import React from 'react';
+import React, { useEffect } from 'react';
 import Head from '@docusaurus/Head';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
@@ -24,9 +24,6 @@ function Providers({ children }) {
 }
 
 function Layout(props) {
-  if (localStorage) {
-    localStorage.removeItem('theme');
-  }
   const { siteConfig = {} } = useDocusaurusContext();
   const {
     favicon,
@@ -50,6 +47,9 @@ function Layout(props) {
     absolute: true,
   });
   const faviconUrl = useBaseUrl(favicon);
+  useEffect(() => {
+    localStorage.removeItem('theme');
+  }, []);
   return (
     <Providers>
       <Head>

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -24,7 +24,9 @@ function Providers({ children }) {
 }
 
 function Layout(props) {
-  localStorage.removeItem('theme');
+  if (localStorage) {
+    localStorage.removeItem('theme');
+  }
   const { siteConfig = {} } = useDocusaurusContext();
   const {
     favicon,

--- a/src/theme/Layout/index.js
+++ b/src/theme/Layout/index.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import Head from '@docusaurus/Head';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import ThemeProvider from '@theme/ThemeProvider';
+import UserPreferencesProvider from '@theme/UserPreferencesProvider';
+import AnnouncementBar from '@theme/AnnouncementBar';
+import Navbar from '@theme/Navbar';
+import Footer from '@theme/Footer';
+import './styles.css';
+
+function Providers({ children }) {
+  return (
+    <ThemeProvider>
+      <UserPreferencesProvider>{children}</UserPreferencesProvider>
+    </ThemeProvider>
+  );
+}
+
+function Layout(props) {
+  localStorage.removeItem('theme');
+  const { siteConfig = {} } = useDocusaurusContext();
+  const {
+    favicon,
+    title: siteTitle,
+    themeConfig: { image: defaultImage },
+    url: siteUrl,
+  } = siteConfig;
+  const {
+    children,
+    title,
+    noFooter,
+    description,
+    image,
+    keywords,
+    permalink,
+    version,
+  } = props;
+  const metaTitle = title ? `${title} | ${siteTitle}` : siteTitle;
+  const metaImage = image || defaultImage;
+  const metaImageUrl = useBaseUrl(metaImage, {
+    absolute: true,
+  });
+  const faviconUrl = useBaseUrl(favicon);
+  return (
+    <Providers>
+      <Head>
+        {/* TODO: Do not assume that it is in english language */}
+        <html lang="en" />
+
+        {metaTitle && <title>{metaTitle}</title>}
+        {metaTitle && <meta property="og:title" content={metaTitle} />}
+        {favicon && <link rel="shortcut icon" href={faviconUrl} />}
+        {description && <meta name="description" content={description} />}
+        {description && (
+          <meta property="og:description" content={description} />
+        )}
+        {version && <meta name="docsearch:version" content={version} />}
+        {keywords && keywords.length && (
+          <meta name="keywords" content={keywords.join(',')} />
+        )}
+        {metaImage && <meta property="og:image" content={metaImageUrl} />}
+        {metaImage && <meta property="twitter:image" content={metaImageUrl} />}
+        {metaImage && (
+          <meta name="twitter:image:alt" content={`Image for ${metaTitle}`} />
+        )}
+        {permalink && <meta property="og:url" content={siteUrl + permalink} />}
+        {permalink && <link rel="canonical" href={siteUrl + permalink} />}
+        <meta name="twitter:card" content="summary_large_image" />
+      </Head>
+      <AnnouncementBar />
+      <Navbar />
+      <div className="main-wrapper">{children}</div>
+      {!noFooter && <Footer />}
+    </Providers>
+  );
+}
+
+export default Layout;

--- a/src/theme/Layout/styles.css
+++ b/src/theme/Layout/styles.css
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  transition: var(--ifm-transition-fast) ease color;
+}
+
+#__docusaurus {
+  min-height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.main-wrapper {
+  flex: 1 0 auto;
+}


### PR DESCRIPTION
This isn't testable on the live deploy. I tested it via the following:

1. Temporarily re-enable the theme selection for docusaurus 

```
    colorMode: {
      defaultMode: 'dark',
      disableSwitch: false,
    },
```

2. Open up the site in incognito and enable light mode
3. Open a new incognito tab and close the docusaurus one so the incognito window stays open but docusaurus does not
4. Navigate to docusaurus again. Things will still look broken. 
5. Refresh the page. The issue is permanently fixed.


To be clear standard users will need to load the site and refresh once to fix the issue. After doing so it will be gone permanently. 