### PR TITLE
add missing 'context' import

### DIFF
--- a/docs/go/testing.md
+++ b/docs/go/testing.md
@@ -13,6 +13,7 @@ The following code implements unit tests for the `SimpleWorkflow` sample:
 package sample
 
 import (
+        "context"
         "errors"
         "testing"
 


### PR DESCRIPTION
## What does this PR do?

This example uses [golang's `context.Context`](https://golang.org/pkg/context/) class, but doesn't `import "context"`, so it won't compile.

## Notes to reviewers
<!-- delete if n/a -->
