### PR TITLE
Adding components to create standard "related read" links

### DIFF
--- a/docs/concepts-new/mesh.md
+++ b/docs/concepts-new/mesh.md
@@ -6,6 +6,8 @@ sidebar_label: Introduction
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import LanguageLinkTabs from '../shared/LanguageLinkTabs.js'
+import RelatedRead from '../shared/RelatedRead.js'
 
 :::caution
 
@@ -100,39 +102,16 @@ The following is a full list of all properties that can be customized for a Work
 - [Search Attributes](#search-attributes)
 - [Parent Close Policy](#parent-close-policy)
 
-See how to implement Workflow Options using an SDK:
-
-<Tabs
-groupId='sdk-preference'
-defaultValue='go'
-values={[
-{label: 'Go', value: 'go'},
-{label: 'Java', value: 'java'},
-{label: 'Node.js', value: 'node'},
-{label: 'PHP', value: 'php'},
-]
-}>
-<TabItem value='go'>
-
-How to provide Workflow Options in Go
-
-</TabItem>
-<TabItem value='java'>
-
-How to provide Workflow Options in Java
-
-</TabItem>
-<TabItem value='node'>
-
-How to provide Workflow Options in Node.js
-
-</TabItem>
-<TabItem value='php'>
-
-How to provide Workflow Options in PHP
-
-</TabItem>
-</Tabs>
+<LanguageLinkTabs
+goText="How to provide Workflow Options in Go"
+goGoTo="#"
+javaText="How to provide Workflow Options in Java"
+javaGoTo="#"
+nodeText="How to provide Workflow Options in Node.js"
+nodeGoTo="#"
+phpText= "How to provide Workflow Options in PHP"
+phpGoTo="#"
+/>
 
 ## What are the timeout properties of a Workflow Execution?
 
@@ -258,40 +237,6 @@ Maximum Interval     = 100 × Initial Interval
 Maximum Attempts     = ∞
 Non-Retryable Errors = []
 ```
-
-See how to implement a Retry Policy using an SDK:
-
-<Tabs
-groupId='sdk-preference'
-defaultValue='go'
-values={[
-{label: 'Go', value: 'go'},
-{label: 'Java', value: 'java'},
-{label: 'Node.js', value: 'node'},
-{label: 'PHP', value: 'php'},
-]
-}>
-<TabItem value='go'>
-
-How to implement a Retry Policy in Go
-
-</TabItem>
-<TabItem value='java'>
-
-How to implement a Retry Policy in Java
-
-</TabItem>
-<TabItem value='node'>
-
-How to implement a Retry Policy in Node.js
-
-</TabItem>
-<TabItem value='php'>
-
-How to implement a Retry Policy in PHP
-
-</TabItem>
-</Tabs>
 
 ### Initial Interval
 

--- a/docs/shared/LanguageLinkTabs.js
+++ b/docs/shared/LanguageLinkTabs.js
@@ -1,7 +1,7 @@
 import React from "react";
-import Tabs from '@theme/Tabs';
-import TabItem from '@theme/TabItem';
-import RelatedRead from './RelatedRead'
+import Tabs from "@theme/Tabs";
+import TabItem from "@theme/TabItem";
+import RelatedRead from "./RelatedRead";
 
 export default function LangugageLinkTabs({
   goText,
@@ -15,54 +15,26 @@ export default function LangugageLinkTabs({
 }) {
   return (
     <Tabs
-      groupId='sdk-preference'
-      defaultValue='go'
+      groupId="sdk-preference"
+      defaultValue="go"
       values={[
-        {label: 'Go', value: 'go'},
-        {label: 'Java', value: 'java'},
-        {label: 'Node.js', value: 'node'},
-        {label: 'PHP', value: 'php'},
-      ]
-      }>
-      <TabItem value='go'>
-
-        <RelatedRead
-          text={goText}
-          goTo={goGoTo}
-          tagChar="g"
-        >
-        </RelatedRead>
-
+        {label: "Go", value: "go"},
+        {label: "Java", value: "java"},
+        {label: "Node.js", value: "node"},
+        {label: "PHP", value: "php"},
+      ]}
+    >
+      <TabItem value="go">
+        <RelatedRead text={goText} goTo={goGoTo} tagChar="g"></RelatedRead>
       </TabItem>
-      <TabItem value='java'>
-
-        <RelatedRead
-          text={javaText}
-          goTo={javaGoTo}
-          tagChar="g"
-        >
-        </RelatedRead>
-
+      <TabItem value="java">
+        <RelatedRead text={javaText} goTo={javaGoTo} tagChar="g"></RelatedRead>
       </TabItem>
-      <TabItem value='node'>
-
-        <RelatedRead
-          text={nodeText}
-          goTo={nodeGoTo}
-          tagChar="g"
-        >
-        </RelatedRead>
-
+      <TabItem value="node">
+        <RelatedRead text={nodeText} goTo={nodeGoTo} tagChar="g"></RelatedRead>
       </TabItem>
-      <TabItem value='php'>
-
-        <RelatedRead
-          text={phpText}
-          goTo={phpGoTo}
-          tagChar="g"
-        >
-        </RelatedRead>
-
+      <TabItem value="php">
+        <RelatedRead text={phpText} goTo={phpGoTo} tagChar="g"></RelatedRead>
       </TabItem>
     </Tabs>
   );

--- a/docs/shared/LanguageLinkTabs.js
+++ b/docs/shared/LanguageLinkTabs.js
@@ -1,0 +1,69 @@
+import React from "react";
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import RelatedRead from './RelatedRead'
+
+export default function LangugageLinkTabs({
+  goText,
+  goGoTo,
+  javaText,
+  javaGoTo,
+  nodeText,
+  nodeGoTo,
+  phpText,
+  phpGoTo,
+}) {
+  return (
+    <Tabs
+      groupId='sdk-preference'
+      defaultValue='go'
+      values={[
+        {label: 'Go', value: 'go'},
+        {label: 'Java', value: 'java'},
+        {label: 'Node.js', value: 'node'},
+        {label: 'PHP', value: 'php'},
+      ]
+      }>
+      <TabItem value='go'>
+
+        <RelatedRead
+          text={goText}
+          goTo={goGoTo}
+          tagChar="g"
+        >
+        </RelatedRead>
+
+      </TabItem>
+      <TabItem value='java'>
+
+        <RelatedRead
+          text={javaText}
+          goTo={javaGoTo}
+          tagChar="g"
+        >
+        </RelatedRead>
+
+      </TabItem>
+      <TabItem value='node'>
+
+        <RelatedRead
+          text={nodeText}
+          goTo={nodeGoTo}
+          tagChar="g"
+        >
+        </RelatedRead>
+
+      </TabItem>
+      <TabItem value='php'>
+
+        <RelatedRead
+          text={phpText}
+          goTo={phpGoTo}
+          tagChar="g"
+        >
+        </RelatedRead>
+
+      </TabItem>
+    </Tabs>
+  );
+}

--- a/docs/shared/RelatedRead.js
+++ b/docs/shared/RelatedRead.js
@@ -1,0 +1,50 @@
+import React from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+
+export default function RelatedRead({
+  text,
+  goTo,
+  tagChar,
+}) {
+  var tagClass;
+  var tag;
+  switch(tagChar) {
+    case "g":
+      tagClass="archetype-tag-guide";
+      tag="guide";
+      break;
+    case "t":
+      tagClass="archetype-tag-tutorial";
+      tag="tutorial";
+      break;
+    case "e":
+      tagClass="archetype-tag-tutorial";
+      tag="explanation";
+      break;
+    default:
+      tagClass="archetype-tag-reference";
+      tag="reference";
+  }
+  return (
+    <div
+      className={"related-read-div"}
+    >
+      <b>Related:</b>
+      <Link
+        className={"related-read-link"}
+        to={goTo}
+      >
+        {text}
+      </Link>
+      <span
+        className={clsx(
+          "archetype-tag",
+          tagClass
+        )}
+      >
+        {tag}
+      </span>
+    </div>
+  );
+}

--- a/docs/shared/RelatedRead.js
+++ b/docs/shared/RelatedRead.js
@@ -2,49 +2,33 @@ import React from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 
-export default function RelatedRead({
-  text,
-  goTo,
-  tagChar,
-}) {
+export default function RelatedRead({text, goTo, tagChar}) {
   var tagClass;
   var tag;
-  switch(tagChar) {
+  switch (tagChar) {
     case "g":
-      tagClass="archetype-tag-guide";
-      tag="guide";
+      tagClass = "archetype-tag-guide";
+      tag = "guide";
       break;
     case "t":
-      tagClass="archetype-tag-tutorial";
-      tag="tutorial";
+      tagClass = "archetype-tag-tutorial";
+      tag = "tutorial";
       break;
     case "e":
-      tagClass="archetype-tag-tutorial";
-      tag="explanation";
+      tagClass = "archetype-tag-tutorial";
+      tag = "explanation";
       break;
     default:
-      tagClass="archetype-tag-reference";
-      tag="reference";
+      tagClass = "archetype-tag-reference";
+      tag = "reference";
   }
   return (
-    <div
-      className={"related-read-div"}
-    >
+    <div className={"related-read-div"}>
       <b>Related:</b>
-      <Link
-        className={"related-read-link"}
-        to={goTo}
-      >
+      <Link className={"related-read-link"} to={goTo}>
         {text}
       </Link>
-      <span
-        className={clsx(
-          "archetype-tag",
-          tagClass
-        )}
-      >
-        {tag}
-      </span>
+      <span className={clsx("archetype-tag", tagClass)}>{tag}</span>
     </div>
   );
 }

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -194,3 +194,46 @@ h4,
 #mc-embedded-waitlist {
   margin-top: 15px;
 }
+
+.related-read-div {
+  background-color: var(--ifm-color-primary-lightest);
+  border-color: var(--ifm-color-primary-lightest);
+  border-radius: var(--ifm-alert-border-radius);
+  border-style: solid;
+  border-width: var(--ifm-alert-border-width);
+  padding: var(--ifm-alert-padding-vertical) var(--ifm-alert-padding-horizontal);
+  margin-bottom: 1em;
+}
+
+.related-read-link {
+  margin-left: 7px;
+  color: var(--ifm-color-primary-darkest);
+}
+
+.related-read-link:hover {
+  color: var(--ifm-color-primary-dark);
+}
+
+.archetype-tag {
+  padding:3px;
+  color: #ffffff;
+  font-size: 0.8em;
+  border-radius: 6px;
+  margin-left: 7px;
+}
+
+.archetype-tag-guide {
+  background-color: #CA1A7B;
+}
+
+.archetype-tag-tutorial {
+  background-color: #1AC9C7;
+}
+
+.archetype-tag-explanation {
+  background-color: #78C91A;
+}
+
+.archetype-tag-reference {
+  background-color: #CF8F19;
+}

--- a/src/theme/BlogPostItem/index.js
+++ b/src/theme/BlogPostItem/index.js
@@ -6,16 +6,16 @@
  */
 import React from "react";
 import clsx from "clsx";
-import { MDXProvider } from "@mdx-js/react";
-import Translate, { translate } from "@docusaurus/Translate";
+import {MDXProvider} from "@mdx-js/react";
+import Translate, {translate} from "@docusaurus/Translate";
 import Link from "@docusaurus/Link";
 import MDXComponents from "@theme/MDXComponents";
 import Seo from "@theme/Seo";
 import styles from "./styles.module.css";
-import { usePluralForm } from "@docusaurus/theme-common"; // Very simple pluralization: probably good enough for now
+import {usePluralForm} from "@docusaurus/theme-common"; // Very simple pluralization: probably good enough for now
 
 function useReadingTimePlural() {
-  const { selectMessage } = usePluralForm();
+  const {selectMessage} = usePluralForm();
   return (readingTimeFloat) => {
     const readingTime = Math.ceil(readingTimeFloat);
     return selectMessage(
@@ -44,8 +44,8 @@ function BlogPostItem(props) {
     truncated,
     isBlogPostPage = false,
   } = props;
-  const { date, formattedDate, permalink, tags, readingTime } = metadata;
-  const { author, title, image } = frontMatter;
+  const {date, formattedDate, permalink, tags, readingTime} = metadata;
+  const {author, title, image} = frontMatter;
   const authorURL = frontMatter.author_url || frontMatter.authorURL;
   // const authorTitle = frontMatter.author_title || frontMatter.authorTitle;
   const authorImageURL =
@@ -92,7 +92,7 @@ function BlogPostItem(props) {
         <div className={styles.metadata}>
           {(tags.length > 0 || truncated) && tags.length > 0 && (
             <span className={styles.tagList}>
-              {tags.map(({ label, permalink: tagPermalink }) => (
+              {tags.map(({label, permalink: tagPermalink}) => (
                 <Link
                   key={tagPermalink}
                   className="margin-horiz--sm"

--- a/src/theme/BlogSidebar/index.js
+++ b/src/theme/BlogSidebar/index.js
@@ -8,7 +8,7 @@ import React from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
 import styles from "./styles.module.css";
-export default function BlogSidebar({ sidebar, row }) {
+export default function BlogSidebar({sidebar, row}) {
   if (sidebar.items.length === 0) {
     return null;
   }
@@ -117,7 +117,7 @@ export default function BlogSidebar({ sidebar, row }) {
   );
 }
 
-function LinkWrapped({ href, children }) {
+function LinkWrapped({href, children}) {
   return (
     <Link
       isNavLink


### PR DESCRIPTION
This PR adds two mdx components that create "standardized" links for "related" articles / info for use throughout the docs.

### How to use:

Basic link:
```
<RelatedRead
text="Link text"
goTo="/docs/someplace/etc"
tagChar="e"
/>
```

<img width="826" alt="Screen Shot 2021-07-11 at 7 53 50 AM" src="https://user-images.githubusercontent.com/34380806/125198469-379f9180-e21f-11eb-97e7-a03ebe6c734d.png">

With tabs:

```
<LanguageLinkTabs
goText="How to provide Workflow Options in Go"
goGoTo="#"
javaText="How to provide Workflow Options in Java"
javaGoTo="#"
nodeText="How to provide Workflow Options in Node.js"
nodeGoTo="#"
phpText= "How to provide Workflow Options in PHP"
phpGoTo="#"
/>
```

<img width="817" alt="Screen Shot 2021-07-11 at 7 54 07 AM" src="https://user-images.githubusercontent.com/34380806/125198470-3a01eb80-e21f-11eb-8b69-c303208ba13d.png">
