### PR TITLE
Copyedits

### DIFF
--- a/blog/2021-07-08-temporal-transparency-update-11.md
+++ b/blog/2021-07-08-temporal-transparency-update-11.md
@@ -31,7 +31,7 @@ Hey community, things are going very well in the Temporal universe and we've see
 
 A few months ago, [we announced the official EOL date for Cadence support](https://docs.temporal.io/blog/cadence-eol-support). That date remains **September 29, 2021** which also marks the 1 year anniversary of Temporal V1 release. Cadence will always be an important part of the Temporal story, we just need to close that chapter out so we can continue fundamentally improving the way applications are built and run. 
 
-If you are still running on Cadence and depend on our team or the support they provide in anyway, we highly recommend migrating before the EOL date. 
+If you are still running on Cadence and depend on our team or the support they provide in any way, we highly recommend migrating before the EOL date.
 
 ## [Temporal.io](http://temporal.io) updates
 

--- a/docs/concepts/activities.md
+++ b/docs/concepts/activities.md
@@ -73,17 +73,17 @@ Here are some use cases for employing multiple Activity task queues in a single 
 
 ## Asynchronous Activity Completion
 
-By default an Activity is a function or a method depending on a client side library language. As soon as the function returns, an Activity completes. But in some cases an Activity implementation is asynchronous. For example it is forwarded to an external system through a message queue. And the reply comes through a different queue.
+By default, an Activity is a function or method (depending on the language) that completes as soon as the function or method returns. But in some cases an Activity implementation is asynchronous. For example, the action could be forwarded to an external system through a message queue, and the result could come through a different queue.
 
 To support such use cases, Temporal allows Activity implementations that do not complete upon Activity function completions. A separate API should be used in this case to complete the Activity. This API can be called from any process, even in a different programming language, that the original Activity worker used.
 
 ## Local Activities
 
-Some of the Activities are very short lived and do not need the queing semantic, flow control, rate limiting and routing capabilities. For these Temporal supports so called _local Activity_ feature. Local Activities are executed in the same worker process as the Workflow that invoked them. Consider using local Activities for functions that are:
+Some Activities are very short lived and do not need the queuing semantic, flow control, rate limiting and routing capabilities. For this case, Temporal supports a _local Activity_ feature. Local Activities are executed in the same worker process as the Workflow that invoked them. Consider using local Activities for functions that are:
 
 - no longer than a few seconds
 - do not require global rate limiting
 - do not require routing to specific workers or pools of workers
 - can be implemented in the same binary as the Workflow that invokes them
 
-The main benefit of local Activities is that they are much more efficient in utilizing Temporal service resources and have much lower latency overhead comparing to the usual Activity invocation.
+The main benefit of local Activities is that they are much more efficient in utilizing Temporal service resources and have much lower latency overhead compared to the usual Activity invocation.

--- a/docs/concepts/queries.md
+++ b/docs/concepts/queries.md
@@ -6,12 +6,12 @@ sidebar_label: Queries
 
 ## Synchronous Query
 
-Workflow code is stateful with the Temporal framework preserving it over various software and hardware failures. The state is constantly mutated during Workflow execution. To expose this internal state to the external world Temporal provides a synchronous query feature. From the Workflow implementer point of view the query is exposed as a synchronous callback that is invoked by external entities. Multiple such callbacks can be provided per Workflow type exposing different information to different external systems.
+Workflow code is stateful with the Temporal framework preserving it over various software and hardware failures. The state is constantly mutated during Workflow execution. To expose this internal state to the external world Temporal provides a synchronous query feature. From the Workflow implementer's point of view, they define a synchronous callback—the _query handler_—that is invoked by external entities. Multiple such callbacks can be provided per Workflow type, exposing different information to different external systems.
 
 To execute a query an external client calls a synchronous Temporal API providing _namespace, workflowId, query name_ and optional _query arguments_.
 
-Query callbacks must be read-only not mutating the Workflow state in any way. The other limitation is that the query callback cannot contain any blocking code. Both above limitations rule out ability to invoke Activities from the query handlers.
+Query handlers must be read-only: they cannot mutate the Workflow state in any way. The other limitation is that the handler may not contain blocking code. Both of these limitations rule out ability to invoke Activities from query handlers.
 
 ## Stack Trace Query
 
-The Temporal client libraries expose some predefined queries out of the box. Currently the only supported built-in query is _stack_trace_. This query returns stacks of all Workflow owned threads. This is a great way to troubleshoot any Workflow in production.
+The Temporal client libraries expose some predefined queries out of the box. Currently, the only supported built-in query is _stack_trace_, which returns stacks of all Workflow-owned threads. This is a great way to troubleshoot any Workflow in production.

--- a/docs/concepts/signals.md
+++ b/docs/concepts/signals.md
@@ -6,13 +6,13 @@ sidebar_label: Signals
 
 ## Event Handling
 
-Fault-oblivious stateful Workflows can be signaled about an external event. A signal is always point to point destined to a specific Workflow instance. Signals are always processed in the order in which they are received.
+Fault-oblivious stateful Workflows can be signaled about an external event. A signal is always point-to-point destined to a specific Workflow instance. Signals are always processed in the order in which they are received.
 
-There are multiple scenarios for which signals are useful.
+There are multiple scenarios in which signals are useful.
 
 ## Event Aggregation and Correlation
 
-Temporal is not a replacement for generic stream processing engines like Apache Flink or Apache Spark. But in certain scenarios it is a better fit. For example, when all events that should be aggregated and correlated are always applied to to some business entity with a clear Id. And then when a certain condition is met, actions should be executed.
+Temporal is not a replacement for generic stream processing engines like Apache Flink or Apache Spark. But in certain scenarios it is a better fit. For example, when all events that should be aggregated and correlated are always applied to some business entity with a clear Id. And then when a certain condition is met, actions should be executed.
 
 The main limitation is that a single Temporal Workflow has a pretty limited throughput, while the number of Workflows is practically unlimited. So if you need to aggregate events per customer, and your application has 100 million customers and each customer doesn't generate more than 20 events per second, then Temporal would work fine. But if you want to aggregate all events for US customers then the rate of these events would be beyond the single Workflow capacity.
 
@@ -22,7 +22,7 @@ Another use case is a customer loyalty program. Every time a customer makes a pu
 
 ## Human Tasks
 
-A lot of business processes involve human participants. The standard Temporal pattern for implementing an external interaction is to execute an Activity that creates a human task in an external system. It can be an email with a form, or a record in some external database, or a mobile app notification. When a user changes the status of the task, a signal is sent to the corresponding Workflow. For example, when the form is submitted, or a mobile app notification is acknowledged. Some tasks have multiple possible actions like claim, return, complete, reject. So multiple signals can be sent in relation to it.
+A lot of business processes involve human participants. The standard Temporal pattern for implementing an external interaction is to execute an Activity that creates a human task in an external system. It can be an email with a form, or a record in some external database, or a mobile app notification. When a user changes the status of the task, a signal is sent to the corresponding Workflow. For example, when the form is submitted, or a mobile app notification is acknowledged. Some tasks have multiple possible actions—like claim, return, complete, and reject—so multiple signals can be sent in relation to them.
 
 ## Process Execution Alteration
 
@@ -32,4 +32,4 @@ Another example is a service deployment Workflow. While rolling out new software
 
 ## Synchronization
 
-Temporal Workflows are strongly consistent so they can be used as a synchronization point for executing actions. For example, there is a requirement that all messages for a single user are processed sequentially but the underlying messaging infrastructure can deliver them in parallel. The Temporal solution would be to have a Workflow per user and signal it when an event is received. Then the Workflow would buffer all signals in an internal data structure and then call an Activity for every signal received. See the following [Stack Overflow answer](https://stackoverflow.com/a/56615120/1664318) for an example.
+Temporal Workflows are strongly consistent so they can be used as a synchronization point for executing actions. For example, suppose there is a requirement that all messages for a single user are processed sequentially but the underlying messaging infrastructure can deliver them in parallel. The Temporal solution would be to have a Workflow per user and signal it when an event is received. Then the Workflow would buffer all signals in an internal data structure and then call an Activity for every signal received. See [this Stack Overflow answer](https://stackoverflow.com/a/56615120/1664318) for an example.

--- a/docs/concepts/task-queues.md
+++ b/docs/concepts/task-queues.md
@@ -15,7 +15,7 @@ workflowLink="/docs/concepts/workflows"
 workerLink="/docs/concepts/workers"
 />
 
-From the perspective of a developer, using the SDK, Task Queues are one of the means by which you associate a Worker with a Workflow and/or Activity.
+From the perspective of a developer using the SDK, Task Queues are one of the means by which you associate a Worker with a Workflow and/or Activity.
 In this case, you can learn about how to implement Task Queues within the context of the language you are writing your application in:
 
 - [Go](/docs/go/task-queues)

--- a/docs/shared/task-queues-basic.md
+++ b/docs/shared/task-queues-basic.md
@@ -1,7 +1,7 @@
 From a high level, we can say that a Task Queue is exactly what the name suggests.
-It is a "first-in-first-out" queue for Tasks, where a Task is the context needed to execute a chunk of code that alters the "state" of a <a href={props.workflowLink}>Workflow</a>.
+It is a "first-in, first-out" queue for Tasks, where a Task is the context needed to execute a chunk of code that alters the "state" of a <a href={props.workflowLink}>Workflow</a>.
 
 Task Queues are maintained by the [Temporal Server](/docs/server/introduction).
 The Server places Tasks into a Task Queue to schedule, start, cancel, and complete parts of a Workflow and/or Activity, for example.
-A <a href={props.workerLink}>Worker</a> engages in a long poll with a Task Queue, hungrily waiting for a Task to become available.
-The Worker then executes what ever the Task tells the Worker to do.
+A <a href={props.workerLink}>Worker</a> long polls the Task Queue, hungrily waiting for a Task to become available.
+The Worker then executes whatever the Task tells the Worker to do.


### PR DESCRIPTION
In queries.md, there was a mix of "query callback" and "query handler". I standardized on latter because it seemed more functionally descriptive.