### PR TITLE
add activity cancel docs

### DIFF
--- a/docs/concepts/activities.md
+++ b/docs/concepts/activities.md
@@ -50,11 +50,21 @@ Long running Activities can be used as a special case of leader election. Tempor
 
 One common use case for such leader election is monitoring. An Activity executes an internal loop that periodically polls some API and checks for some condition. It also heartbeats on every iteration. If the condition is satisfied, the Activity completes which lets its Workflow to handle it. If the Activity worker dies, the Activity times out after the heartbeat interval is exceeded and is retried on a different worker. The same pattern works for polling for new files in Amazon S3 buckets or responses in REST or other synchronous APIs.
 
-## Cancellation
+## Activity Cancellation
 
-A Workflow can request an Activity cancellation. Currently the only way for an Activity to learn that it was cancelled is through heart beating. The heartbeat request fails with a special error indicating that the Activity was cancelled. Then it is up to the Activity implementation to perform all the necessary cleanup and report that it is done with it. It is up to the Workflow implementation to decide if it wants to wait for the Activity cancellation confirmation or just proceed without waiting.
+import WhatIsActivityCancellation from '../content/what-is-activity-cancellation.md'
 
-Another common case for Activity heartbeat failure is that the Workflow that invoked it is in a completed state. In this case an Activity is expected to perform cleanup as well.
+<WhatIsActivityCancellation />
+
+:::note Cancellations are not immediate
+
+`ctx.Done()` is only signaled when a heartbeat is sent to the service.
+Temporal's SDK throttles this so a heartbeat may not be sent to the service until 80% of the heartbeat timeout has elapsed.
+
+For example, if your heartbeat timeout is 20 seconds, `ctx.Done()` will not be signaled until 80% of 20 seconds (~16 seconds) has elapsed.
+To increase or decrease the delay of cancelation, modify the heartbeat timeout defined for the activity context.
+
+:::
 
 ## Activity Task Routing through Task Queues
 

--- a/docs/content/what-is-activity-cancellation.md
+++ b/docs/content/what-is-activity-cancellation.md
@@ -1,0 +1,18 @@
+---
+id: what-is-activity-cancellation
+title: What is Activity Cancellation?
+description: Workflows can request to cancel an Activity, and the Activity should then perform cleanup.
+tags:
+  - explanation
+---
+
+A Workflow can request to cancel an Activity.
+When an Activity is cancelled, or its Workflow execution has completed or failed, the context passed into its function is cancelled, which also sets its channel’s closed state to `Done`.
+An Activity can use that to perform any necessary cleanup and abort its execution.
+
+Cancellation is only delivered to Activities that record heartbeats:
+
+- The heartbeat request fails with a special error indicating that the Activity was cancelled.
+  Heartbeats can also fail when the Workflow that invoked it is in a completed state.
+- The Activity should perform all necessary cleanup and report when it is done.
+- The Workflow can decide if it wants to wait for the Activity cancellation confirmation or proceed without waiting.

--- a/docs/go/activities.md
+++ b/docs/go/activities.md
@@ -126,10 +126,9 @@ The parameters of the `RecordActivityHeartbeat` function are:
 
 #### Cancellation
 
-When an Activity is cancelled, or its Workflow execution has completed or failed, the context passed
-into its function is cancelled, which sets its channel’s closed state to `Done`. An Activity can use that
-to perform any necessary cleanup and abort its execution. Cancellation is only delivered to Activities
-that call `RecordActivityHeartbeat`.
+import WhatIsActivityCancellation from '../content/what-is-activity-cancellation.md'
+
+<WhatIsActivityCancellation />
 
 ### Registration
 

--- a/docs/go/workflows.md
+++ b/docs/go/workflows.md
@@ -313,13 +313,14 @@ func ParentWorkflow(ctx workflow.Context) error {
 
 ## How to cancel a Workflow Execution
 
-There are many scenarios where it is necessary and even ideal to be able to cancel a Workflow Execution.
 Use the `CancelWorkflow` API to cancel a Workflow Execution using its Id.
 
 <!--SNIPSTART samples-go-cancellation-cancel-workflow-execution-trigger-->
 <!--SNIPEND-->
 
-Workflow Definitions can be written to handle execution cancellation requests.
+### How to clean up after a Workflow is cancelled
+
+Workflow Definitions can be written to handle execution cancellation requests with Go's `defer` and the `workflow.NewDisconnectedContext` API.
 In the Workflow Definition below, there is a special Activity that handles clean up should the execution be cancelled.
 
 <!--SNIPSTART samples-go-cancellation-workflow-definition-->

--- a/docs/java/activities.md
+++ b/docs/java/activities.md
@@ -360,6 +360,12 @@ public class FileProcessingActivitiesImpl implements FileProcessingActivities {
 }
 ```
 
+### Activity Cancellation
+
+import WhatIsActivityCancellation from '../content/what-is-activity-cancellation.md'
+
+<WhatIsActivityCancellation />
+
 ## Throwing Activity errors
 
 If there is a need to throw checked Exception from Activity methods which do not support re-throwing checked Exceptions in their signatures,

--- a/docs/node/activities.md
+++ b/docs/node/activities.md
@@ -70,3 +70,14 @@ Currently, you need to use the `@activities` prefix.
 Do **not** import your Activity by using the `'../activities/greeter'` path; otherwise your Activity executes in the same V8 isolate as your Workflow, and your Activity is subject to the same restrictions as your Workflow.
 
 :::
+
+## Heartbeating
+
+Long running activities should heartbeat their progress back to the Workflow.
+This has not yet been implemented in the Node SDK.
+
+### Activity Cancellation
+
+import WhatIsActivityCancellation from '../content/what-is-activity-cancellation.md'
+
+<WhatIsActivityCancellation />

--- a/docs/php/activities.md
+++ b/docs/php/activities.md
@@ -195,6 +195,12 @@ class FileProcessingActivitiesImpl implements FileProcessingActivities
 }
 ```
 
+### Activity Cancellation
+
+import WhatIsActivityCancellation from '../content/what-is-activity-cancellation.md'
+
+<WhatIsActivityCancellation />
+
 ## Calling Activities
 
 `Workflow::newActivityStub` returns a client-side stub an implements an Activity interface.


### PR DESCRIPTION
## What does this PR do?

taking the opportunity to better document how activity cancellation works, per user request and confusion https://community.temporal.io/t/problems-cancelling-a-running-activity-from-parent-workflow/2169

## notes to reviewers

the writing we had before was hard to understand. I rewrote to emphasize clarity and connection of this to heartbeating.

see: 
- https://deploy-preview-563--mystifying-fermi-1bc096.netlify.app/docs/concepts/activities#activity-cancellation
- https://deploy-preview-563--mystifying-fermi-1bc096.netlify.app/docs/go/activities#cancellation

## Before

<img width="850" alt="CleanShot 2021-08-06 at 00 26 20@2x" src="https://user-images.githubusercontent.com/6764957/128473167-0ef3917f-7cf1-4efc-a853-d171f9aa8802.png">

## After

<img width="831" alt="CleanShot 2021-08-06 at 00 26 39@2x" src="https://user-images.githubusercontent.com/6764957/128473204-b01f01ae-68c2-4c26-a8f8-909d73fa21b5.png">
