### PR TITLE
improve readability of single blog display

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,7 +31,6 @@ module.exports = {
         {
           activeBasePath: '/docs',
           label: 'Docs',
-          position: 'right',
           items: [
             {
               to: '/docs/concepts/introduction',
@@ -58,7 +57,6 @@ module.exports = {
         {
           activeBasePath: 'none',
           label: 'Case Studies',
-          position: 'right',
           items: [
             {
               to: '/blog/how-temporal-simplified-checkr-workflows',
@@ -80,9 +78,8 @@ module.exports = {
         },
         {
           to: '/blog',
-          activeBasePath: '/blog/',
+          activeBasePath: '/blog',
           label: 'Blog',
-          position: 'right',
         },
       ],
     },

--- a/src/theme/BlogPostPage/index.js
+++ b/src/theme/BlogPostPage/index.js
@@ -54,7 +54,7 @@ function BlogPostPage(props) {
           </div>
           <div className='row'>
             <div className='col'>
-              <BlogSidebar sidebar={sidebar} row />
+              <BlogSidebar sidebar={sidebar} row={true} />
             </div>
           </div>
         </div>

--- a/src/theme/BlogPostPage/index.js
+++ b/src/theme/BlogPostPage/index.js
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from 'react';
+import Layout from '@theme/Layout';
+import BlogPostItem from '@theme/BlogPostItem';
+import BlogPostPaginator from '@theme/BlogPostPaginator';
+import BlogSidebar from '@theme/BlogSidebar';
+import TOC from '@theme/TOC';
+import EditThisPage from '@theme/EditThisPage';
+import { ThemeClassNames } from '@docusaurus/theme-common';
+
+function BlogPostPage(props) {
+  const { content: BlogPostContents, sidebar } = props;
+  const { frontMatter, metadata } = BlogPostContents;
+  const { title, description, nextItem, prevItem, editUrl } = metadata;
+  const { hide_table_of_contents: hideTableOfContents } = frontMatter;
+  return (
+    <Layout
+      title={title}
+      description={description}
+      wrapperClassName={ThemeClassNames.wrapper.blogPages}
+      pageClassName={ThemeClassNames.page.blogPostPage}
+    >
+      {BlogPostContents && (
+        <div className='container margin-vert--lg'>
+          <div className='row'>
+            <div className='col col--1'></div>
+            <main className='col col--9'>
+              <BlogPostItem
+                frontMatter={frontMatter}
+                metadata={metadata}
+                isBlogPostPage
+              >
+                <BlogPostContents />
+              </BlogPostItem>
+              <div>{editUrl && <EditThisPage editUrl={editUrl} />}</div>
+              {(nextItem || prevItem) && (
+                <div className='margin-vert--xl'>
+                  <BlogPostPaginator nextItem={nextItem} prevItem={prevItem} />
+                </div>
+              )}
+            </main>
+            {!hideTableOfContents &&
+              BlogPostContents.toc &&
+              BlogPostContents.toc.length > 1 && (
+                <div className='col col--2'>
+                  <TOC toc={BlogPostContents.toc} />
+                </div>
+              )}
+          </div>
+          <div className='row'>
+            <div className='col'>
+              <BlogSidebar sidebar={sidebar} row />
+            </div>
+          </div>
+        </div>
+      )}
+    </Layout>
+  );
+}
+
+export default BlogPostPage;

--- a/src/theme/BlogSidebar/index.js
+++ b/src/theme/BlogSidebar/index.js
@@ -8,91 +8,106 @@ import React from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import styles from './styles.module.css';
-export default function BlogSidebar({ sidebar }) {
+export default function BlogSidebar({ sidebar, row }) {
   if (sidebar.items.length === 0) {
     return null;
   }
 
   return (
-    <div className={clsx(styles.sidebar, 'thin-scrollbar')}>
-      <h3 className={styles.sidebarItemTitle}>Featured</h3>
-      <ul className={styles.sidebarItemList}>
-        <li className={styles.sidebarItem}>
-          <LinkWrapped href='/blog/tags/case-study/'>
-            Case Studies: Box, Checkr, Coinbase, Descript
-          </LinkWrapped>
-        </li>
-        <li className={styles.sidebarItem}>
-          <LinkWrapped href='/blog/funding-announcement/'>
-            Series A Funding Announcement
-          </LinkWrapped>
-        </li>
-        <li className={styles.sidebarItem}>
-          <LinkWrapped href='/blog/sergey-why-i-joined-temporal/'>
-            Why I joined Temporal
-          </LinkWrapped>
-        </li>
-        <li className={styles.sidebarItem}>
-          <LinkWrapped href='/blog/workflow-engine-principles/'>
-            Designing A Workflow Engine
-          </LinkWrapped>
-        </li>
-      </ul>
-      <h3 className={styles.sidebarItemTitle}>{sidebar.title}</h3>
-      <ul className={styles.sidebarItemList}>
-        {sidebar.items.map((item) => {
-          return (
-            <li key={item.permalink} className={styles.sidebarItem}>
-              <Link
-                isNavLink
-                to={item.permalink}
-                className={styles.sidebarItemLink}
-                activeClassName={styles.sidebarItemLinkActive}
-              >
-                {item.title}
-              </Link>
-            </li>
-          );
-        })}
-      </ul>
-      <h3 className={styles.sidebarItemTitle}>Tags</h3>
-      <ul className={clsx(styles.sidebarItemList, styles.tagsList)}>
-        <li>
-          <LinkWrapped href='/blog/tags/community'>#community</LinkWrapped>
-        </li>
-        <li>
-          <LinkWrapped href='/blog/tags/errors'>#errors</LinkWrapped>
-        </li>
-        <li>
-          <LinkWrapped href='/blog/tags/bug'>#bug</LinkWrapped>
-        </li>
-        <li>
-          <LinkWrapped href='/blog/tags/announcement'>
-            #announcement
-          </LinkWrapped>
-        </li>
-        <li>
-          <LinkWrapped href='/blog/tags/architecture'>
-            #architecture
-          </LinkWrapped>
-        </li>
-        <li>
-          <LinkWrapped href='/blog/tags/code-first'>#code-first</LinkWrapped>
-        </li>
-        <li>
-          <LinkWrapped href='/blog/tags/cloud'>#cloud</LinkWrapped>
-        </li>
-        <li>
-          <LinkWrapped href='/blog/tags/stability'>#stability</LinkWrapped>
-        </li>
-        <li>
-          <LinkWrapped href='/blog/tags'>Browse all tags</LinkWrapped>
-        </li>
-      </ul>
-      <div>Content request? Guest post?</div>
-      <p>
-        Email: <a href='mailto:docs@temporal.io'>docs@temporal.io</a>
-      </p>
+    <div
+      className={clsx(
+        styles.sidebar,
+        'thin-scrollbar',
+        row && styles.sidebarRow
+      )}
+    >
+      <div className={row && 'col col--4'}>
+        <h3 className={styles.sidebarItemTitle}>Featured</h3>
+
+        <ul className={styles.sidebarItemList}>
+          <li className={styles.sidebarItem}>
+            <LinkWrapped href='/blog/tags/case-study/'>
+              Case Studies: Box, Checkr, Coinbase, Descript
+            </LinkWrapped>
+          </li>
+          <li className={styles.sidebarItem}>
+            <LinkWrapped href='/blog/funding-announcement/'>
+              Series A Funding Announcement
+            </LinkWrapped>
+          </li>
+          <li className={styles.sidebarItem}>
+            <LinkWrapped href='/blog/sergey-why-i-joined-temporal/'>
+              Why I joined Temporal
+            </LinkWrapped>
+          </li>
+          <li className={styles.sidebarItem}>
+            <LinkWrapped href='/blog/workflow-engine-principles/'>
+              Designing A Workflow Engine
+            </LinkWrapped>
+          </li>
+        </ul>
+      </div>
+      <div className={row && 'col col--4'}>
+        <a href='/blog'>
+          <h3 className={styles.sidebarItemTitle}>{sidebar.title}</h3>
+        </a>
+        <ul className={styles.sidebarItemList}>
+          {sidebar.items.map((item) => {
+            return (
+              <li key={item.permalink} className={styles.sidebarItem}>
+                <Link
+                  isNavLink
+                  to={item.permalink}
+                  className={styles.sidebarItemLink}
+                  activeClassName={styles.sidebarItemLinkActive}
+                >
+                  {item.title}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+      <div className={row && 'col col--4'}>
+        <h3 className={styles.sidebarItemTitle}>Tags</h3>
+        <ul className={clsx(styles.sidebarItemList, styles.tagsList)}>
+          <li>
+            <LinkWrapped href='/blog/tags/community'>#community</LinkWrapped>
+          </li>
+          <li>
+            <LinkWrapped href='/blog/tags/errors'>#errors</LinkWrapped>
+          </li>
+          <li>
+            <LinkWrapped href='/blog/tags/bug'>#bug</LinkWrapped>
+          </li>
+          <li>
+            <LinkWrapped href='/blog/tags/announcement'>
+              #announcement
+            </LinkWrapped>
+          </li>
+          <li>
+            <LinkWrapped href='/blog/tags/architecture'>
+              #architecture
+            </LinkWrapped>
+          </li>
+          <li>
+            <LinkWrapped href='/blog/tags/code-first'>#code-first</LinkWrapped>
+          </li>
+          <li>
+            <LinkWrapped href='/blog/tags/cloud'>#cloud</LinkWrapped>
+          </li>
+          <li>
+            <LinkWrapped href='/blog/tags/stability'>#stability</LinkWrapped>
+          </li>
+          <li>
+            <LinkWrapped href='/blog/tags'>Browse all tags</LinkWrapped>
+          </li>
+        </ul>
+        <div>Content request? Guest post?</div>
+        <p>
+          Email: <a href='mailto:docs@temporal.io'>docs@temporal.io</a>
+        </p>
+      </div>
     </div>
   );
 }

--- a/src/theme/BlogSidebar/styles.module.css
+++ b/src/theme/BlogSidebar/styles.module.css
@@ -54,8 +54,15 @@
   font-family: monospace;
 }
 
+.sidebarRow {
+  display: flex;
+}
+
 @media only screen and (max-width: 996px) {
   .sidebar {
     display: none;
+  }
+  .sidebarRow {
+    display: block;
   }
 }

--- a/src/theme/BlogSidebar/styles.module.css
+++ b/src/theme/BlogSidebar/styles.module.css
@@ -6,7 +6,6 @@
  */
 
 .sidebar {
-  display: inherit;
   max-height: calc(100vh - (var(--ifm-navbar-height) + 2rem));
   overflow-y: auto;
   position: sticky;


### PR DESCRIPTION
## What does this PR do?

left sidebar was too noisy and distracting. moved it down to footer

before

![image](https://user-images.githubusercontent.com/6764957/118723749-5bb6a600-b860-11eb-9829-980688301ab4.png)


after

![image](https://user-images.githubusercontent.com/6764957/118723905-8bfe4480-b860-11eb-878b-7c67d0356a44.png)



## Notes to reviewers

- i also handled the mobile view
- if there's only one subheading, we do not display table of contents now
- shift top nav to left for more intuitive discovery