### PR TITLE
Rename clone destination of temporal server to temporal-server

### DIFF
--- a/docs/server-quick-install.md
+++ b/docs/server-quick-install.md
@@ -22,8 +22,8 @@ The following steps will run a local instance of the Temporal Server using the d
 3. Run the `docker-compose up` command.
 
 ```bash
-git clone https://github.com/temporalio/docker-compose.git
-cd  docker-compose
+git clone https://github.com/temporalio/docker-compose.git temporal-server
+cd temporal-server
 docker-compose up
 ```
 


### PR DESCRIPTION
docker-compose is very common name in this context. I suggest to change it to be specific