### PR TITLE
update Signal docs for signalling with structs

### DIFF
--- a/docs/go/signals.md
+++ b/docs/go/signals.md
@@ -75,7 +75,7 @@ You can find more example Signals usage in our [Go Samples](https://github.com/t
 ## Signal with structs
 
 You can also send structs in Signals, as long as the struct is [serializable](https://pkg.go.dev/go.temporal.io/sdk/converter#CompositeDataConverter.ToPayload).
-`Receive()` decodes data into a generic map, to decode the value into a struct you should use a library like [mapstructure](https://github.com/mitchellh/mapstructure).
+`Receive()` decodes data into the struct within the Workflow.
 Note that Temporal only serializes public fields.
 
 ```go
@@ -90,15 +90,11 @@ signalChan := workflow.GetSignalChannel(ctx, signalName)
 
 s := workflow.NewSelector(ctx)
 s.AddReceive(signalChan, func(c workflow.ReceiveChannel, more bool) {
-    var rawSignalVal interface{}
-	c.Receive(ctx, &rawSignalVal)
-
-    // Using github.com/mitchellh/mapstructure
     var signalVal MyStruct
-	err := mapstructure.Decode(rawSignalVal, &signalVal)
+	c.Receive(ctx, &signalVal)
+
     if err != nil {
         workflow.GetLogger(ctx).Error("Received err!", err.Message)
-        return err
     }
 
     workflow.GetLogger(ctx).Info("Received message!", signalVal.Message)


### PR DESCRIPTION
## What does this PR do?
small update to the Signal docs. From my testing, an external library like `mapstructure` was not required to decode into a struct, so I updated the docs to reflect this (unless this changed after 1.9.2). 

The recommendation to use an external library was made in this [PR](https://github.com/temporalio/documentation/pull/469) but it seems to be unnecessary (per the linked [Temporal forum question](https://github.com/temporalio/documentation/commit/a8923441195860e8eece94154104d4c5dc812071)). This was confusing when I wanted to pass a `struct` in a Signal and thought I needed to add another external dependency.

* `Receive` decodes structs without the need for an external library
* The code example has a return inside the anonymous function, but the anonymous function can't return

## Notes to reviewers

<!-- delete if n/a -->
