### PR TITLE
add links to new spiralscout blog

### DIFF
--- a/docs/go/tracing.md
+++ b/docs/go/tracing.md
@@ -84,3 +84,7 @@ It also uses Jaeger for tracing.
 ### Can I configure multiple context propagators?
 
 Yes. Multiple context propagators help to structure code with each propagator having its own scope of responsibility.
+
+## Useful Resources
+
+- [Passing Context with Temporal](https://spiralscout.com/blog/passing-context-with-temporal) by SpiralScout


### PR DESCRIPTION
## What was changed

added direct link to https://spiralscout.com/blog/passing-context-with-temporal

## Why?

didnt belong in External Resources because that is a more generic place - its better when found in context?