### PR TITLE
add bad redirect pages

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -38,6 +38,10 @@
   to = "/docs/concepts/task-queues"
 
 [[redirects]]
+  from = "/docs/task-queues"
+  to = "/docs/concepts/task-queues"
+  
+[[redirects]]
   from = "/docs/concept-workers"
   to = "/docs/concepts/workers"
 
@@ -421,6 +425,10 @@
 
 [[redirects]]
   from = "/docs/server-namespaces"
+  to = "/docs/server/namespaces"
+  
+[[redirects]]
+  from = "/docs/namespaces"
   to = "/docs/server/namespaces"
 
 [[redirects]]


### PR DESCRIPTION
## What was changed:

google says that some of these pages are still being visited, i'm not sure from where but we can at least redirect the most recent two

![image](https://user-images.githubusercontent.com/6764957/116905777-04b2ad80-ac72-11eb-8cac-a6f9fa6448f3.png)
