### PR TITLE
fix Temporal Cloud link

### DIFF
--- a/docs/cloud-introduction.md
+++ b/docs/cloud-introduction.md
@@ -1,7 +1,7 @@
 ---
 id: cloud-introduction
-title: Temporal cloud
+title: Temporal Cloud
 sidebar_label: Cloud
 ---
 
-A hosted version of Temporal is in private alpha. If you want to be first to know about Temporal Cloud's public beta, you can [sign up to the Temporal Cloud mailing list](https://temporal.us17.list-manage.coms/subscribe/post?u=2334a0f23e55fd1840613755d&amp;id=bbbbd4709f).
+A hosted version of Temporal is in private alpha. If you want to be first to know about Temporal Cloud's public beta, you can [sign up to the Temporal Cloud mailing list](http://eepurl.com/hhcaaX).


### PR DESCRIPTION
docusaurus doesnt like the semicolon in the link we gave