### PR TITLE
fix bad indent in go activities doc

### DIFF
--- a/docs/go/activities.md
+++ b/docs/go/activities.md
@@ -47,12 +47,11 @@ The Activity declares two return values: string and error. The string return val
 Activities are implemented as regular Go functions:
 
 - Parameters:
-    - Data can be passed directly to an Activity via function
-parameters. The parameters can be either basic types or structs (must be serializable).
-    - Though it is not required, we recommend that the first parameter of an Activity function is of type `context.Context`, in order to allow the Activity to interact with other framework methods.
+  - Data can be passed directly to an Activity via function parameters. The parameters can be either basic types or structs (must be serializable).
+  - Though it is not required, we recommend that the first parameter of an Activity function is of type `context.Context`, in order to allow the Activity to interact with other framework methods.
 - Return values:
-    - The function must return an `error` value. To mark an Activity as failed, return an error here, instead of `nil`.
-    - The result value is optional, and can be either a basic type or a struct (must be serializable).
+  - The function must return an `error` value. To mark an Activity as failed, return an error here, instead of `nil`.
+  - The result value is optional, and can be either a basic type or a struct (must be serializable).
 
 There's no hard limit on what you can pass into or return from an Activity function, but keep in mind that all parameters and return values are recorded in the execution history.
 A large execution history can adversely impact the performance of your Workflows as the entire history is transferred to your workers with every event processed.


### PR DESCRIPTION

## What was changed:
bad indents

![image](https://user-images.githubusercontent.com/6764957/116904393-362a7980-ac70-11eb-9798-90e87c7fce1b.png)
