### PR TITLE
design tweak: make edit this button floaty

### DIFF
--- a/docs/server/production-deploy.md
+++ b/docs/server/production-deploy.md
@@ -79,7 +79,7 @@ Here is a comprehensive list of all the hard (error) / soft (warn) server limits
 - **Event Batch Size**: The `DefaultTransactionSizeLimit` limit is [4MB](https://github.com/temporalio/temporal/pull/1363).
   This is the largest transaction size we allow for event histories to be persisted.
   - This is configurable with `TransactionSizeLimit`, if you know what you are doing.
-- **Blob size limit**: For incoming payloads (including Workflow context) - *[source](https://github.com/temporalio/temporal/blob/v1.7.0/service/frontend/service.go#L133-L134)*
+- **Blob size limit**: For incoming payloads (including Workflow context) - _[source](https://github.com/temporalio/temporal/blob/v1.7.0/service/frontend/service.go#L133-L134)_
   - we warn at 512KB: [`Blob size exceeds limit.`](https://github.com/temporalio/temporal/blob/fee1c43823699e90b330680a8efeb9d8dbee8cf3/common/util.go#L568)
   - we error at 2MB: `ErrBlobSizeExceedsLimit: Blob data size exceeds limit.`
   - This is configurable with [`BlobSizeLimitError` and `BlobSizeLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L378-L379), if you know what you are doing.

--- a/src/theme/EditThisPage/index.js
+++ b/src/theme/EditThisPage/index.js
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React from "react";
+import Translate from "@docusaurus/Translate";
+import IconEdit from "@theme/IconEdit";
+import styles from "./styles.module.css";
+export default function EditThisPage({editUrl}) {
+  return (
+    <a
+      className={styles.EditThisLink}
+      href={editUrl}
+      target="_blank"
+      rel="noreferrer noopener"
+    >
+      <IconEdit />
+      <Translate
+        id="theme.common.editThisPage"
+        description="The link label to edit the current page"
+      >
+        Edit this page
+      </Translate>
+    </a>
+  );
+}

--- a/src/theme/EditThisPage/styles.module.css
+++ b/src/theme/EditThisPage/styles.module.css
@@ -1,0 +1,13 @@
+@media screen and (min-width: 998px) {
+  .EditThisLink {
+    position: fixed;
+    top: 90vh;
+    right: 1rem;
+    padding: 1rem;
+    border: 2px dashed;
+    border-radius: 2rem;
+  }
+  .EditThisLink:hover {
+    color: var(--ifm-link-decoration);
+  }
+}

--- a/src/theme/EditThisPage/styles.module.css
+++ b/src/theme/EditThisPage/styles.module.css
@@ -1,13 +1,13 @@
 @media screen and (min-width: 998px) {
   .EditThisLink {
     position: fixed;
-    top: 90vh;
+    bottom: 1rem;
     right: 1rem;
     padding: 1rem;
-    border: 2px dashed;
-    border-radius: 2rem;
+    z-index: 99;
   }
   .EditThisLink:hover {
-    color: var(--ifm-link-decoration);
+    background-color: var(--ifm-color-content);
+    color: var(--ifm-color-content-inverse);
   }
 }


### PR DESCRIPTION
## What does this PR do?

on desktop, the edit button is more obvious now for people to contribute:
![image](https://user-images.githubusercontent.com/6764957/119765247-7c789e80-bee5-11eb-8731-03f47f9df436.png)

on smaller sizes, there is no change from what we have

## Notes to reviewers
this is just an idea i had in my head on encouraging tweaks and contributions