### PR TITLE
Bump minimum Elasticsearch version to 7.10

### DIFF
--- a/docs/server/versions-dependencies.md
+++ b/docs/server/versions-dependencies.md
@@ -50,7 +50,7 @@ The only required dependency is a database, and there are multiple types of data
 Temporal has built-in Workflow search functionality.
 To enhance this feature, Temporal supports an [integration with Elasticsearch](/docs/server/elasticsearch-setup).
 
-- Elasticsearch v7.7 is supported from Temporal version 1.7.0 onwards
+- Elasticsearch v7.10 is supported from Temporal version 1.7.0 onwards
 - Elasticsearch v6.8 is supported in all Temporal versions
 - Both versions are explicitly supported with AWS Elasticsearch
 


### PR DESCRIPTION
## What does this PR do?
Bump minimum Elasticsearch version from 7.7 to 7.10.

## Notes to reviewers
`ScanWorkflow` API is implemented using "point in time" feature of Elasticsearch which is available only in [7.10](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/release-highlights.html#points-in-time-for-search).

