### PR TITLE
Update java-helloworld.md with small changes

### DIFF
--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -54,7 +54,8 @@ To limit the logging output from the SDK, within src/main/resources/ create a lo
 
 If you are editing the files in IntelliJ, a "refresh" icon will appear on the screen. Click it to load the changes. Gradle will rebuild with the dependencies. Otherwise you can run `./gradlew build` from the root of the project again.
 
-All of the files for our application will be created in src/main/java/helloworldapp/. Gradle might have generated a default App.java class in that location - if it has done so, remove it before proceeding.
+All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of the terminal, you may have to create the directory `helloworldapp` by yourself. Also, Gradle might have generated a default App.java class in that location - if it has done so, remove it before proceeding.
+
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/apps.png) "Hello World!" app
 

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -144,7 +144,7 @@ Look for "BUILD SUCCESSFUL" in the output to confirm.
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/running.png) Run the app
 
-To run the app we need to start the Workflow and the Worker. You can start them in any order. Make sure you have the Temporal server running in a terminal and have the [Temporal Web UI](localhost:8088) open in your browser
+To run the app we need to start the Workflow and the Worker. You can start them in any order. Make sure you have the [Temporal server](https://docs.temporal.io/docs/server-introduction) running in a terminal and have the [Temporal Web UI](localhost:8088) open in your browser
 
 If you are using the terminal, add tasks to the build.gradle file so that you can run the main methods from there.
 

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -54,7 +54,7 @@ To limit the logging output from the SDK, within src/main/resources/ create a lo
 
 If you are editing the files in IntelliJ, a "refresh" icon will appear on the screen. Click it to load the changes. Gradle will rebuild with the dependencies. Otherwise you can run `./gradlew build` from the root of the project again.
 
-All of the files for our application will be created in src/main/java/helloworldapp/. Gradle will have generated a default App.java class in that location. Remove it before proceeding.
+All of the files for our application will be created in src/main/java/helloworldapp/. Gradle might have generated a default App.java class in that location - if it has done so, remove it before proceeding.
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/apps.png) "Hello World!" app
 

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -123,7 +123,7 @@ Create InitiateHelloWorld.java and use the SDK to define the start of the Workfl
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/check.png) Test the app
 
-Let's add a simple unit test to our application to make sure things are working as expected. Test code lives in src/test/java/helloworldapp. Gradle will have generated a default AppTest.java in that location. Remove that file and replace it with HelloWorldWorkflowTest.java that contains the following code:
+Let's add a simple unit test to our application to make sure things are working as expected. Test code lives in src/test/java/helloworldapp. If you don't see the `helloworldapp` directory, go ahead and create it yourself. Gradle might have generated a default AppTest.java in that location - if so, remove that file. Create a new class HelloWorldWorkflowTest.java that contains the following code:
 
 <!--SNIPSTART hello-world-project-template-java-workflow-test-->
 <!--SNIPEND-->

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -54,7 +54,7 @@ To limit the logging output from the SDK, within src/main/resources/ create a lo
 
 If you are editing the files in IntelliJ, a "refresh" icon will appear on the screen. Click it to load the changes. Gradle will rebuild with the dependencies. Otherwise you can run `./gradlew build` from the root of the project again.
 
-All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of scaffolding it from the terminal, you may have to create the directory `helloworldapp` by yourself. Also, Gradle might have generated a default App.java class in that location - if it has done so, remove it before proceeding.
+All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of scaffolding it from the terminal, you may have to create the directory `helloworldapp` by yourself. If you have scaffolded Gradle through terminal, Gradle will have generated a default App.java class in that location. Remove it before proceeding.
 
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/apps.png) "Hello World!" app

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -144,7 +144,7 @@ Look for "BUILD SUCCESSFUL" in the output to confirm.
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/running.png) Run the app
 
