### PR TITLE
Adding footer link to TOS pdf

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -79,7 +79,7 @@ module.exports = {
             },
             {
               label: 'Terms of Service',
-              to: 'pdf/temporal-tos-2021-01-19.pdf'
+              to: 'https://docs.temporal.io/pdf/temporal-tos-2021-01-19.pdf'
             },
           ],
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -77,6 +77,10 @@ module.exports = {
               label: 'Privacy Policy',
               to: '/privacy-policy',
             },
+            {
+              label: 'Terms of Service',
+              to: 'pdf/temporal-tos-2021-01-19.pdf'
+            },
           ],
         },
         {


### PR DESCRIPTION
Link is now in the footer.
![Screen Shot 2021-01-20 at 12 35 46 PM](https://user-images.githubusercontent.com/34380806/105225582-079eed80-5b1c-11eb-8924-2f5f1469dd21.png)
