### PR TITLE
Add node about never using dryrun option

### DIFF
--- a/docs/server/versions-dependencies.md
+++ b/docs/server/versions-dependencies.md
@@ -89,6 +89,10 @@ To use a more recent version of Temporal, first [check to see](https://github.co
 
 We ensure that any consecutive versions are compatible in terms of database schema upgrades, features, and system behavior, however there is no guarantee that there is compatibility between *any* 2 non-consecutive versions. Please reach out to us or check the forums at [community.temporal.io](http://community.temporal.io) for more information.
 
+We strongly recommend *never* using the "dryrun" (`-y`, or `--dryrun`) options in any of your schema update commands.
+Using this option might lead to potential loss of data, as when using this will create a new database and drop your
+existing one.
+
 ### Upgrade Cassandra schema
 
 You can use the `temporal-cassandra-tool` to upgrade both the default and visibility schemas for your Cassandra DB:

--- a/docs/server/versions-dependencies.md
+++ b/docs/server/versions-dependencies.md
@@ -89,9 +89,9 @@ To use a more recent version of Temporal, first [check to see](https://github.co
 
 We ensure that any consecutive versions are compatible in terms of database schema upgrades, features, and system behavior, however there is no guarantee that there is compatibility between *any* 2 non-consecutive versions. Please reach out to us or check the forums at [community.temporal.io](http://community.temporal.io) for more information.
 
-We strongly recommend *never* using the "dryrun" (`-y`, or `--dryrun`) options in any of your schema update commands.
-Using this option might lead to potential loss of data, as when using this will create a new database and drop your
-existing one.
+If you are using a schema tools version prior to 1.8.0, we strongly recommend *never* using the "dryrun" (`-y`, or `--dryrun`) options in any of your schema update commands.
+Using this option might lead to potential loss of data, as when using it will create a new database and drop your
+existing one. This flag was removed in the 1.8.0 release.
 
 ### Upgrade Cassandra schema
 


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

## What does this PR do?
Using this option is dangerous. We have ran into issues with this and removed it, but this will take effect in next tools version. We need to warn users to not use this option to not lose data.

https://github.com/temporalio/temporal/pull/1300

## Notes to reviewers
<!-- delete if n/a -->
