### PR TITLE
attempt algolia search fix

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,7 +187,10 @@ module.exports = {
       indexName: 'temporal',
       // contextualSearch: true, // Optional, If you different version of docs etc (v1 and v2) doesn't display dup results
       // appId: 'app-id', // Optional, if you run the DocSearch crawler on your own
-      // algoliaOptions: {}, // Optional, if provided by Algolia
+      searchOptions: { // used to be called algoliaOptions
+        facetFilters: null,
+        facets: null
+      }
     },
   },
   presets: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -188,8 +188,8 @@ module.exports = {
       // contextualSearch: true, // Optional, If you different version of docs etc (v1 and v2) doesn't display dup results
       // appId: 'app-id', // Optional, if you run the DocSearch crawler on your own
       searchParameters: { // used to be called algoliaOptions https://docusaurus.io/docs/search#using-algolia-docsearch
-        facetFilters: null,
-        facets: null
+        facetFilters: [],
+        facets: []
       }
     },
   },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -187,7 +187,7 @@ module.exports = {
       indexName: 'temporal',
       // contextualSearch: true, // Optional, If you different version of docs etc (v1 and v2) doesn't display dup results
       // appId: 'app-id', // Optional, if you run the DocSearch crawler on your own
-      searchOptions: { // used to be called algoliaOptions
+      searchParameters: { // used to be called algoliaOptions https://docusaurus.io/docs/search#using-algolia-docsearch
         facetFilters: null,
         facets: null
       }

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -185,7 +185,7 @@ module.exports = {
     algolia: {
       apiKey: '14805ba2eb682edb2e719df4d5e03c8a',
       indexName: 'temporal',
-      // contextualSearch: true, // Optional, If you different version of docs etc (v1 and v2) doesn't display dup results
+      contextualSearch: true, // see if this matters
       // appId: 'app-id', // Optional, if you run the DocSearch crawler on your own
       searchParameters: { // used to be called algoliaOptions https://docusaurus.io/docs/search#using-algolia-docsearch
         facetFilters: [],


### PR DESCRIPTION
> This doesnt work yet! we THINK we have a cause, but we are not sure it is the ROOT cause. have filed a pair issue on the docusaurus repo https://github.com/facebook/docusaurus/issues/4644

## What was changed:

changed algolia search config

## Why?
our search page [always returns blank](https://docs.temporal.io/search?q=workflow) right now. we think its because as of this PR
https://github.com/temporalio/documentation/pull/327 (When we upgraded Docusaurus from alpha 66 to  alpha 72)

- Working: https://deploy-preview-326--mystifying-fermi-1bc096.netlify.app/search/?q=workflows
- Broken: https://deploy-preview-327--mystifying-fermi-1bc096.netlify.app/search/?q=workflows

the search has started to send in default facets `["language","docusaurus_tag"]` and facetFilters `[["language:en"],["docusaurus_tag:default","docusaurus_tag:docs-default-current"]]"}` where it didn't use to before (internal notes: https://www.notion.so/temporalio/debug-search-8213484654214fb784952d0e5d474501)

as far as I can tell this is undocumented and i'm not sure it is intentional behavior (cc @slorber in case this was supposed to be documented)

## How was this tested:

testing in deploy preview:

https://deploy-preview-357--mystifying-fermi-1bc096.netlify.app/search/?q=workflow