### PR TITLE
alternate landing page second row with less hero images

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -217,7 +217,6 @@ export default function Home() {
             <li><Link to={useBaseUrl("/blog/tags/case-study")}> Case Studies </Link> - Big names use Temporal for big things!</li>
             <li><Link to={useBaseUrl("/docs/cadence-to-temporal")}> Migrate from Cadence </Link> - There are key differences, but it's easy!</li>
           </ul>
->>>>>>> 9a2b6990 (alternate landing apge)
         </div>
       </div>
       <div className="container">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -200,11 +200,11 @@ export default function Home() {
             </Link>
           </div>
           <ul>
-            <li><Link to={useBaseUrl("/docs/concept-overview")}> Introduction </Link></li>
-            <li><Link to={useBaseUrl("/docs/concept-workflows")}> Workflows </Link></li>
-            <li><Link to={useBaseUrl("/docs/concept-activities")}> Activities </Link></li>
-            <li><Link to={useBaseUrl("/docs/concept-workers")}> Workers </Link></li>
-            <li>More: <Link to={useBaseUrl("/docs/concept-task-queues")}> Task Queues</Link>, <Link to={useBaseUrl("/docs/concept-signals")}> Signals</Link>, <Link to={useBaseUrl("/docs/concept-queries")}>Queries </Link></li>
+            <li><Link to={useBaseUrl("/docs/concepts/introduction")}> Introduction </Link></li>
+            <li><Link to={useBaseUrl("/docs/concepts/workflows")}> Workflows </Link></li>
+            <li><Link to={useBaseUrl("/docs/concepts/activities")}> Activities </Link></li>
+            <li><Link to={useBaseUrl("/docs/concepts/workers")}> Workers </Link></li>
+            <li>More: <Link to={useBaseUrl("/docs/concepts/task-queues")}> Task Queues</Link>, <Link to={useBaseUrl("/docs/concepts/signals")}> Signals</Link>, <Link to={useBaseUrl("/docs/concepts/queries")}>Queries </Link></li>
           </ul>
         </div>
         <div className="container">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -185,15 +185,11 @@ export default function Home() {
           </section>
         )}
       </main>
-      <div className={clsx('hero hero--secondary', styles.heroBanner)}>
+      <div className={clsx('hero hero--secondary boo', styles.heroSecondRow)}>
         <div className="container">
           <h2>Core concepts</h2>
-          <div className="text--center">
-            <a href={useBaseUrl("img/concept-map.svg")}>
-              <img className={styles.featureImage} src={useBaseUrl("img/concept-map.svg")} alt="concepts" />
-            </a>
-          </div>
           <p>Review some of Temporal's core concepts and building blocks.</p>
+<<<<<<< HEAD
           <div className={styles.buttons}>
             <Link
             className={clsx(
@@ -204,21 +200,28 @@ export default function Home() {
             Learn more
             </Link>
           </div>
+=======
+          <ul>
+            <li><Link to={useBaseUrl("/docs/concept-overview")}> Overview </Link></li>
+            <ul>
+              <li><Link to={useBaseUrl("/docs/concept-workflows")}> Workflows </Link></li>
+              <li><Link to={useBaseUrl("/docs/concept-activities")}> Activities </Link></li>
+              <li><Link to={useBaseUrl("/docs/concept-workers")}> Workers </Link></li>
+            </ul>
+            <li>More: <Link to={useBaseUrl("/docs/concept-task-queues")}> Task Queues</Link>, <Link to={useBaseUrl("/docs/concept-signals")}> Signals</Link>, <Link to={useBaseUrl("/docs/concept-queries")}>Queries </Link></li>
+          </ul>
+        </div>
+        <div className="container">
+          <h2>Additional Resources</h2>
+          <p>Everything else to help you learn Temporal and pitch it internally.</p>
+          <ul>
+            <li><Link to={useBaseUrl("/docs/external-resources")}> External Resources </Link> - Why Temporal, Tutorials, How It Works</li>
+            <li><Link to={useBaseUrl("/blog/tags/case-study")}> Case Studies </Link> - Big names use Temporal for big things!</li>
+            <li><Link to={useBaseUrl("/docs/cadence-to-temporal")}> Migrate from Cadence </Link> - There are key differences, but it's easy!</li>
+          </ul>
+>>>>>>> 9a2b6990 (alternate landing apge)
         </div>
       </div>
-      <main>
-        {levelTwoFeatures && levelTwoFeatures.length > 0 && (
-          <section className={styles.features}>
-            <div className="container">
-              <div className="row">
-                {levelTwoFeatures.map((props, idx) => (
-                  <LevelTwoFeature key={idx} {...props} />
-                ))}
-              </div>
-            </div>
-          </section>
-        )}
-      </main>
       <div className="container">
         <div className={styles.formFeature}>
           <h2 className="text-3xl font-bold mb-4">Temporal Cloud</h2>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -187,7 +187,7 @@ export default function Home() {
       </main>
       <div className={clsx('hero hero--secondary boo', styles.heroSecondRow)}>
         <div className="container">
-          <h2>Core concepts</h2>
+          <h2>🍎 Core concepts</h2>
           <p>Review some of Temporal's core concepts and building blocks.</p>
 <<<<<<< HEAD
           <div className={styles.buttons}>
@@ -212,7 +212,7 @@ export default function Home() {
           </ul>
         </div>
         <div className="container">
-          <h2>Additional Resources</h2>
+          <h2>🔥 Additional Resources</h2>
           <p>Everything else to help you learn Temporal and pitch it internally.</p>
           <ul>
             <li><Link to={useBaseUrl("/docs/external-resources")}> External Resources </Link> - Why Temporal, Tutorials, How It Works</li>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -202,12 +202,10 @@ export default function Home() {
           </div>
 =======
           <ul>
-            <li><Link to={useBaseUrl("/docs/concept-overview")}> Overview </Link></li>
-            <ul>
-              <li><Link to={useBaseUrl("/docs/concept-workflows")}> Workflows </Link></li>
-              <li><Link to={useBaseUrl("/docs/concept-activities")}> Activities </Link></li>
-              <li><Link to={useBaseUrl("/docs/concept-workers")}> Workers </Link></li>
-            </ul>
+            <li><Link to={useBaseUrl("/docs/concept-overview")}> Introduction </Link></li>
+            <li><Link to={useBaseUrl("/docs/concept-workflows")}> Workflows </Link></li>
+            <li><Link to={useBaseUrl("/docs/concept-activities")}> Activities </Link></li>
+            <li><Link to={useBaseUrl("/docs/concept-workers")}> Workers </Link></li>
             <li>More: <Link to={useBaseUrl("/docs/concept-task-queues")}> Task Queues</Link>, <Link to={useBaseUrl("/docs/concept-signals")}> Signals</Link>, <Link to={useBaseUrl("/docs/concept-queries")}>Queries </Link></li>
           </ul>
         </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -202,11 +202,11 @@ export default function Home() {
           </div>
 =======
           <ul>
-            <li><Link to={useBaseUrl("/docs/concept-overview")}> Introduction </Link></li>
-            <li><Link to={useBaseUrl("/docs/concept-workflows")}> Workflows </Link></li>
-            <li><Link to={useBaseUrl("/docs/concept-activities")}> Activities </Link></li>
-            <li><Link to={useBaseUrl("/docs/concept-workers")}> Workers </Link></li>
-            <li>More: <Link to={useBaseUrl("/docs/concept-task-queues")}> Task Queues</Link>, <Link to={useBaseUrl("/docs/concept-signals")}> Signals</Link>, <Link to={useBaseUrl("/docs/concept-queries")}>Queries </Link></li>
+            <li><Link to={useBaseUrl("/docs/concepts/introduction")}> Introduction </Link></li>
+            <li><Link to={useBaseUrl("/docs/concepts/workflows")}> Workflows </Link></li>
+            <li><Link to={useBaseUrl("/docs/concepts/activities")}> Activities </Link></li>
+            <li><Link to={useBaseUrl("/docs/concepts/workers")}> Workers </Link></li>
+            <li>More: <Link to={useBaseUrl("/docs/concepts/task-queues")}> Task Queues</Link>, <Link to={useBaseUrl("/docs/concepts/signals")}> Signals</Link>, <Link to={useBaseUrl("/docs/concepts/queries")}>Queries </Link></li>
           </ul>
         </div>
         <div className="container">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -200,12 +200,10 @@ export default function Home() {
             </Link>
           </div>
           <ul>
-            <li><Link to={useBaseUrl("/docs/concept-overview")}> Overview </Link></li>
-            <ul>
-              <li><Link to={useBaseUrl("/docs/concept-workflows")}> Workflows </Link></li>
-              <li><Link to={useBaseUrl("/docs/concept-activities")}> Activities </Link></li>
-              <li><Link to={useBaseUrl("/docs/concept-workers")}> Workers </Link></li>
-            </ul>
+            <li><Link to={useBaseUrl("/docs/concept-overview")}> Introduction </Link></li>
+            <li><Link to={useBaseUrl("/docs/concept-workflows")}> Workflows </Link></li>
+            <li><Link to={useBaseUrl("/docs/concept-activities")}> Activities </Link></li>
+            <li><Link to={useBaseUrl("/docs/concept-workers")}> Workers </Link></li>
             <li>More: <Link to={useBaseUrl("/docs/concept-task-queues")}> Task Queues</Link>, <Link to={useBaseUrl("/docs/concept-signals")}> Signals</Link>, <Link to={useBaseUrl("/docs/concept-queries")}>Queries </Link></li>
           </ul>
         </div>

--- a/src/pages/styles.module.css
+++ b/src/pages/styles.module.css
@@ -5,6 +5,10 @@
  * and scoped locally.
  */
 
+.heroSecondRow {
+  align-items: baseline;
+}
+
 .heroBanner {
   padding: 4rem 0;
   text-align: center;
@@ -52,13 +56,13 @@
 
 .unOrderedList {
   list-style-type: none;
-  margin:0px;
+  margin: 0px;
   padding: 0px;
 }
 
 .videoContainer {
   margin: 15px auto;
-  text-align:center;
+  text-align: center;
   max-width: 600px;
 }
 
@@ -77,7 +81,7 @@
 .sdkTakeMeToTutorialLogo {
   margin: 5px 15px;
   max-width: 80px;
-  padding:10px;
+  padding: 10px;
   vertical-align: bottom;
   transition: transform 1s;
 }
@@ -93,6 +97,6 @@
   border-width: 1px;
 }
 
-.cloudWaitlistSubmit:hover{
+.cloudWaitlistSubmit:hover {
   background-color: var(--ifm-color-primary);
 }


### PR DESCRIPTION

## What was changed:
second row now just uses bullet points

## Why?
too many heroes

before:

![image](https://user-images.githubusercontent.com/6764957/115797985-cb737580-a407-11eb-9449-677ca0a574fa.png)

after:

![image](https://user-images.githubusercontent.com/6764957/115798013-d75f3780-a407-11eb-8347-e99ef02a8ea2.png)
