### PR TITLE
Adding server dependency information

### DIFF
--- a/docs/server-dependencies.md
+++ b/docs/server-dependencies.md
@@ -8,10 +8,7 @@ sidebar_label: Dependencies
 
 This page details some of the requirements and dependencies needed to build and run an instance of Temporal.
 
-All versions of Temporal require the following:
-
-1. [Go 1.15+](https://golang.org/dl/)
-2. [Go package dependencies](https://github.com/temporalio/temporal/blob/master/go.mod)
+All versions of Temporal require that [Go v1.15+](https://golang.org/dl/) is installed in the environment.
 
 ## Dependency matrix
 
@@ -30,24 +27,22 @@ Legend of tested and supported dependency versions:
 - 🟫 &nbsp;**Kafka v2.1.1 & Zookeeper v3.4.6**
 
 
-| Temporal version | Databases | Search | Event streaming | Monitoring | Observation |
-|------------------|-----------|--------|-----------------|------------|-------------|
-| 1.3.2            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
-| 1.3.1            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
-| 1.3.0            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
-| 1.2.2            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
-| 1.2.1            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
-| 1.1.1            | 🟩 🟪    | 🟥     | 🟫              | 🟦        | 🟨          |
-| 1.1.0            | 🟩 🟪    | 🟥     | 🟫              | 🟦        | 🟨          |
-| 1.0.0            | 🟩 🟪    | 🟥     | 🟫              | 🟦        | 🟨          |
+| Version | Go packages | Databases | Search | Event streaming | Monitoring | Observation |
+|---------|-------------|-----------|--------|-----------------|------------|-------------|
+| [1.3.2](https://github.com/temporalio/temporal/tree/v1.3.2) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.2/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨 |
+| [1.3.1](https://github.com/temporalio/temporal/tree/v1.3.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.1/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨 |
+| [1.3.0](https://github.com/temporalio/temporal/tree/v1.3.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.0/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨 |
+| [1.2.2](https://github.com/temporalio/temporal/tree/v1.2.2) | [go.mod](https://github.com/temporalio/temporal/blob/v1.2.2/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨 |
+| [1.2.1](https://github.com/temporalio/temporal/tree/v1.2.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.2.1/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨          |
+| [1.1.1](https://github.com/temporalio/temporal/tree/v1.1.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.1.1/go.mod) | 🟩 🟪 | 🟥 | 🟫 | 🟦 | 🟨 |
+| [1.1.0](https://github.com/temporalio/temporal/tree/v1.1.0)   | [go.mod](https://github.com/temporalio/temporal/blob/v1.1.0/go.mod) | 🟩 🟪 | 🟥 | 🟫 | 🟦 | 🟨 |
+| [1.0.0](https://github.com/temporalio/temporal/tree/v1.0.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.0.0/go.mod) | 🟩 🟪 | 🟥 | 🟫 | 🟦 | 🟨 |
 
 ## How to use a different Temporal release version
 
 To use a more recent version of Temporal, first [check to see](https://github.com/temporalio/temporal/releases) if an upgrade to the database schema is required. Newer binaries can not run with older database schemas. Some releases require changes to the schema, and some do not. If you are using a version that is older than 1.0.0, reach out to us at [community.temporal.io](http://community.temporal.io) to ask how to upgrade.
 
-If you wish to use an older version of Temporal, you do not need to make schema changes as older binaries can operate with newer schemas. Note: we do not recommend using any version older than v1.0.0.
-
-We ensure that any consecutive versions are compatible in terms of database schema upgrades, however there is no guarantee that schema changes between *any* 2 non-consecutive versions are compatible. Please reach out to us or check the forums at [community.temporal.io](http://community.temporal.io) for more information.
+We ensure that any consecutive versions are compatible in terms of database schema upgrades, features, and system behavior, however there is no guarantee that there is compatibility between *any* 2 non-consecutive versions. Please reach out to us or check the forums at [community.temporal.io](http://community.temporal.io) for more information.
 
 ### Upgrade Cassandra schema
 
@@ -55,7 +50,7 @@ You can use the `temporal-cassandra-tool` to upgrade both the default and visibi
 
 **Example default schema upgrade:**
 
-```
+```bash
 temporal_v1.2.1 $ temporal-cassandra-tool \
    --tls \
    --tls-ca-file <...> \
@@ -71,7 +66,7 @@ temporal_v1.2.1 $ temporal-cassandra-tool \
 
 **Example visibility schema upgrade:**
 
-```
+```bash
 temporal_v1.2.1 $ temporal-cassandra-tool \
    --tls \
    --tls-ca-file <...> \
@@ -91,12 +86,64 @@ Use the `temporal-sql-tool`, which works similarly to the `temporal-cassandra-to
 
 Refer to this [Makefile](https://github.com/temporalio/temporal/blob/v1.3.2/Makefile#L367-L383) for context.
 
+#### PostgreSQL
+
+**Example default schema upgrade:***
+
+```bash
+./temporal-sql-tool \
+	--tls \
+	--tls-enable-host-verification \
+	--tls-cert-file <path to your client cert> \
+	--tls-key-file <path to your client key> \
+	--tls-ca-file <path to your CA> \
+	--ep localhost -p 5432 -u temporal -pw temporal --pl postgres --db temporal update-schema -d ./schema/postgresql/v96/temporal/versioned
+```
+
+**Example visibility schema upgrade:**
+
+```bash
+./temporal-sql-tool \
+	--tls \
+	--tls-enable-host-verification \
+	--tls-cert-file <path to your client cert> \
+	--tls-key-file <path to your client key> \
+	--tls-ca-file <path to your CA> \
+	--ep localhost -p 5432 -u temporal -pw temporal --pl postgres --db temporal_visibility update-schema -d ./schema/postgresql/v96/visibility/versioned
+```
+
+#### MySQL
+
+**Example default schema upgrade:**
+
+```bash
+./temporal-sql-tool \
+	--tls \
+	--tls-enable-host-verification \
+	--tls-cert-file <path to your client cert> \
+	--tls-key-file <path to your client key> \
+	--tls-ca-file <path to your CA> \
+	--ep localhost -p 3036 -u root -pw root --pl mysql --db temporal update-schema -d ./schema/mysql/v57/temporal/versioned/
+```
+
+**Example visibility schema upgrade:**
+
+```bash
+./temporal-sql-tool \
+	--tls \
+	--tls-enable-host-verification \
+	--tls-cert-file <path to your client cert> \
+	--tls-key-file <path to your client key> \
+	--tls-ca-file <path to your CA> \
+	--ep localhost -p 3036 -u root -pw root --pl mysql --db temporal_visibility update-schema -d ./schema/mysql/v57/visibility/versioned/
+```
+
 ### Cluster Management
 
 We recommend preparing a staging cluster and then do the following to verify the upgrade is successful:
 
-1. Create simulation load on the staging cluster.
-2. Upgrade the database schema in staging cluster.
+1. Create some simulation load on the staging cluster.
+2. Upgrade the database schema in the staging cluster.
 3. Wait and observe for few minutes to verify that there is no unstable behavior from both the server and the simulation load logic.
 4. Upgrade the server.
-5. Now do the same to live environment cluster.
+5. Now do the same to the live environment cluster.

--- a/docs/server-dependencies.md
+++ b/docs/server-dependencies.md
@@ -1,0 +1,102 @@
+---
+id: server-dependencies
+title: Temporal server dependencies
+sidebar_label: Dependencies
+---
+
+## Overview
+
+This page details some of the requirements and dependencies needed to build and run an instance of Temporal.
+
+All versions of Temporal require the following:
+
+1. [Go 1.15+](https://golang.org/dl/)
+2. [Go package dependencies](https://github.com/temporalio/temporal/blob/master/go.mod)
+
+## Dependency matrix
+
+The following table shows which versions of dependencies are supported with a specific version of Temporal.
+
+Note that the only required dependency is a database, and there are multiple types of databases that are supported. Search is an optional feature and currently only ElasticSearch is supported. Event streaming software as a dependency is only required when ElasticSearch is being used or when Temporal is deployed across multiple data centers, however in future releases of Temporal, third party event streaming software will likely cease to be needed as dependency for both. Temporal emits metrics by default in a format that is supported by Prometheus. Monitoring and observing those metrics is optional. Any software that can pull metrics that supports the same format could be used, but we only ensure it works with Prometheus and Grafana versions.
+
+Legend of tested and supported dependency versions:
+
+- 🟩 &nbsp;**Cassandra v3.11**
+- 🟪 &nbsp;**MySQL v5.7**
+- 🟧 &nbsp;**PostgreSQL v9.6**
+- 🟥 &nbsp;**ElasticSearch v6.8**
+- 🟦 &nbsp;**Prometheus >= v2.0**
+- 🟨 &nbsp;**Grafana >= v2.5**
+- 🟫 &nbsp;**Kafka v2.1.1 & Zookeeper v3.4.6**
+
+
+| Temporal version | Databases | Search | Event streaming | Monitoring | Observation |
+|------------------|-----------|--------|-----------------|------------|-------------|
+| 1.3.2            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
+| 1.3.1            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
+| 1.3.0            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
+| 1.2.2            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
+| 1.2.1            | 🟩 🟪 🟧 | 🟥     | 🟫              | 🟦        | 🟨          |
+| 1.1.1            | 🟩 🟪    | 🟥     | 🟫              | 🟦        | 🟨          |
+| 1.1.0            | 🟩 🟪    | 🟥     | 🟫              | 🟦        | 🟨          |
+| 1.0.0            | 🟩 🟪    | 🟥     | 🟫              | 🟦        | 🟨          |
+
+## How to use a different Temporal release version
+
+To use a more recent version of Temporal, first [check to see](https://github.com/temporalio/temporal/releases) if an upgrade to the database schema is required. Newer binaries can not run with older database schemas. Some releases require changes to the schema, and some do not. If you are using a version that is older than 1.0.0, reach out to us at [community.temporal.io](http://community.temporal.io) to ask how to upgrade.
+
+If you wish to use an older version of Temporal, you do not need to make schema changes as older binaries can operate with newer schemas. Note: we do not recommend using any version older than v1.0.0.
+
+We ensure that any consecutive versions are compatible in terms of database schema upgrades, however there is no guarantee that schema changes between *any* 2 non-consecutive versions are compatible. Please reach out to us or check the forums at [community.temporal.io](http://community.temporal.io) for more information.
+
+### Upgrade Cassandra schema
+
+You can use the `temporal-cassandra-tool` to upgrade both the default and visibility schemas for your Cassandra DB:
+
+**Example default schema upgrade:**
+
+```
+temporal_v1.2.1 $ temporal-cassandra-tool \
+   --tls \
+   --tls-ca-file <...> \
+   --user <cassandra-user> \
+   --password <cassandra-password> \
+   --endpoint <cassandra.example.com> \
+   --keyspace temporal \
+   --timeout 120 \
+   update \
+   --schema-dir ./schema/cassandra/temporal/versioned
+
+```
+
+**Example visibility schema upgrade:**
+
+```
+temporal_v1.2.1 $ temporal-cassandra-tool \
+   --tls \
+   --tls-ca-file <...> \
+   --user <cassandra-user> \
+   --password <cassandra-password> \
+   --endpoint <cassandra.example.com> \
+   --keyspace temporal_visibility \
+   --timeout 120 \
+   update \
+   --schema-dir ./schema/cassandra/visibility/versioned
+
+```
+
+### Upgrade MySQL / PostgreSQL schema
+
+Use the `temporal-sql-tool`, which works similarly to the `temporal-cassandra-tool`.
+
+Refer to this [Makefile](https://github.com/temporalio/temporal/blob/v1.3.2/Makefile#L367-L383) for context.
+
+### Cluster Management
+
+We recommend preparing a staging cluster and then do the following to verify the upgrade is successful:
+
+1. Create simulation load on the staging cluster.
+2. Upgrade the database schema in staging cluster.
+3. Wait and observe for few minutes to verify that there is no unstable behavior from both the server and the simulation load logic.
+4. Upgrade the server.
+5. Now do the same to live environment cluster.

--- a/docs/server-dependencies.md
+++ b/docs/server-dependencies.md
@@ -10,33 +10,49 @@ This page details some of the requirements and dependencies needed to build and 
 
 All versions of Temporal require that [Go v1.15+](https://golang.org/dl/) is installed in the environment.
 
-## Dependency matrix
+## Dependencies
 
-The following table shows which versions of dependencies are supported with a specific version of Temporal.
+Temporal offers official support for and is tested against dependencies with these exact versions:
 
-Note that the only required dependency is a database, and there are multiple types of databases that are supported. Search is an optional feature and currently only ElasticSearch is supported. Event streaming software as a dependency is only required when ElasticSearch is being used or when Temporal is deployed across multiple data centers, however in future releases of Temporal, third party event streaming software will likely cease to be needed as dependency for both. Temporal emits metrics by default in a format that is supported by Prometheus. Monitoring and observing those metrics is optional. Any software that can pull metrics that supports the same format could be used, but we only ensure it works with Prometheus and Grafana versions.
+### Go Packages
 
-Legend of tested and supported dependency versions:
+| Temporal version | Go packages |
+|------------------|-------------|
+| [1.3.2](https://github.com/temporalio/temporal/tree/v1.3.2) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.2/go.mod) |
+| [1.3.1](https://github.com/temporalio/temporal/tree/v1.3.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.1/go.mod) |
+| [1.3.0](https://github.com/temporalio/temporal/tree/v1.3.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.0/go.mod) |
+| [1.2.2](https://github.com/temporalio/temporal/tree/v1.2.2) | [go.mod](https://github.com/temporalio/temporal/blob/v1.2.2/go.mod) |
+| [1.2.1](https://github.com/temporalio/temporal/tree/v1.2.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.2.1/go.mod) |
+| [1.1.1](https://github.com/temporalio/temporal/tree/v1.1.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.1.1/go.mod) |
+| [1.1.0](https://github.com/temporalio/temporal/tree/v1.1.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.1.0/go.mod) |
+| [1.0.0](https://github.com/temporalio/temporal/tree/v1.0.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.0.0/go.mod) |
 
-- 🟩 &nbsp;**Cassandra v3.11**
-- 🟪 &nbsp;**MySQL v5.7**
-- 🟧 &nbsp;**PostgreSQL v9.6**
-- 🟥 &nbsp;**ElasticSearch v6.8**
-- 🟦 &nbsp;**Prometheus >= v2.0**
-- 🟨 &nbsp;**Grafana >= v2.5**
-- 🟫 &nbsp;**Kafka v2.1.1 & Zookeeper v3.4.6**
+### Databases
 
+The only required dependency is a database, and there are multiple types of databases that are supported.
 
-| Version | Go packages | Databases | Search | Event streaming | Monitoring | Observation |
-|---------|-------------|-----------|--------|-----------------|------------|-------------|
-| [1.3.2](https://github.com/temporalio/temporal/tree/v1.3.2) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.2/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨 |
-| [1.3.1](https://github.com/temporalio/temporal/tree/v1.3.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.1/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨 |
-| [1.3.0](https://github.com/temporalio/temporal/tree/v1.3.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.3.0/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨 |
-| [1.2.2](https://github.com/temporalio/temporal/tree/v1.2.2) | [go.mod](https://github.com/temporalio/temporal/blob/v1.2.2/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨 |
-| [1.2.1](https://github.com/temporalio/temporal/tree/v1.2.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.2.1/go.mod) | 🟩 🟪 🟧 | 🟥 | 🟫 | 🟦 | 🟨          |
-| [1.1.1](https://github.com/temporalio/temporal/tree/v1.1.1) | [go.mod](https://github.com/temporalio/temporal/blob/v1.1.1/go.mod) | 🟩 🟪 | 🟥 | 🟫 | 🟦 | 🟨 |
-| [1.1.0](https://github.com/temporalio/temporal/tree/v1.1.0)   | [go.mod](https://github.com/temporalio/temporal/blob/v1.1.0/go.mod) | 🟩 🟪 | 🟥 | 🟫 | 🟦 | 🟨 |
-| [1.0.0](https://github.com/temporalio/temporal/tree/v1.0.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.0.0/go.mod) | 🟩 🟪 | 🟥 | 🟫 | 🟦 | 🟨 |
+- **Cassandra v3.11**
+- **MySQL v5.7**
+- **PostgreSQL v9.6** (supported since Temporal v1.2.1)
+
+### Search
+
+Search is an optional feature and currently only ElasticSearch is supported.
+
+- **ElasticSearch v6.8**
+
+### Monitoring & Observability
+
+Temporal emits metrics by default in a format that is supported by Prometheus. Monitoring and observing those metrics is optional. Any software that can pull metrics that supports the same format could be used, but we only ensure it works with Prometheus and Grafana versions.
+
+- **Prometheus >= v2.0**
+- **Grafana >= v2.5**
+
+### Sreaming
+
+Event streaming software as a dependency is only required when ElasticSearch is being used or when Temporal is deployed across multiple data centers, however in future releases of Temporal, third party event streaming software will likely cease to be needed as dependency for both.
+
+- **Kafka v2.1.1 & Zookeeper v3.4.6**
 
 ## How to use a different Temporal release version
 
@@ -138,7 +154,7 @@ Refer to this [Makefile](https://github.com/temporalio/temporal/blob/v1.3.2/Make
 	--ep localhost -p 3036 -u root -pw root --pl mysql --db temporal_visibility update-schema -d ./schema/mysql/v57/visibility/versioned/
 ```
 
-### Cluster Management
+### Cluster management
 
 We recommend preparing a staging cluster and then do the following to verify the upgrade is successful:
 

--- a/docs/server-dependencies.md
+++ b/docs/server-dependencies.md
@@ -12,7 +12,7 @@ All versions of Temporal require that [Go v1.15+](https://golang.org/dl/) is ins
 
 ## Dependencies
 
-Temporal offers official support for and is tested against dependencies with these exact versions:
+Temporal offers official support for and is tested against dependencies with the exact versions described below.
 
 ### Go Packages
 

--- a/docs/server-versions-dependencies.md
+++ b/docs/server-versions-dependencies.md
@@ -1,12 +1,12 @@
 ---
-id: server-dependencies
-title: Temporal server dependencies
-sidebar_label: Dependencies
+id: server-versions-and-dependencies
+title: Versions and dependencies
+sidebar_label: Versions & dependencies
 ---
 
 ## Overview
 
-This page details some of the requirements and dependencies needed to build and run an instance of Temporal.
+This page details some of the version specific requirements and dependencies needed to build and run an instance of Temporal.
 
 All versions of Temporal require that [Go v1.15+](https://golang.org/dl/) is installed in the environment.
 

--- a/docs/server-versions-dependencies.md
+++ b/docs/server-versions-dependencies.md
@@ -27,7 +27,7 @@ Temporal offers official support for and is tested against dependencies with the
 | [1.1.0](https://github.com/temporalio/temporal/tree/v1.1.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.1.0/go.mod) |
 | [1.0.0](https://github.com/temporalio/temporal/tree/v1.0.0) | [go.mod](https://github.com/temporalio/temporal/blob/v1.0.0/go.mod) |
 
-### Databases
+### Persistence
 
 The only required dependency is a database, and there are multiple types of databases that are supported.
 
@@ -35,9 +35,9 @@ The only required dependency is a database, and there are multiple types of data
 - **MySQL v5.7**
 - **PostgreSQL v9.6** (supported since Temporal v1.2.1)
 
-### Search
+### Visibility via search
 
-Search is an optional feature and currently only ElasticSearch is supported.
+The Workflow search feature is optional. Currently only ElasticSearch is supported.
 
 - **ElasticSearch v6.8**
 
@@ -48,9 +48,9 @@ Temporal emits metrics by default in a format that is supported by Prometheus. M
 - **Prometheus >= v2.0**
 - **Grafana >= v2.5**
 
-### Sreaming
+### Multi-cluster replication
 
-Event streaming software as a dependency is only required when ElasticSearch is being used or when Temporal is deployed across multiple data centers, however in future releases of Temporal, third party event streaming software will likely cease to be needed as dependency for both.
+Event streaming software as a dependency is only required when ElasticSearch is being used or when Temporal is deployed across multiple data centers. However, in future releases of Temporal, third party event streaming software will likely cease to be needed as dependency for both.
 
 - **Kafka v2.1.1 & Zookeeper v3.4.6**
 

--- a/docs/server-versions-dependencies.md
+++ b/docs/server-versions-dependencies.md
@@ -12,7 +12,7 @@ All versions of Temporal require that [Go v1.15+](https://golang.org/dl/) is ins
 
 ## Dependencies
 
-Temporal offers official support for and is tested against dependencies with the exact versions described below.
+Temporal offers official support for, and is tested against, dependencies with the exact versions described below.
 
 ### Go Packages
 
@@ -35,13 +35,14 @@ The only required dependency is a database, and there are multiple types of data
 - **MySQL v5.7**
 - **PostgreSQL v9.6** (supported since Temporal v1.2.1)
 
-### Visibility via search
+### Workflow search
 
-The Workflow search feature is optional. Currently only ElasticSearch is supported.
+The feature that enables you to search for Workflows is optional. Currently only ElasticSearch is supported. The use of ElasticSearch also requires the use of event streaming software and currently only Kafka + Zookeeper is supported. See the note on event streaming dependency below.
 
 - **ElasticSearch v6.8**
+- **Kafka v2.1.1 & Zookeeper v3.4.6**
 
-### Monitoring & observability
+### Monitoring & observation
 
 Temporal emits metrics by default in a format that is supported by Prometheus. Monitoring and observing those metrics is optional. Any software that can pull metrics that supports the same format could be used, but we only ensure it works with Prometheus and Grafana versions.
 
@@ -50,9 +51,15 @@ Temporal emits metrics by default in a format that is supported by Prometheus. M
 
 ### Multi-cluster replication
 
-Event streaming software as a dependency is only required when ElasticSearch is being used or when Temporal is deployed across multiple data centers. However, in future releases of Temporal, third party event streaming software will likely cease to be needed as dependency for both.
+This is an experimental feature, most Temporal users do not need this. Requires the use of event streaming software. See the note on event streaming dependency below.
 
 - **Kafka v2.1.1 & Zookeeper v3.4.6**
+
+:::note Note on event streaming dependency
+
+Event streaming software as a dependency is only required when ElasticSearch is being used or when Temporal is deployed across multiple data centers. However, in future releases of Temporal, third party event streaming software will likely cease to be needed as dependency for both.
+
+:::
 
 ## Upgrade your version of Temporal
 

--- a/docs/server-versions-dependencies.md
+++ b/docs/server-versions-dependencies.md
@@ -41,7 +41,7 @@ Search is an optional feature and currently only ElasticSearch is supported.
 
 - **ElasticSearch v6.8**
 
-### Monitoring & Observability
+### Monitoring & observability
 
 Temporal emits metrics by default in a format that is supported by Prometheus. Monitoring and observing those metrics is optional. Any software that can pull metrics that supports the same format could be used, but we only ensure it works with Prometheus and Grafana versions.
 
@@ -54,7 +54,9 @@ Event streaming software as a dependency is only required when ElasticSearch is 
 
 - **Kafka v2.1.1 & Zookeeper v3.4.6**
 
-## How to use a different Temporal release version
+## Upgrade your version of Temporal
+
+If there is a newer version of Temporal available, a notification will appear in the Temporal Web UI.
 
 To use a more recent version of Temporal, first [check to see](https://github.com/temporalio/temporal/releases) if an upgrade to the database schema is required. Newer binaries can not run with older database schemas. Some releases require changes to the schema, and some do not. If you are using a version that is older than 1.0.0, reach out to us at [community.temporal.io](http://community.temporal.io) to ask how to upgrade.
 
@@ -154,7 +156,7 @@ Refer to this [Makefile](https://github.com/temporalio/temporal/blob/v1.3.2/Make
 	--ep localhost -p 3036 -u root -pw root --pl mysql --db temporal_visibility update-schema -d ./schema/mysql/v57/visibility/versioned/
 ```
 
-### Cluster management
+### Manage cluster
 
 We recommend preparing a staging cluster and then do the following to verify the upgrade is successful:
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -38,6 +38,7 @@ module.exports = {
       label: 'Server',
       items: [
         'install-temporal-server',
+        'server-dependencies',
         'configure-temporal-server',
         'filter-workflows',
         'archive-data',

--- a/sidebars.js
+++ b/sidebars.js
@@ -38,7 +38,7 @@ module.exports = {
       label: 'Server',
       items: [
         'install-temporal-server',
-        'server-dependencies',
+        'server-versions-and-dependencies',
         'configure-temporal-server',
         'filter-workflows',
         'archive-data',


### PR DESCRIPTION
This PR adds a new page (Dependencies) to the Server category.
It describes the basic requirements Temporal has and its relationship to other thirdparty software that might be used for optional features.
It has has some information about how to upgrade Temporal versions.

The page can be previewed here: https://deploy-preview-204--mystifying-fermi-1bc096.netlify.app/docs/server-versions-and-dependencies
