### PR TITLE
Changed SDK section to not be collapsed by default

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -57,7 +57,7 @@ module.exports = {
         'sdks-introduction',
         {
           type: 'category',
-          collapsed: true,
+          collapsed: false,
           label: 'Go',
           items: [
             'go-sdk-overview',

--- a/sidebars.js
+++ b/sidebars.js
@@ -51,13 +51,13 @@ module.exports = {
     'tctl',
     {
       type: 'category',
-      collapsed: true,
+      collapsed: false,
       label: 'SDKs',
       items: [
         'sdks-introduction',
         {
           type: 'category',
-          collapsed: false,
+          collapsed: true,
           label: 'Go',
           items: [
             'go-sdk-overview',


### PR DESCRIPTION
Default sidebar:
<img width="295" alt="Screen Shot 2021-01-21 at 12 32 31 PM" src="https://user-images.githubusercontent.com/34380806/105402504-beff3700-5be4-11eb-886d-c228d8d020c7.png">
