### PR TITLE
change OriginalType to Type in the go docs

### DIFF
--- a/docs/go/error-handling.md
+++ b/docs/go/error-handling.md
@@ -30,7 +30,7 @@ if err != nil {
 		applicationErr.Details(&detailMsg) // extract strong typed details
 
 		// handle Activity errors (errors created other than using NewApplicationError() API)
-		switch err.OriginalType() {
+		switch err.Type() {
 		case "CustomErrTypeA":
 			// handle CustomErrTypeA
 		case CustomErrTypeB:


### PR DESCRIPTION
## What does this PR do?
Changes the `OriginalType` to `Type` as it is changed in the go-sdk ([PR](https://github.com/temporalio/sdk-go/pull/176)).
