### PR TITLE
add recommended production deploy resolution questions

### DIFF
--- a/docs/server/production-deploy.md
+++ b/docs/server/production-deploy.md
@@ -54,6 +54,17 @@ Use `workflow_success`, `workflow_failed`, `workflow_timeout`, `workflow_termina
 They are also include the `namespace` tag.
 Additional information is available in [this forum post](https://community.temporal.io/t/metrics-for-monitoring-server-performance/536/3).
 
+## Debugging Temporal
+
+### Debugging Temporal Server Configs
+
+Recommended techniques to be aware of for production Temporal Server setups:
+
+- Containers (tbc)
+- Storage (tbc)
+- Networking
+  - [Temporal cluster unable to establish ring membership, causing an infinite crash loop](https://community.temporal.io/t/crash-loop-of-history-service-in-k8s-cluster/2015): Use `tcurl` to audit it
+
 ### Debugging Workflows
 
 > ⚠️ This is a basic guide to troubleshooting/debugging Temporal applications. It is work-in-progress and we encourage [reading about our Architecture](https://docs.temporal.io/docs/server-architecture) for more detail. The better you understand how Temporal works, the better you will be at debugging your workflows.

--- a/docs/server/production-deploy.md
+++ b/docs/server/production-deploy.md
@@ -58,7 +58,7 @@ Additional information is available in [this forum post](https://community.tempo
 
 ### Debugging Temporal Server Configs
 
-Recommended techniques to be aware of for production Temporal Server setups:
+Recommended configuration debugging techniques for production Temporal Server setups:
 
 - Containers (tbc)
 - Storage (tbc)

--- a/docs/server/production-deploy.md
+++ b/docs/server/production-deploy.md
@@ -60,8 +60,8 @@ Additional information is available in [this forum post](https://community.tempo
 
 Recommended configuration debugging techniques for production Temporal Server setups:
 
-- Containers (tbc)
-- Storage (tbc)
+- Containers (to be completed)
+- Storage (to be completed)
 - Networking
   - [Temporal cluster unable to establish ring membership, causing an infinite crash loop](https://community.temporal.io/t/crash-loop-of-history-service-in-k8s-cluster/2015): Use `tcurl` to audit it
 


### PR DESCRIPTION
## What was changed

add recommended production deploy resolution questions

## Why?

it will take us FOREVER to figure out how to document this  - this is a cheap and easy way to raise the visibility and ensure we keep it around once we figure it out.