### PR TITLE
Add max-width to email form input

### DIFF
--- a/src/theme/DocItem/index.js
+++ b/src/theme/DocItem/index.js
@@ -12,15 +12,15 @@ import LastUpdated from "@theme/LastUpdated";
 import TOC from "@theme/TOC";
 import TOCCollapsible from "@theme/TOCCollapsible";
 import EditThisPage from "@theme/EditThisPage";
-import {MainHeading} from "@theme/Heading";
+import { MainHeading } from "@theme/Heading";
 import clsx from "clsx";
 import styles from "./styles.module.css";
-import {useActivePlugin, useVersions} from "@theme/hooks/useDocs";
+import { useActivePlugin, useVersions } from "@theme/hooks/useDocs";
 import useWindowSize from "@theme/hooks/useWindowSize";
 
 function DocItem(props) {
-  const {content: DocContent, versionMetadata} = props;
-  const {metadata, frontMatter} = DocContent;
+  const { content: DocContent, versionMetadata } = props;
+  const { metadata, frontMatter } = DocContent;
   const {
     image,
     keywords,
@@ -35,7 +35,7 @@ function DocItem(props) {
     formattedLastUpdatedAt,
     lastUpdatedBy,
   } = metadata;
-  const {pluginId} = useActivePlugin({
+  const { pluginId } = useActivePlugin({
     failfast: true,
   });
   const versions = useVersions(pluginId); // If site is not versioned or only one version is included
@@ -154,7 +154,7 @@ function TemporalCloudForm() {
         className="validate"
       >
         <div id="mc_embed_signup_scroll" className="signup_controls">
-          <div className="email_wrap">
+          <div className={styles.email_wrap}>
             <label htmlFor="mce-EMAIL" className="sr-only">
               Email:
             </label>
@@ -167,7 +167,7 @@ function TemporalCloudForm() {
               required="required"
             />
           </div>
-          <span className="cta_text" style={{display: "none"}}>
+          <span className="cta_text" style={{ display: "none" }}>
             You are in the waitlist!
           </span>
           <input

--- a/src/theme/DocItem/styles.module.css
+++ b/src/theme/DocItem/styles.module.css
@@ -53,3 +53,7 @@
 .formFeature {
   --ifm-button-border-color: var(--ifm-color-content);
 }
+
+.email_wrap {
+  max-width: 262px;
+}

--- a/src/theme/DocItem/styles.module.css
+++ b/src/theme/DocItem/styles.module.css
@@ -33,11 +33,12 @@
 }
 
 .EditThisPage {
-  backdrop-filter: invert(0.2);
+  margin-top: 2rem;
 }
 
 @media screen and (min-width: 998px) {
   .EditThisPage {
+    backdrop-filter: invert(0.2);
     position: fixed;
     bottom: 1rem;
     right: 1rem;
@@ -55,5 +56,12 @@
 }
 
 .email_wrap {
-  max-width: 262px;
+  max-width: 30ch;
+}
+
+.email_wrap input:focus {
+  background-color: lightyellow;
+  color: black;
+  font-weight: bolder;
+  padding-left: 0.2rem;
 }


### PR DESCRIPTION
As is currently, my eyes skip over the input because it feels like a section divider. After the change, it looks like:

![image](https://user-images.githubusercontent.com/251288/126912319-1a557859-ec5e-4bc7-afc1-3cd7908bcf5a.png)
