### PR TITLE
Remove nodejs message from Other SDKs section

### DIFF
--- a/src/pages/application-development.js
+++ b/src/pages/application-development.js
@@ -87,7 +87,6 @@ export default function ApplicationDevelopment() {
             <div className={clsx('col col-4', styles.textFeature)}>
               <h3>In the works, not yet endorsed</h3>
               <ul className={clsx(styles.unOrderedList)}>
-                <li>Reach out via the #nodejs-sdk Slack channel</li>
                 <li>
                   <img className={clsx(styles.listImage)} src={useBaseUrl('img/python.svg')} alt="Python" />
                   <a href="https://github.com/firdaus/temporal-python-sdk">Python SDK by firdaus</a>


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed:
<!-- Describe what has changed in this PR -->
Cleaned nodejs sdk message ⬇️ from `other SDKs`, as it was later added to the main SDKs
![image](https://user-images.githubusercontent.com/11838981/117734570-98233b80-b1a8-11eb-8c1f-b2abc3d051ae.png)

## Why?
<!-- Tell your future self why have you made these changes -->
Cleaning up the SDK page

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->
Navigated to the edited page

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
