### PR TITLE
better document cron options

### DIFF
--- a/docs/go/distributed-cron.md
+++ b/docs/go/distributed-cron.md
@@ -3,59 +3,23 @@ id: distributed-cron
 title: Distributed CRON
 ---
 
-It is relatively straightforward to turn any Temporal Workflow into a Cron Workflow. All you need
-is to supply a cron schedule when starting the Workflow using the CronSchedule
-parameter of
-[StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#StartWorkflowOptions).
+import DistributedCron from '../shared/distributed-cron.md'
 
-You can also start a Workflow using the Temporal CLI with an optional cron schedule using the `--cron` argument.
-
-For Workflows with CronSchedule:
-
-* Cron schedule is based on UTC time. For example cron schedule "15 8 \* \* \*"
-  will run daily at 8:15am UTC.
-* If a Workflow failed and a RetryPolicy is supplied to the StartWorkflowOptions
-  as well, the Workflow will retry based on the RetryPolicy. While the Workflow is
-  retrying, the server will not schedule the next cron run.
-* Temporal server only schedules the next cron run after the current run is
-  completed. If the next schedule is due while a Workflow is running (or retrying),
-  then it will skip that schedule.
-* Cron Workflows will not stop until they are terminated or cancelled.
-
-Temporal supports the standard cron spec:
+<DistributedCron docUrl="https://pkg.go.dev/go.temporal.io/sdk/internal#StartWorkflowOptions">
 
 ```go
-// CronSchedule - Optional cron schedule for Workflow. If a cron schedule is specified, the Workflow will run
-// as a cron based on the schedule. The scheduling will be based on UTC time. The schedule for next run only happen
-// after the current run is completed/failed/timeout. If a RetryPolicy is also supplied, and the Workflow failed
-// or timed out, the Workflow will be retried based on the retry policy. While the Workflow is retrying, it won't
-// schedule its next run. If next schedule is due while the Workflow is running (or retrying), then it will skip that
-// schedule. Cron Workflow will not stop until it is terminated or cancelled (by returning temporal.CanceledError).
-// The cron spec is as following:
-// ┌───────────── minute (0 - 59)
-// │ ┌───────────── hour (0 - 23)
-// │ │ ┌───────────── day of the month (1 - 31)
-// │ │ │ ┌───────────── month (1 - 12)
-// │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
-// │ │ │ │ │
-// │ │ │ │ │
-// * * * * *
-CronSchedule string
+	workflowOptions := client.StartWorkflowOptions{
+		ID:           workflowID,
+		TaskQueue:    "cron",
+		CronSchedule: "* * * * *",
+	}
+
+	we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, cron.SampleCronWorkflow)
 ```
 
-The [crontab guru site](https://crontab.guru/) is useful for testing your cron expressions.
+You can [check our Go Samples](https://github.com/temporalio/samples-go/tree/master/cron) for example code.
 
-## Convert existing cron Workflow
-
-Before CronSchedule was available, the previous approach to implementing cron
-Workflows was to use a delay timer as the last step and then return
-`ContinueAsNew`. One problem with that implementation is that if the Workflow
-fails or times out, the cron would stop.
-
-To convert those Workflows to make use of Temporal CronSchedule, all you need is to
-remove the delay timer and return without using
-`ContinueAsNew`. Then start the Workflow with the desired CronSchedule.
-
+</DistributedCron>
 
 ## Retrieve last successful result
 

--- a/docs/go/workflows.md
+++ b/docs/go/workflows.md
@@ -155,7 +155,8 @@ we.Get(ctx, &result)
 
 :::note
 
-In most uses cases it is better to be prepared to execute the Workflow asynchronously.
+In most use cases it is better to execute the Workflow asynchronously.
+You can also start your workflows on a regular schedule with [the CronSchedule option](distributed-cron).
 
 :::
 

--- a/docs/go/workflows.md
+++ b/docs/go/workflows.md
@@ -156,7 +156,7 @@ we.Get(ctx, &result)
 :::note
 
 In most use cases it is better to execute the Workflow asynchronously.
-You can also start your workflows on a regular schedule with [the CronSchedule option](distributed-cron).
+You can also start a Workflow Execution on a regular schedule with [the CronSchedule option](distributed-cron).
 
 :::
 

--- a/docs/java/distributed-cron.md
+++ b/docs/java/distributed-cron.md
@@ -3,12 +3,28 @@ id: distributed-cron
 title: Distributed CRON
 ---
 
-It is relatively straightforward to turn any Temporal Workflow into a Cron Workflow. All you need
-is to supply a cron schedule when starting the Workflow using the CronSchedule
+You can turn any Temporal Workflow into a Cron Workflow. Two choices:
+
+- start a Workflow using the Temporal CLI with an optional cron schedule using the `--cron` argument
+- (recommended) Supply a cron schedule when starting the Workflow using the CronSchedule
 parameter of
 [StartWorkflowOptions](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.html).
 
-You can also start a Workflow using the Temporal CLI with an optional cron schedule using the `--cron` argument.
+```java
+    WorkflowOptions workflowOptions =
+        WorkflowOptions.newBuilder()
+            .setWorkflowId(WORKFLOW_ID)
+            .setTaskQueue(TASK_QUEUE)
+            .setCronSchedule("* * * * *")
+            .setWorkflowExecutionTimeout(Duration.ofMinutes(3))
+            .setWorkflowRunTimeout(Duration.ofMinutes(1))
+            .build();
+
+    // Create the workflow client stub. It is used to start our workflow execution.
+    GreetingWorkflow workflow = client.newWorkflowStub(GreetingWorkflow.class, workflowOptions);
+```
+
+You can [check our Java Samples](https://github.com/temporalio/samples-java/blob/master/src/main/java/io/temporal/samples/hello/HelloCron.java) for example code.
 
 For Workflows with CronSchedule:
 

--- a/docs/java/distributed-cron.md
+++ b/docs/java/distributed-cron.md
@@ -3,12 +3,9 @@ id: distributed-cron
 title: Distributed CRON
 ---
 
-You can turn any Temporal Workflow into a Cron Workflow. Two choices:
+import DistributedCron from '../shared/distributed-cron.md'
 
-- start a Workflow using the Temporal CLI with an optional cron schedule using the `--cron` argument
-- (recommended) Supply a cron schedule when starting the Workflow using the CronSchedule
-parameter of
-[StartWorkflowOptions](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.html).
+<DistributedCron docUrl="https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.html">
 
 ```java
     WorkflowOptions workflowOptions =
@@ -26,51 +23,7 @@ parameter of
 
 You can [check our Java Samples](https://github.com/temporalio/samples-java/blob/master/src/main/java/io/temporal/samples/hello/HelloCron.java) for example code.
 
-For Workflows with CronSchedule:
-
-* CronSchedule is based on UTC time. For example cron schedule "15 8 \* \* \*"
-  will run daily at 8:15am UTC.
-* If a Workflow failed and a RetryPolicy is supplied to the StartWorkflowOptions
-  as well, the Workflow will retry based on the RetryPolicy. While the Workflow is
-  retrying, the server will not schedule the next cron run.
-* Temporal server only schedules the next cron run after the current run is
-  completed. If the next schedule is due while a Workflow is running (or retrying),
-  then it will skip that schedule.
-* Cron Workflows will not stop until they are terminated or cancelled.
-
-Temporal supports the standard cron spec:
-
-```go
-// CronSchedule - Optional cron schedule for Workflow. If a cron schedule is specified, the Workflow will run
-// as a cron based on the schedule. The scheduling will be based on UTC time. The schedule for the next run only happens
-// after the current run is completed/failed/timeout. If a RetryPolicy is also supplied, and the Workflow failed
-// or timed out, the Workflow will be retried based on the retry policy. While the Workflow is retrying, it won't
-// schedule its next run. If the next schedule is due while the Workflow is running (or retrying), then it will skip that
-// schedule. Cron Workflow will not stop until it is terminated or cancelled (by returning temporal.CanceledError).
-// The cron spec is as follows:
-// ┌───────────── minute (0 - 59)
-// │ ┌───────────── hour (0 - 23)
-// │ │ ┌───────────── day of the month (1 - 31)
-// │ │ │ ┌───────────── month (1 - 12)
-// │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
-// │ │ │ │ │
-// │ │ │ │ │
-// * * * * *
-CronSchedule string
-```
-
-The [crontab guru site](https://crontab.guru/) is useful for testing your cron expressions.
-
-## Convert an existing cron Workflow
-
-Before CronSchedule was available, the previous approach to implementing cron
-Workflows was to use a delay timer as the last step and then return
-`ContinueAsNew`. One problem with that implementation is that if the Workflow
-fails or times out, the cron would stop.
-
-To convert those Workflows to make use of Temporal CronSchedule, all you need is to remove the delay timer and return without using
-`ContinueAsNew`. Then start the Workflow with the desired CronSchedule.
-
+</DistributedCron>
 
 ## Retrieve last successful result
 

--- a/docs/java/workflows.md
+++ b/docs/java/workflows.md
@@ -330,7 +330,7 @@ If you need to wait for the completion of a Workflow after an asynchronous start
 If `WorkflowOptions.WorkflowIdReusePolicy` is not set to `AllowDuplicate`, then instead of throwing `DuplicateWorkflowException`,
 it reconnects to an existing Workflow and waits for its completion.
 
-The following example shows how to do this from a different process than the one that started the Workflow.
+The following example shows how to do this from a different process than the one that started the Workflow Execution.
 
 ```java
 YourWorkflow workflow = client.newWorkflowStub(YourWorkflow.class, workflowId);
@@ -358,7 +358,7 @@ A Synchronous start initiates a Workflow and then waits for its completion. The 
 
 ### Recurring start
 
-You can start your workflows on a regular schedule with [the CronSchedule option](distributed-cron).
+You can start a Workflow Execution on a regular schedule with [the CronSchedule option](distributed-cron).
 
 ## Large Event Histories
 

--- a/docs/java/workflows.md
+++ b/docs/java/workflows.md
@@ -327,7 +327,7 @@ This is the most common way to start Workflows in a live environment.
 
 If you need to wait for the completion of a Workflow after an asynchronous start, the most straightforward way is to call the blocking Workflow instance again.
 
-If `WorkflowOptions.WorkflowIdReusePolicy` is not set to `AllowDuplicate`, then instead of throwing `DuplicateWorkflowException`, 
+If `WorkflowOptions.WorkflowIdReusePolicy` is not set to `AllowDuplicate`, then instead of throwing `DuplicateWorkflowException`,
 it reconnects to an existing Workflow and waits for its completion.
 
 The following example shows how to do this from a different process than the one that started the Workflow.
@@ -355,6 +355,10 @@ A Synchronous start initiates a Workflow and then waits for its completion. The 
 
 <!--SNIPSTART hello-world-project-template-java-workflow-initiator-->
 <!--SNIPEND-->
+
+### Recurring start
+
+You can start your workflows on a regular schedule with [the CronSchedule option](distributed-cron).
 
 ## Large Event Histories
 

--- a/docs/php/distributed-cron.md
+++ b/docs/php/distributed-cron.md
@@ -3,59 +3,33 @@ id: distributed-cron
 title: Distributed CRON
 ---
 
-It is relatively straightforward to turn any Temporal Workflow into a Cron Workflow. All you need
-is to supply a cron schedule when starting the Workflow using the CronSchedule
-parameter of
-[WorkflowOptions](https://github.com/temporalio/sdk-php/blob/master/src/Client/WorkflowOptions.php).
+import DistributedCron from '../shared/distributed-cron.md'
 
-You can also start a Workflow using the Temporal CLI with an optional cron schedule using the `--cron` argument.
+<DistributedCron docUrl="https://github.com/temporalio/sdk-php/blob/master/src/Client/WorkflowOptions.php">
 
-For Workflows with CronSchedule:
+```php
+  $workflow = $this->workflowClient->newWorkflowStub(
+      CronWorkflowInterface::class,
+      WorkflowOptions::new()
+          ->withWorkflowId(CronWorkflowInterface::WORKFLOW_ID)
+          ->withCronSchedule('* * * * *')
+          // Execution timeout limits total time. Cron will stop executing after this timeout.
+          ->withWorkflowExecutionTimeout(CarbonInterval::minutes(10))
+          // Run timeout limits duration of a single workflow invocation.
+          ->withWorkflowRunTimeout(CarbonInterval::minute(1))
+  );
 
-* Cron schedule is based on UTC time. For example cron schedule "15 8 \* \* \*"
-  will run daily at 8:15am UTC.
-* If a Workflow failed and a RetryOptions is supplied to the WorkflowOptions
-  as well, the Workflow will retry based on the RetryOptions. While the Workflow is
-  retrying, the server will not schedule the next cron run.
-* Temporal server only schedules the next cron run after the current run is
-  completed. If the next schedule is due while a Workflow is running (or retrying),
-  then it will skip that schedule.
-* Cron Workflows will not stop until they are terminated or cancelled.
+  $output->writeln("Starting <comment>CronWorkflow</comment>... ");
 
-Temporal supports the standard cron spec:
-
-```go
-// CronSchedule - Optional cron schedule for Workflow. If a cron schedule is specified, the Workflow will run
-// as a cron based on the schedule. The scheduling will be based on UTC time. The schedule for next run only happen
-// after the current run is completed/failed/timeout. If a RetryOptions is also supplied, and the Workflow failed
-// or timed out, the Workflow will be retried based on the retry policy. While the Workflow is retrying, it won't
-// schedule its next run. If next schedule is due while the Workflow is running (or retrying), then it will skip that
-// schedule. Cron Workflow will not stop until it is terminated or cancelled (by returning temporal.CanceledError).
-// The cron spec is as following:
-// ┌───────────── minute (0 - 59)
-// │ ┌───────────── hour (0 - 23)
-// │ │ ┌───────────── day of the month (1 - 31)
-// │ │ │ ┌───────────── month (1 - 12)
-// │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
-// │ │ │ │ │
-// │ │ │ │ │
-// * * * * *
-CronSchedule string
+  try {
+      $run = $this->workflowClient->start($workflow, 'Antony');
+      // ...
+  }
 ```
 
-The [crontab guru site](https://crontab.guru/) is useful for testing your cron expressions.
+You can [check our PHP Samples](https://github.com/temporalio/samples-php/tree/master/app/src/Cron) for example code.
 
-## Convert existing cron Workflow
-
-Before CronSchedule was available, the previous approach to implementing cron
-Workflows was to use a delay timer as the last step and then return
-`ContinueAsNew`. One problem with that implementation is that if the Workflow
-fails or times out, the cron would stop.
-
-To convert those Workflows to make use of Temporal CronSchedule, all you need is to
-remove the delay timer and return without using
-`ContinueAsNew`. Then start the Workflow with the desired CronSchedule.
-
+</DistributedCron>
 
 ## Retrieve last successful result
 

--- a/docs/php/workflows.md
+++ b/docs/php/workflows.md
@@ -42,12 +42,12 @@ Workflows can also answer synchronous [Queries](/docs/php/queries) and receive [
 All interface methods must have one of the following annotations:
 
 - **#[WorkflowMethod]** indicates an entry point to a Workflow.
-It contains parameters such as timeouts and a task queue.
-Required parameters (such as `executionStartToCloseTimeoutSeconds`) that are not specified through the annotation must be provided at runtime.
+  It contains parameters such as timeouts and a task queue.
+  Required parameters (such as `executionStartToCloseTimeoutSeconds`) that are not specified through the annotation must be provided at runtime.
 - **#[SignalMethod]** indicates a method that reacts to external signals. It must have a `void` return type.
 - **#[QueryMethod]** indicates a method that reacts to synchronous query requests. It must have a non `void` return type.
 
-> It is possible (though not recommended for usability reasons) to annotate concrete class implementation.  
+> It is possible (though not recommended for usability reasons) to annotate concrete class implementation.
 
 You can have more than one method with the same annotation (except #[WorkflowMethod]).
 
@@ -223,6 +223,7 @@ Therefore, be mindful of the amount of data that you transfer via Activity invoc
 Otherwise, no additional limitations exist on Activity implementations.
 
 ## Awaits
+
 Use specialized construct `Workflow::await` and `Workflow::awaitWithTimeout` to wait for Closure function become positive.
 
 ```php
@@ -323,6 +324,10 @@ $run = $workflowClient->start($accountTransfer, 'fromID', 'toID', 'refID', 1000)
 var_dump($run->getExecution()->getID());
 ```
 
+### Recurring start
+
+You can start your workflows on a regular schedule with [the CronSchedule option](distributed-cron).
+
 ## Connect to Running Workflows
 
 If you need to wait for the completion of a Workflow after an asynchronous start, make a blocking call to
@@ -355,7 +360,7 @@ $child = Workflow::newChildWorkflowStub(
     ChildWorkflowOptions::new()
         // Do not specify WorkflowId if you want Temporal to generate a unique Id
         // for the child execution.
-        ->withWorkflowId('BID-SIMPLE-CHILD-WORKFLOW')        
+        ->withWorkflowId('BID-SIMPLE-CHILD-WORKFLOW')
         ->withExecutionStartToCloseTimeout(DateInterval::createFromDateString('30 minutes'))
 );
 
@@ -393,7 +398,7 @@ $childResult = yield Workflow::executeChildWorkflow(
     'ChildWorkflowName',
     ['args'],
     ChildWorkflowOptions::new()->withWorkflowId('BID-SIMPLE-CHILD-WORKFLOW'),
-    Type::TYPE_STRING // optional: defines the return type     
+    Type::TYPE_STRING // optional: defines the return type
 );
 ```
 

--- a/docs/php/workflows.md
+++ b/docs/php/workflows.md
@@ -42,7 +42,7 @@ Workflows can also answer synchronous [Queries](/docs/php/queries) and receive [
 All interface methods must have one of the following annotations:
 
 - **#[WorkflowMethod]** indicates an entry point to a Workflow.
-  It contains parameters such as timeouts and a task queue.
+  It contains parameters that specify timeouts and a Task Queue name.
   Required parameters (such as `executionStartToCloseTimeoutSeconds`) that are not specified through the annotation must be provided at runtime.
 - **#[SignalMethod]** indicates a method that reacts to external signals. It must have a `void` return type.
 - **#[QueryMethod]** indicates a method that reacts to synchronous query requests. It must have a non `void` return type.
@@ -326,7 +326,7 @@ var_dump($run->getExecution()->getID());
 
 ### Recurring start
 
-You can start your workflows on a regular schedule with [the CronSchedule option](distributed-cron).
+You can start a Workflow Execution on a regular schedule with [the CronSchedule option](distributed-cron).
 
 ## Connect to Running Workflows
 

--- a/docs/shared/distributed-cron.md
+++ b/docs/shared/distributed-cron.md
@@ -1,0 +1,42 @@
+You can turn any Temporal Workflow into a repeatedly initiated Workflow. Two choices:
+
+- start a Workflow using the Temporal CLI with an optional cron schedule using the `--cron` argument
+- (recommended) Supply a cron schedule when starting the Workflow using the CronSchedule
+  parameter of <a href={props.docUrl}>StartWorkflowOptions</a>.
+
+<div>{props.children}</div>
+
+For Workflows with CronSchedule:
+
+- CronSchedule is based on UTC time. For example cron schedule "15 8 \* \* \*"
+  will run daily at 8:15am UTC.
+- If a Workflow failed and a RetryPolicy is supplied to the StartWorkflowOptions
+  as well, the Workflow will retry based on the RetryPolicy. While the Workflow is
+  retrying, the server will not schedule the next cron run.
+- Temporal server only schedules the next cron run after the current run is
+  completed. If the next schedule is due while a Workflow is running (or retrying),
+  then it will skip that schedule.
+- Cron Workflows will not stop until they are terminated or cancelled.
+
+Temporal supports the standard cron spec:
+
+```go
+// CronSchedule - Optional cron schedule for Workflow. If a cron schedule is specified, the Workflow will run
+// as a cron based on the schedule. The scheduling will be based on UTC time. The schedule for the next run only happens
+// after the current run is completed/failed/timeout. If a RetryPolicy is also supplied, and the Workflow failed
+// or timed out, the Workflow will be retried based on the retry policy. While the Workflow is retrying, it won't
+// schedule its next run. If the next schedule is due while the Workflow is running (or retrying), then it will skip that
+// schedule. Cron Workflow will not stop until it is terminated or cancelled (by returning temporal.CanceledError).
+// The cron spec is as follows:
+// ┌───────────── minute (0 - 59)
+// │ ┌───────────── hour (0 - 23)
+// │ │ ┌───────────── day of the month (1 - 31)
+// │ │ │ ┌───────────── month (1 - 12)
+// │ │ │ │ ┌───────────── day of the week (0 - 6) (Sunday to Saturday)
+// │ │ │ │ │
+// │ │ │ │ │
+// * * * * *
+CronSchedule string
+```
+
+The [crontab guru site](https://crontab.guru/) is useful for testing your cron expressions.

--- a/docs/shared/distributed-cron.md
+++ b/docs/shared/distributed-cron.md
@@ -1,22 +1,20 @@
-You can turn any Temporal Workflow into a repeatedly initiated Workflow. Two choices:
+There are two ways that you can turn any Temporal Workflow into a repeatedly executed Workflow.
 
-- start a Workflow using the Temporal CLI with an optional cron schedule using the `--cron` argument
-- (recommended) Supply a cron schedule when starting the Workflow using the CronSchedule
+1. Start a Workflow Execution using the Temporal CLI with an optional cron schedule using the `--cron` argument.
+2. **Recommended**: Supply a cron schedule when starting the Workflow Execution using the CronSchedule.
   parameter of <a href={props.docUrl}>StartWorkflowOptions</a>.
 
 <div>{props.children}</div>
 
 For Workflows with CronSchedule:
 
-- CronSchedule is based on UTC time. For example cron schedule "15 8 \* \* \*"
-  will run daily at 8:15am UTC.
-- If a Workflow failed and a RetryPolicy is supplied to the StartWorkflowOptions
-  as well, the Workflow will retry based on the RetryPolicy. While the Workflow is
-  retrying, the server will not schedule the next cron run.
-- Temporal server only schedules the next cron run after the current run is
-  completed. If the next schedule is due while a Workflow is running (or retrying),
-  then it will skip that schedule.
-- Cron Workflows will not stop until they are terminated or cancelled.
+- CronSchedule is based on UTC time.
+For example, cron schedule "15 8 \* \* \*" will run daily at 8:15am UTC.
+- If a Workflow Execution failed and a RetryPolicy is supplied to the `StartWorkflowOptions`, the Workflow Execution will be retried based on the RetryPolicy.
+While the Workflow Execution is retrying, the Server will not schedule the next Workflow Execution.
+- The Temporal Server only schedules the next Workflow Execution after the current execution has completed.
+If the next execution is due to occur while the Workflow is currently executing (including retries), then the next execution will be skipped.
+- Cron initiated Workflow Executions will not stop until they are terminated or cancelled.
 
 Temporal supports the standard cron spec:
 


### PR DESCRIPTION
## What does this PR do?

![image](https://user-images.githubusercontent.com/6764957/118696647-18007400-b841-11eb-959b-c5b98833944d.png)


better document cron options. 

- https://deploy-preview-439--mystifying-fermi-1bc096.netlify.app/docs/go/distributed-cron
- https://deploy-preview-439--mystifying-fermi-1bc096.netlify.app/docs/java/distributed-cron
- https://deploy-preview-439--mystifying-fermi-1bc096.netlify.app/docs/php/distributed-cron

## Notes to reviewers

i am moving some of the cron content into shared content across the 3 languages, and making them more discoverable from each SDK's workflows page.

i dont think node sdk has cron yet so am leaving that for now