### PR TITLE
Update docker command option --dt to --wtt

### DIFF
--- a/docs/go-sdk-video-tutorial.md
+++ b/docs/go-sdk-video-tutorial.md
@@ -138,5 +138,5 @@ func main() {
 Commands:
 
 ```bash
-docker run --network=host --rm temporalio/tctl:latest wf start --tq tutorial_tq -w Greet_Temporal_1 --wt Greetings --et 3600 --dt 10
+docker run --network=host --rm temporalio/tctl:latest wf start --tq tutorial_tq -w Greet_Temporal_1 --wt Greetings --et 3600 --wtt 10
 ```


### PR DESCRIPTION
# Update docker command option --dt to --wtt

Latest `tctl wf start` command does not recognize flag `--dt`. It should be replaced with `--wtt`

<!--- Reminder to change the title 👆 -->

## Description, Motivation and Context

<!--- For External Contributors -->
> Thanks for opening a PR to our repos! If it is a significant code change, please make sure there is an
> opened issue where we have accepted the idea before filing this PR.

<!--- For All  Contributors -->

<!--- What was changed? Is this a bugfix or new feature? Include screenshots if relevant -->
What was changed: just the docker command provided in the documentation page of the Go SDK Video Tutorial.

<!--- Why is this change required? What problem does it solve? -->
Motivation & Context: when executing the docker command provided at the end of the [Go SDK Video Tutorial page](https://docs.temporal.io/docs/go-sdk-video-tutorial), it throws the  error `Incorrect Usage: flag provided but not defined: -dt`

<!--- If it fixes an open issue, please link to the issue here. -->
Closes issue: NA

## How has this been tested?
<!--- Please describe how you tested your changes/how we can test them -->

I run the new docker command and the server effectively executed the requested workflow. This is the new command:

```
docker run --network=host --rm temporalio/tctl:latest wf start --tq tutorial_tq -w Greet_Temporal_1 --wt Greetings --et 3600 --wtt 10
```

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
