### PR TITLE
fix namespaces docs

### DIFF
--- a/docs/content/what-is-a-namespace.md
+++ b/docs/content/what-is-a-namespace.md
@@ -6,10 +6,10 @@ description: A Namespace is the fundamental unit of isolation within Temporal, w
 
 A Namespace is the fundamental unit of isolation within Temporal, which is backed by a multi-tenant service.
 
-You may use these to match the development lifecycle, e.g. having separate `dev` and `prod` Namespaces.
-Or you could use them to ensure workflows between different teams never communicate, e.g. `teamA` Namespace should never impact `teamB` Namespace.
+You can use Namespaces to match the development lifecycle; for example, having separate `dev` and `prod` Namespaces.
+Or you could use them to ensure workflows between different teams never communicate; such as ensuring that the `teamA` Namespace never impacts the `teamB` Namespace.
 
-- Out of the box, Temporal server has one "default" and one internal Namespace.
+- By default, Temporal server has one "default" and one internal Namespace.
   All APIs and tools, such as the UI and CLI, default to the "default" Namespace if it is not specified.
   So, if you are not planning to use multiple Namespaces, we recommend using the default one.
 - **Membership**: [Task Queue](#task-queue) names and [Workflow Ids](#workflow-id) must all correspond to a specific Namespace.

--- a/docs/content/what-is-a-namespace.md
+++ b/docs/content/what-is-a-namespace.md
@@ -1,14 +1,19 @@
 ---
 id: what-is-a-namespace
-title: What is an Namespace?
-description: todo
+title: What is a Namespace?
+description: A Namespace is the fundamental unit of isolation within Temporal, which is backed by a multi-tenant service.
 ---
 
-The unit of isolation within Temporal, which is backed by a multi-tenant service.
+A Namespace is the fundamental unit of isolation within Temporal, which is backed by a multi-tenant service.
 
-- By default, a Temporal service is provisioned with a "default" Namespace. All APIs and tools, such as the UI and CLI, default to the "default" Namespace if it is not specified. So, if you are not planning to use multiple Namespaces, we recommend using the default one.
-- [Task Queue](#task-queue) names and [Workflow Ids](#workflow-id) correspond to a specific Namespace. For example, when a [Workflow](#workflow) is started, it starts within a specific Namespace.
-- Temporal guarantees a unique [Workflow Id](#workflow-id) within a Namespace. Temporal supports running [Workflow Executions](#workflow-execution) that use the same [Workflow Id](#workflow-id) if they are in different Namespaces.
-- Various configuration options like the retention period or [Archival](#archival) destination are configured per Namespace through a special CRUD API or through [`tctl`](/docs/system-tools/tctl/).
-- In a multi-cluster deployment, Namespace is a unit of fail-over.
-- Each Namespace can be active on only a single Temporal cluster at a time. However, different Namespaces can be active in different clusters and can fail-over independently.
+You may use these to match the development lifecycle, e.g. having separate `dev` and `prod` Namespaces.
+Or you could use them to ensure workflows between different teams never communicate, e.g. `teamA` Namespace should never impact `teamB` Namespace.
+
+- Out of the box, Temporal server has one "default" and one internal Namespace.
+  All APIs and tools, such as the UI and CLI, default to the "default" Namespace if it is not specified.
+  So, if you are not planning to use multiple Namespaces, we recommend using the default one.
+- **Membership**: [Task Queue](#task-queue) names and [Workflow Ids](#workflow-id) must all correspond to a specific Namespace.
+  For example, when a [Workflow](#workflow) is started, it starts within a specific Namespace.
+- **Uniqueness**: Temporal guarantees a unique [Workflow Id](#workflow-id) within a Namespace.
+  Temporal supports running [Workflow Executions](#workflow-execution) that use the same [Workflow Id](#workflow-id) if they are in different Namespaces.
+- **Namespace Configuration**: Various configuration options like the retention period or [Archival](#archival) destination are configured per Namespace through a special CRUD API or through [`tctl`](/docs/system-tools/tctl/).

--- a/docs/server/namespaces.md
+++ b/docs/server/namespaces.md
@@ -4,11 +4,85 @@ title: Temporal Server Namespaces
 sidebar_label: Namespaces
 ---
 
-The Temporal Global Namespace feature provides clients with the capability to continue their Workflow execution from another
-cluster in the event of a datacenter failover. Although you can configure a Global Namespace to be replicated to any number of
+## What is a Namespace?
+
+import Content from '../content/what-is-a-namespace.md'
+
+<Content />
+
+## Querying Namespaces by CLI
+
+Some useful operations with [Temporal's CLI](/docs/system-tools/tctl):
+
+- `tctl namespace list`: List all namespaces.
+- `tctl --namespace my-namespace-name namespace register`: Register a new namespace named "my-namespace-name"
+- `tctl --namespace my-namespace-name namespace describe`: View "my-namespace-name" details
+
+## Assigning Namespaces on Clients
+
+You set namespaces when you create a client in any of the SDKs (necessary whenever creating workers or starters). If not specified, this defaults to the `default` namespace.
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs
+defaultValue="go"
+values={[
+{label: 'Go', value: 'go'},
+{label: 'Java', value: 'java'},
+{label: 'TypeScript', value: 'ts'},
+]
+}>
+
+<TabItem value="go">
+
+```go
+	c, err := client.NewClient(client.Options{
+		Namespace: "my-namespace-name",
+	})
+```
+
+</TabItem>
+<TabItem value="java">
+
+```java
+ WorkflowServiceStubs service = WorkflowServiceStubs.newInstance();
+ // https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowClientOptions.Builder.html
+ WorkflowOptions clientOptions = WorkflowClientOptions.newBuilder()
+    .setNamespace('my-namespace-name');
+ WorkflowClient workflowClient =  WorkflowClient.newInstance(service, clientOptions);
+```
+
+</TabItem>
+<TabItem value="ts">
+
+```java
+  const connection = new Connection();
+  // https://nodejs.temporal.io/api/interfaces/client.WorkflowClientOptions
+  const client = new WorkflowClient(connection.service, {
+    namespace: 'my-namespace-name'
+  });
+```
+
+</TabItem>
+</Tabs>
+
+## Global Namespaces
+
+import CustomWarning from "../components/CustomWarning.js"
+
+<CustomWarning>
+
+This feature is related to Temporal's experimental Multi-cluster Replication feature which is considered **experimental** and not subject to normal [versioning and support policy](/docs/server/versions-and-dependencies).
+
+</CustomWarning>
+
+The Temporal Global Namespace feature provides clients with the capability to continue their Workflow execution from another cluster in the event of a datacenter failover.
+
+Although you can configure a Global Namespace to be replicated to any number of
 clusters, it is only considered active in a single cluster.
 
-## Global Namespaces Architecture
+### Global Namespaces Architecture
 
 Temporal has introduced a new top level entity, Global Namespaces, which provides support for replication of Workflow
 execution across clusters (aka [Multi-Cluster Replication](/docs/server/multi-cluster)).
@@ -24,32 +98,16 @@ cluster where Global Namespace is in standby mode, Temporal will reject those ca
 contains the name of the current active cluster. It is the responsibility of the application to forward the external
 event to the cluster that is currently active.
 
-## New config for Global Namespaces
+### Global Namespaces Config
 
-### IsGlobal
+| Config              | Description                                                                                                                                                                                                                                                                                           |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| IsGlobal            | This config is used to distinguish namespaces local to the cluster from the global namespace. It controls the creation of replication tasks on updates allowing the state to be replicated across clusters. This is a read-only setting that can only be set when the namespace is provisioned.       |
+| Clusters            | A list of clusters where the namespace can fail over to, including the current active cluster. This is also a read-only setting that can only be set when the namespace is provisioned. A re-replication feature on the roadmap will allow updating this config to add/remove clusters in the future. |
+| Active Cluster Name | Name of the current active cluster for the Global Namespace. This config is updated each time the Global Namespace is failed over to another cluster.                                                                                                                                                 |
+| Failover Version    | Unique failover version which also represents the current active cluster for Global Namespace. Temporal allows failover to be triggered from any cluster, so failover version is designed in a way to not allow conflicts if failover is mistakenly triggered simultaneously on two clusters.         |
 
-This config is used to distinguish namespaces local to the cluster from the global namespace. It controls the creation of
-replication tasks on updates allowing the state to be replicated across clusters. This is a read-only setting that can
-only be set when the namespace is provisioned.
-
-### Clusters
-
-A list of clusters where the namespace can fail over to, including the current active cluster.
-This is also a read-only setting that can only be set when the namespace is provisioned. A re-replication feature on the
-roadmap will allow updating this config to add/remove clusters in the future.
-
-### Active Cluster Name
-
-Name of the current active cluster for the Global Namespace. This config is updated each time the Global Namespace is failed over to
-another cluster.
-
-### Failover Version
-
-Unique failover version which also represents the current active cluster for Global Namespace. Temporal allows failover to
-be triggered from any cluster, so failover version is designed in a way to not allow conflicts if failover is mistakenly
-triggered simultaneously on two clusters.
-
-## Conflict Resolution
+### Conflict Resolution
 
 Unlike local namespaces which provide at-most-once semantics for Activity execution, Global Namespaces can only support at-least-once
 semantics. [Temporal Multi-cluster Replication](/docs/server/multi-cluster) relies on asynchronous replication of events across clusters, so in the event of a failover
@@ -60,7 +118,7 @@ previous active cluster. During such conflict resolution, Temporal re-injects an
 new history before discarding replication tasks. Even though some progress could rollback during failovers, Temporal
 provides the guarantee that Workflows won’t get stuck and will continue to make forward progress.
 
-## Visibility API
+### Visibility API
 
 All Visibility APIs are allowed on both active and standby clusters. This enables
 [Temporal Web](https://github.com/temporalio/temporal-web) to work seamlessly for Global Namespaces as all visibility records for
@@ -68,11 +126,11 @@ Workflow executions can be queried from any cluster the namespace is replicated 
 to the Temporal Visibility API will continue to work even if a Global Namespace is in standby mode. However, they might see
 a lag due to replication delay when querying the Workflow execution state from a standby cluster.
 
-## CLI
+### CLI
 
 The Temporal CLI can also be used to query the namespace config or perform failovers. Here are some useful commands.
 
-### Query Global Namespace
+#### Query Global Namespace
 
 The following command can be used to describe Global Namespace metadata:
 
@@ -89,7 +147,7 @@ ActiveClusterName: dc1
 Clusters: dc1, dc2
 ```
 
-### Failover Global Namespace
+#### Failover Global Namespace
 
 The following command can be used to failover Global Namespace _my-namespace-global_ to the _dc2_ cluster:
 
@@ -97,21 +155,21 @@ The following command can be used to failover Global Namespace _my-namespace-glo
 $ tctl --ns my-namespace-global n up --ac dc2
 ```
 
-## FAQ
+### Global Namespaces FAQ
 
-### What happens to outstanding Activities after failover?
+#### What happens to outstanding Activities after failover?
 
 Temporal does not forward Activity completions across clusters. Any outstanding Activity will eventually timeout based
 on the configuration. Your application should have retry logic in place so that the Activity gets retried and dispatched
 again to a worker after the failover to the new DC. Handling this is pretty much the same as Activity timeout caused by
 a worker restart even without Global Namespaces.
 
-### What happens when a start or signal API call is made to a standby cluster?
+#### What happens when a start or signal API call is made to a standby cluster?
 
 Temporal will reject the call and return **NamespaceNotActiveError**. It is the responsibility of the application to forward
 the failed call to active cluster based on information provided in the error.
 
-### What is the recommended pattern to send external events to an active cluster?
+#### What is the recommended pattern to send external events to an active cluster?
 
 The recommendation at this point is to publish events to a Kafka topic if they can be generated in any cluster.
 Then, have a consumer that consumes from the aggregated Kafka topic in the same cluster and sends them to Temporal. Both the


### PR DESCRIPTION
## What does this PR do?

[our current namespaces doc](https://docs.temporal.io/docs/server/namespaces) is actually about "global namespaces", a feature most users will never use. this PR fixes that by adding the prerequisite knowledge our customers (who only ever interact with us via non default namespaces) actually need.

## Notes to reviewers

reuses and refactors some of the content work we already did as part of jargon mesh drive
