### PR TITLE
Java Auth token page

### DIFF
--- a/docs/content/how-to-pass-an-authorization-header-in-java.md
+++ b/docs/content/how-to-pass-an-authorization-header-in-java.md
@@ -1,0 +1,39 @@
+---
+id: how-to-provide-an-authorization-token-in-java
+title: How to provide an Authorization Token in Java
+description: Providing authorization header to Temporal Server in Java SDK including JWT tokens
+sidebar_label: Authorization
+tags:
+  - developer-guide
+  - java
+  - auth
+---
+
+import RelatedReadList from '../components/RelatedReadList.js'
+
+Authorization Tokens are provided in the `WorkflowServiceStubsOptions` that are passed to the instance of the `WorkflowServiceStubs`.
+
+Create an instance of `AuthorizationTokenSupplier` (available from the `io.temporal.serviceclient.WorkflowServiceStubsOptions` package) which is a header string that specifies a Base64 url-encoded value of your token.
+
+The instance of `AuthorizationTokenSupplier` is then passed to an instance `AuthorizationGrpcMetadataProvider` which is then added to an instance of `WorkflowServiceStubsOptions` via the `addGrpcMetadataProvider` method.
+
+**Example**
+
+```java
+  AuthorizationTokenSupplier tokenSupplier =
+    //your implementation of token supplier
+    () -> "Bearer <Base64 url-encoded value of the token for default JWT ClaimMapper>";
+  WorkflowServiceStubsOptions serviceStubOptions =
+    WorkflowServiceStubsOptions.newBuilder()
+      //other service stub options
+      .addGrpcMetadataProvider(new AuthorizationGrpcMetadataProvider(tokenSupplier))
+      .build();
+  WorkflowServiceStubs service = WorkflowServiceStubs.newInstance(serviceStubOptions);
+  WorkflowClient client = WorkflowClient.newInstance(service);
+```
+
+<RelatedReadList
+readlist={[
+["How to secure a Temporal Cluster", "/docs/server/security", "operation guide"]  
+]}
+/>

--- a/sidebars.js
+++ b/sidebars.js
@@ -208,6 +208,7 @@ module.exports = {
         "java/side-effect",
         "java/distributed-cron",
         "java/testing-and-debugging",
+        "content/how-to-provide-an-authorization-token-in-java",
       ],
     },
     {


### PR DESCRIPTION
Refactor of this PR: https://github.com/temporalio/documentation/pull/614

Preview: https://deploy-preview-661--mystifying-fermi-1bc096.netlify.app/docs/content/how-to-provide-an-authorization-token-in-java

@Spikhalskiy I just focused on the implementation example which seems to be specifically "how to provide an Authorization Token in Java" and put the file in the new `/content` directory.
I made the "Server security" page a related read.
There are a lot of pieces to break apart in the security page in order to build the proper context and connections... so for now this would be my recommendation.