-To run the app we need to start the Workflow and the Worker. You can start them in any order. Make sure you have the [Temporal server](https://docs.temporal.io/docs/server-introduction) running in a terminal and have the [Temporal Web UI](localhost:8088) open in your browser
+To run the app we need to start the Workflow and the Worker. You can start them in any order. Make sure you have the [Temporal server](https://docs.temporal.io/docs/server-quick-install) running in a terminal and have the [Temporal Web UI](localhost:8088) open in your browser
 
 If you are using the terminal, add tasks to the build.gradle file so that you can run the main methods from there.
 

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -123,7 +123,7 @@ Create InitiateHelloWorld.java and use the SDK to define the start of the Workfl
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/check.png) Test the app
 
-Let's add a simple unit test to our application to make sure things are working as expected. Test code lives in src/test/java/helloworldapp. If you don't see the helloworldapp-directory, go ahead and create it yourself. Gradle might have generated a default AppTest.java in that location - if so, remove that file. Create a new class HelloWorldWorkflowTest.java that contains the following code:
+Let's add a simple unit test to our application to make sure things are working as expected. Test code lives in src/test/java/helloworldapp. If you don't see the helloworldapp-directory, go ahead and create it yourself. Gradle might have generated a default AppTest.java in that location. If AppTest.java is there, remove that file. Create a new class HelloWorldWorkflowTest.java that contains the following code:
 
 <!--SNIPSTART hello-world-project-template-java-workflow-test-->
 <!--SNIPEND-->

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -54,7 +54,7 @@ To limit the logging output from the SDK, within src/main/resources/ create a lo
 
 If you are editing the files in IntelliJ, a "refresh" icon will appear on the screen. Click it to load the changes. Gradle will rebuild with the dependencies. Otherwise you can run `./gradlew build` from the root of the project again.
 
-All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of scaffolding it from the terminal, you may have to create the directory `helloworldapp` by yourself. If you have scaffolded Gradle through terminal, Gradle will have generated a default App.java class in that location. Remove it before proceeding.
+All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of scaffolding it from the terminal, you may have to create the directory `helloworldapp` by yourself. If you have scaffolded Gradle through the terminal, Gradle will have generated a default App.java class in that location. Remove it before proceeding.
 
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/apps.png) "Hello World!" app

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -54,7 +54,7 @@ To limit the logging output from the SDK, within src/main/resources/ create a lo
 
 If you are editing the files in IntelliJ, a "refresh" icon will appear on the screen. Click it to load the changes. Gradle will rebuild with the dependencies. Otherwise you can run `./gradlew build` from the root of the project again.
 
-All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of the terminal, you may have to create the directory `helloworldapp` by yourself. Also, Gradle might have generated a default App.java class in that location - if it has done so, remove it before proceeding.
+All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of scaffolding it from the terminal, you may have to create the directory `helloworldapp` by yourself. Also, Gradle might have generated a default App.java class in that location - if it has done so, remove it before proceeding.
 
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/apps.png) "Hello World!" app

--- a/docs/java-helloworld.md
+++ b/docs/java-helloworld.md
@@ -54,7 +54,7 @@ To limit the logging output from the SDK, within src/main/resources/ create a lo
 
 If you are editing the files in IntelliJ, a "refresh" icon will appear on the screen. Click it to load the changes. Gradle will rebuild with the dependencies. Otherwise you can run `./gradlew build` from the root of the project again.
 
-All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of scaffolding it from the terminal, you may have to create the directory `helloworldapp` by yourself. If you have scaffolded Gradle through the terminal, Gradle will have generated a default App.java class in that location. Remove it before proceeding.
+All of the files for our application will be created in src/main/java/helloworldapp/. However, if you have selected Gradle through IntelliJ instead of scaffolding it from the terminal, you may have to create the directory helloworldapp by yourself. If you have scaffolded Gradle through the terminal, Gradle will have generated a default App.java class in that location. Remove it before proceeding.
 
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/apps.png) "Hello World!" app
@@ -123,7 +123,7 @@ Create InitiateHelloWorld.java and use the SDK to define the start of the Workfl
 
 ## ![](https://raw.githubusercontent.com/temporalio/documentation-images/main/static/check.png) Test the app
 
-Let's add a simple unit test to our application to make sure things are working as expected. Test code lives in src/test/java/helloworldapp. If you don't see the `helloworldapp` directory, go ahead and create it yourself. Gradle might have generated a default AppTest.java in that location - if so, remove that file. Create a new class HelloWorldWorkflowTest.java that contains the following code:
+Let's add a simple unit test to our application to make sure things are working as expected. Test code lives in src/test/java/helloworldapp. If you don't see the helloworldapp-directory, go ahead and create it yourself. Gradle might have generated a default AppTest.java in that location - if so, remove that file. Create a new class HelloWorldWorkflowTest.java that contains the following code:
 
 <!--SNIPSTART hello-world-project-template-java-workflow-test-->
 <!--SNIPEND-->


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
A few sentences.

## Why?
<!-- Tell your future self why have you made these changes -->
In the [tutorial](https://docs.temporal.io/docs/java-hello-world/#scaffold-gradle), the user is presented with descriptions of how to scaffold gradle either with terminal or IntelliJ.

If you select/add Gradle **through IntelliJ** when creating a new project and follow step 1 of ["Getting Started with Gradle Guide"](https://www.jetbrains.com/help/idea/getting-started-with-gradle.html#create_project) as is advised, neither the directories for `helloworldapp`, `App.java` nor `AppTest.java` is generated, like it is when you initialize gradle through terminal/command-line with `gradle init`. Therefore, I changed a few sentences a bit to clarify for people who initialize project/gradle with IntelliJ's interface, that they may not see those directories or files, and that it shouldn't halt them from proceeding with the tutorial.

Additionally, I added a link to the server-page in a place I found relevant, since you will need to visit that page to get the app up and running.

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
