### PR TITLE
Update node docs according to sdk-node pull 86

### DIFF
--- a/docs/node/determinism.md
+++ b/docs/node/determinism.md
@@ -15,11 +15,8 @@ When an Activity completes its result is stored in the Workflow history to be re
 
 ### Imports in Workflow code
 
-Workflow code can reliably import [ES modules](https://nodejs.org/api/esm.html#esm_modules_ecmascript_modules).
-In order for the Typescript compiler to output ES modules we set the [`module` compiler option](https://www.typescriptlang.org/tsconfig#module) to `es2020` in the initializer project (`npm init @temporalio`).
-
-- [CommonJS](https://nodejs.org/docs/latest/api/modules.html#modules_modules_commonjs_modules) modules are experimentally supported via babel transformation using [babel-plugin-transform-commonjs](https://www.npmjs.com/package/babel-plugin-transform-commonjs).
-- Built-in node modules are not supported and will throw an exception on import.
+Workflow code is bundled on Worker creation using [Webpack](https://webpack.js.org), you may import any JS package as long as it doesn't reference Node or DOM APIs.
+`@activities` prefixed imports are replaced by Webpack with stubs that schedule activities in the system.
 
 ### Sources of non-determinism
 

--- a/docs/node/getting-started.md
+++ b/docs/node/getting-started.md
@@ -4,7 +4,7 @@ Follow the instructions below for setting up a local development environment.
 
 ### Install system dependencies
 
-This project requires nodejs LTS version 12 (or later).
+This project requires nodejs LTS version 14 (or later).
 
 Furthermore, you will need to install [node-gyp](https://github.com/nodejs/node-gyp#installation).
 
@@ -20,7 +20,7 @@ We've provided prebuilt binaries for the Worker for:
 
 If you need to compile the Worker yourself, set up the Rust toolchain by following the instructions [here](https://rustup.rs/).
 
-> NOTE: Macs with an Apple chip require NodeJS 15 installed from source, the easiest way to install it is using [`nvm`](https://github.com/nvm-sh/nvm).
+> NOTE: Brew installation of NodeJS>=15 does not work with the SDK, install with [`nvm`](https://github.com/nvm-sh/nvm) instead.
 
 ### Create a new project
 

--- a/docs/node/hello-world.md
+++ b/docs/node/hello-world.md
@@ -41,7 +41,7 @@ Workflow interface declarations are optional, they're only required for generati
 
 #### Implementation
 
-A Workflow implmentation module may export a `workflow` object which can be type checked using a pre-defined inteface or `main` - and optionally `signals` and `queries` - directly.
+A Workflow implmentation module may export a `workflow` object which can be type checked using a pre-defined interface or `main` - and optionally `signals` and `queries` - directly.
 
 In a Workflow, Activities can be imported and called as regular functions. At runtime, the imported Activities are replaced with stubs which schedule Activities in the system.
 


### PR DESCRIPTION
## What was changed:
Updated the node docs re imports, minimum node version, and homebrew node installation.
See https://github.com/temporalio/sdk-node/pull/86.
