### PR TITLE
New DetermineHeader component

### DIFF
--- a/docs/components/DetermineHeader.js
+++ b/docs/components/DetermineHeader.js
@@ -5,24 +5,16 @@ import Link from "@docusaurus/Link";
 export default function DetermineHeader({hLevel, hText}) {
   switch (hLevel) {
     case "##":
-      return (
-        <h2>{hText}</h2>
-      );
+      return <h2>{hText}</h2>;
       break;
     case "###":
-      return (
-        <h3>{hText}</h3>
-      )
+      return <h3>{hText}</h3>;
       break;
     case "####":
-      return (
-        <h4>{hText}</h4>
-      )
+      return <h4>{hText}</h4>;
       break;
     case "#####":
-      return (
-        <h4>{hText}</h4>
-      )
+      return <h4>{hText}</h4>;
       break;
     default:
       return null;

--- a/docs/components/DetermineHeader.js
+++ b/docs/components/DetermineHeader.js
@@ -1,0 +1,30 @@
+import React from "react";
+import clsx from "clsx";
+import Link from "@docusaurus/Link";
+
+export default function DetermineHeader({hLevel, hText}) {
+  switch (hLevel) {
+    case "##":
+      return (
+        <h2>{hText}</h2>
+      );
+      break;
+    case "###":
+      return (
+        <h3>{hText}</h3>
+      )
+      break;
+    case "####":
+      return (
+        <h4>{hText}</h4>
+      )
+      break;
+    case "#####":
+      return (
+        <h4>{hText}</h4>
+      )
+      break;
+    default:
+      return null;
+  }
+}

--- a/docs/content/what-is-temporal.md
+++ b/docs/content/what-is-temporal.md
@@ -5,6 +5,15 @@ tags:
   - explanation
 ---
 
+import DetermineHeader from '../components/DetermineHeader.js'
+
+export const headingText = 'What is Temporal?'
+
+<DetermineHeader
+hLevel={props.heading}
+hText={headingText}
+/>
+
 Temporal is a scalable and reliable runtime for Temporal Workflow Executions.
 
 **Temporal's tenth rule**

--- a/docs/server/elasticsearch-setup.md
+++ b/docs/server/elasticsearch-setup.md
@@ -45,6 +45,7 @@ persistence:
 ```
 
 ## Index schema setup
+
 If you run Temporal Server using our [Helm Charts](https://github.com/temporalio/helm-charts) or
 [docker-compose](https://github.com/temporalio/docker-compose) which uses [auto-setup](https://hub.docker.com/r/temporalio/auto-setup) docker image,
 then Elasticsearch index is automatically created. Docker auto-setup image also [creates](https://github.com/temporalio/temporal/blob/master/docker/auto-setup.sh#L263-L269) 6 custom search attributes for testing.

--- a/docs/server/workflow-search.md
+++ b/docs/server/workflow-search.md
@@ -93,9 +93,10 @@ Search attributes must be one of the following types:
 - Datetime
 
 Note:
+
 - **Double** is backed up by `scaled_float` Elasticsearch type with scale factor 10000 (4 decimal digits).
 - **Datetime** is backed up by `date` type with milliseconds precision in Elasticsearch 6 and `date_nanos` type with nanoseconds precision in Elasticsearch 7.
-- **Int** is 64-bits integer (`long` Elasticsearch type). 
+- **Int** is 64-bits integer (`long` Elasticsearch type).
 - **Keyword** and **String** types are concepts taken from Elasticsearch. Each word in a **String** is considered a searchable keyword.
   For a UUID, that can be problematic as Elasticsearch will index each portion of the UUID separately.
   To have the whole string considered as a searchable keyword, use the **Keyword** type.

--- a/docs/system-tools/tctl.md
+++ b/docs/system-tools/tctl.md
@@ -23,14 +23,19 @@ brew install tctl
 ### Run from docker-compose container
 
 If you are running Temporal Server locally by using [docker-compose](https://github.com/temporalio/docker-compose), you can run `tctl` from the `temporal-admin-tools` container.
+
 ```bash
 docker exec temporal-admin-tools tctl
 ```
+
 If you plan to run `tctl` command multiple times, you might want to create an alias:
+
 ```bash
 alias tctl="docker exec temporal-admin-tools tctl"
 ```
+
 ...and then invoke `tctl` command as though it is installed locally. For example, to describe the default namespace:
+
 ```bash
 tctl namespace describe
 ```
@@ -40,13 +45,17 @@ tctl namespace describe
 You can use `tctl` directly from the [admin-tools](https://hub.docker.com/r/temporalio/admin-tools) docker image:
 
 - On Linux:
+
 ```bash
 docker run --rm -it --entrypoint tctl --network host --env TEMPORAL_CLI_ADDRESS=localhost:7233 temporalio/admin-tools:1.11.1
 ```
+
 - On macOS/Windows:
+
 ```bash
 docker run --rm -it --entrypoint tctl --env TEMPORAL_CLI_ADDRESS=host.docker.internal:7233 temporalio/admin-tools:1.11.1
 ```
+
 Change the value of `TEMPORAL_CLI_ADDRESS` if your Temporal Server is running on remote host.
 
 Same `tctl` alias can be created to simplify experience.
@@ -58,7 +67,7 @@ Copy this executable to any directory from `PATH` environment variable. For exam
 
 :::note
 
-For brevity, the example commands that follow use `tctl` for brevity, which might be a binary or a pre-created alias as described earlier. 
+For brevity, the example commands that follow use `tctl` for brevity, which might be a binary or a pre-created alias as described earlier.
 
 :::
 
@@ -523,10 +532,12 @@ Here is some example output:
 ```
 
 There is also admin version of this command:
+
 ```bash
 tctl admin cluster get-search-attributes
 ```
-which will show you custom and system search attributes separately and also show underlying Elasticsearch index schema and system Workflow status.    
+
+which will show you custom and system search attributes separately and also show underlying Elasticsearch index schema and system Workflow status.
 
 ### Add new search attributes
 
@@ -545,7 +556,7 @@ The possible values for `--type` are:
 - Bool
 - Datetime
 
-:::note 
+:::note
 
 Due to Elasticsearch limitations you can only add new custom search attributes but not rename or remove existing ones.
 
@@ -558,7 +569,8 @@ Here is how you remove an existing search attribute:
 ```bash
 tctl admin cluster remove-search-attributes --name ProductId
 ```
-:::note 
+
+:::note
 
 Due to Elasticsearch limitations, this command removes search attributes only from cluster metadata (Workflows won't be able to use them).
 but not from the Elasticsearch index schema. You need to modify the Elasticsearch index manually; in most cases, this requires reindexing.


### PR DESCRIPTION
When importing a content component into a page, you can now customize the heading level of the component like so:

```
<WhatIsTemporal
heading="##"
/>
```

In the content component, you now export the title variable, and use the DetermineHeader component like so:

```
import DetermineHeader from '../components/DetermineHeader.js'

export const headingText = 'What is Temporal?'

<DetermineHeader
hLevel={props.heading}
hText={headingText}
/>
```
