### PR TITLE
add preview and related reads components

### DIFF
--- a/docs/components/RelatedReadList.js
+++ b/docs/components/RelatedReadList.js
@@ -1,9 +1,104 @@
 import React from "react";
 import clsx from "clsx";
 import Link from "@docusaurus/Link";
-import {v4 as uuidv4} from "uuid";
+import { v4 as uuidv4 } from "uuid";
 
-export default function RelatedReadList({readlist}) {
+export function RelatedReadContainer({ children }) {
+  return (
+    <div className={"related-read-div"}>
+      <span className={"related-read-label"}>Related 📚 </span>
+      {React.Children.count(children) > 1 ?
+        <ul className="related-read-list">
+          {React.Children.forEach(children, child => <li>{child}</li>)}
+        </ul>
+        :
+        children
+      }
+    </div>
+  );
+}
+
+export function RelatedReadItem({ page, children }) {
+  const {
+    frontMatter,
+    metadata,
+    // contentTitle // doesnt seem to work yet
+  } = page
+  // console.log({ frontMatter, metadata })
+  // identify tags
+  let tagClass, tag
+  for (const t of frontMatter.tags) {
+    if ([
+      "developer-guide",
+      "operation-guide",
+      "tutorial",
+      "explanation",
+      "reference",
+    ].includes(t)) {
+      tag = t;
+      tagClass = 'archetype-tag-' + t
+    }
+  }
+  return (
+    <>
+      <Preview className={"related-read-link"} page={page}>{children || frontMatter.title}</Preview>
+      <span className={clsx("related-read-archetype-tag", tagClass)}>
+        {tag}
+      </span>
+    </>
+  )
+}
+
+export function Preview({ className, page: {
+  frontMatter,
+  metadata,
+  // contentTitle // doesnt seem to work yet
+}, children }) {
+  const [show, setShow] = React.useState(false)
+  return <span
+    className={className}
+    onMouseEnter={() => setShow(true)}
+    onMouseLeave={() => setShow(false)}
+    style={{ position: 'relative', display: 'inline-block' }}
+  ><a href={metadata.permalink}>{children}<InfoIcon /></a>
+    {show && <div
+      style={{
+        position: 'absolute',
+        zIndex: 1,
+        width: 'max-content',
+        maxWidth: '350px',
+        display: 'flex', flexDirection: 'column',
+        borderRadius: '8px',
+        backgroundColor: '#f2f2f2',
+        color: '#020202',
+        padding: '8px'
+      }}>
+      <div style={{ fontSize: '1rem', fontWeight: 'bold', textAlign: 'center' }}>{frontMatter.title}</div>
+      <div
+        style={{
+          backgroundColor: '#f2f2f2',
+          padding: 10,
+          fontSize: '0.8rem',
+        }}
+      >
+        <span style={{}}>{metadata.description}</span>
+        <span style={{ marginTop: '1rem', display: 'block', fontSize: '0.75rem' }}>
+          <a style={{ color: "blue" }} href={metadata.permalink}>see full article >></a></span>
+      </div></div>}
+  </span>
+}
+
+function InfoIcon() {
+  return <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center' }}>
+    <svg xmlns="http://www.w3.org/2000/svg" height="0.75rem" width="0.75rem" viewBox="0 0 20 20" fill="currentColor">
+      <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+    </svg></span>
+}
+
+
+// TODO - delete everything below this line once we deprecate
+
+export default function RelatedReadList({ readlist }) {
   let readingList = [];
   for (const item of readlist) {
     const tagStuff = tagInfo(item[2]);
@@ -21,7 +116,7 @@ export default function RelatedReadList({readlist}) {
     return (
       <div className={"related-read-div"}>
         <span className={"related-read-label"}>Related 📚 </span>
-        {readingList.map(({id, text, goTo, tag, tagClass}) => (
+        {readingList.map(({ id, text, goTo, tag, tagClass }) => (
           <span key={id}>
             <Link className={"related-read-link"} to={goTo}>
               {text}
@@ -38,7 +133,7 @@ export default function RelatedReadList({readlist}) {
       <div className={"related-read-div"}>
         <span className={"related-read-label"}>Related 📚 </span>
         <ul className="related-read-list">
-          {readingList.map(({id, text, goTo, tag, tagClass}) => (
+          {readingList.map(({ id, text, goTo, tag, tagClass }) => (
             <li key={id}>
               <Link className={"related-read-link"} to={goTo}>
                 {text}
@@ -75,5 +170,5 @@ function tagInfo(tag) {
     default:
       return new Error("unrecognized tag: " + tag);
   }
-  return {tag: tag, tagClass: tagClass};
+  return { tag: tag, tagClass: tagClass };
 }

--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -119,7 +119,10 @@ There are a few important things to consider with Workflow timeout settings:
 
 #### Task timeout
 
-- **Description**: This is the maximum amount of time that the Server will wait for the Worker to start processing a [Workflow Task](/docs/content/what-is-a-workflow-task) after the Task has been pulled from the Task Queue.
+<!-- prettier-ignore -->
+import * as WorkflowTask from "../content/what-is-a-workflow-task.md"
+
+- **Description**: This is the maximum amount of time that the Server will wait for the Worker to start processing a <preview page={WorkflowTask}>Workflow Task</preview> after the Task has been pulled from the Task Queue.
   The default value is 10 seconds.
 - **Use-case**: This is primarily available to recognize whether a Worker has gone down so that the Workflow can be recovered and continue executing on a different Worker.
   The main reason for increasing the default value would be to accommodate a Workflow that has a very long event history that could take longer than 10 seconds for the Worker to load.

--- a/docs/content/how-to-develop-an-activity-definition-in-go.md
+++ b/docs/content/how-to-develop-an-activity-definition-in-go.md
@@ -126,8 +126,12 @@ readlist={[
 
 All native features of the Go programming language can be used within an Activity and there are no other limitations to Activity Definition logic:
 
-- **Performance**: Keep in mind that all parameters and return values are recorded in the [Workflow Execution Event History](/docs/content/what-is-an-event-history).
-  A large Workflow Execution Event History can adversely impact the performance of your Workflow Executions, as the entire Event History is transferred to Worker Processes with every [Workflow Task](/docs/content/what-is-a-workflow-task).
+<!-- prettier-ignore -->
+import * as EventHistory from "./what-is-an-event-history.md"
+import * as WFTask from "./what-is-a-workflow-task.md"
+
+- **Performance**: Keep in mind that all parameters and return values are recorded in the <preview page={EventHistory}>Workflow Execution Event History</preview>.
+  A large Workflow Execution Event History can adversely impact the performance of your Workflow Executions, as the entire Event History is transferred to Worker Processes with every <preview page={WFTask}>Workflow Task</preview>.
 - **Idiomatic usage**: You are free to use:
   - your own loggers and metrics controllers
   - the standard Go concurrency constructs

--- a/docs/content/how-to-set-startworkflowoptions-in-go.md
+++ b/docs/content/how-to-set-startworkflowoptions-in-go.md
@@ -7,7 +7,7 @@ tags:
   - options
 ---
 
-import RelatedReadList from '../components/RelatedReadList.js'
+import RelatedReadList, {RelatedReadContainer, RelatedReadItem} from '../components/RelatedReadList.js'
 
 Create an instance of [`StartWorkflowOptions`](https://pkg.go.dev/go.temporal.io/sdk@v1.10.0/client#StartWorkflowOptions) from the `go.temporal.io/sdk/client` package, and pass the instance to the `ExecuteWorkflow` call.
 
@@ -39,6 +39,15 @@ if err != nil {
   // ...
 }
 ```
+
+<!-- prettier-ignore -->
+import * as WWID from './what-is-a-workflow-id.md'
+
+<RelatedReadContainer>
+  <RelatedReadItem page={WWID}>
+    hi cully
+  </RelatedReadItem>
+</RelatedReadContainer>
 
 <RelatedReadList
 readlist={[

--- a/docs/content/how-to-set-startworkflowoptions-in-go.md
+++ b/docs/content/how-to-set-startworkflowoptions-in-go.md
@@ -44,16 +44,8 @@ if err != nil {
 import * as WWID from './what-is-a-workflow-id.md'
 
 <RelatedReadContainer>
-  <RelatedReadItem page={WWID}>
-    hi cully
-  </RelatedReadItem>
+  <RelatedReadItem page={WWID} />
 </RelatedReadContainer>
-
-<RelatedReadList
-readlist={[
-["What is a Workflow Id?","/docs/content/what-is-a-workflow-id","explanation"],
-]}
-/>
 
 ### `TaskQueue`
 

--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+import React, { isValidElement } from 'react';
+import Link from '@docusaurus/Link';
+import CodeBlock from '@theme/CodeBlock';
+import Heading from '@theme/Heading';
+import Details from '@theme/Details';
+const MDXComponents = {
+  code: (props) => {
+    const { children } = props; // For retrocompatibility purposes (pretty rare use case)
+    // See https://github.com/facebook/docusaurus/pull/1584
+
+    if (isValidElement(children)) {
+      return children;
+    }
+
+    return !children.includes('\n') ? (
+      <code {...props} />
+    ) : (
+      <CodeBlock {...props} />
+    );
+  },
+  a: (props) => <Link {...props} />,
+  pre: (props) => {
+    const { children } = props; // See comment for `code` above
+
+    if (isValidElement(children?.props?.children)) {
+      return children?.props.children;
+    }
+
+    return (
+      <CodeBlock
+        {...(isValidElement(children) ? children?.props : { ...props })}
+      />
+    );
+  },
+  details: (props) => {
+    const items = React.Children.toArray(props.children); // Split summary item from the rest to pass it as a separate prop to the Detais theme component
+
+    const summary = items.find((item) => item?.props?.mdxType === 'summary');
+    const children = <>{items.filter((item) => item !== summary)}</>;
+    return (
+      <Details {...props} summary={summary}>
+        {children}
+      </Details>
+    );
+  },
+  h1: Heading('h1'),
+  h2: Heading('h2'),
+  h3: Heading('h3'),
+  h4: Heading('h4'),
+  h5: Heading('h5'),
+  h6: Heading('h6'),
+  preview: Preview,
+};
+export default MDXComponents;
+
+
+function Preview({ page: {
+  frontMatter,
+  metadata,
+  // contentTitle // doesnt seem to work yet
+}, children }) {
+  const [show, setShow] = React.useState(false)
+  return <span
+    onMouseEnter={() => setShow(true)}
+    onMouseLeave={() => setShow(false)}
+    style={{ position: 'relative', display: 'inline-block' }}
+  ><a href={metadata.permalink}>{children}<InfoIcon /></a>
+    {show && <div
+      style={{
+        position: 'absolute',
+        zIndex: 1,
+        width: 'max-content',
+        display: 'flex', flexDirection: 'column',
+        borderRadius: '8px',
+        backgroundColor: '#f2f2f2',
+        color: '#020202',
+        padding: '8px'
+      }}>
+      <div style={{ fontSize: '1rem', fontWeight: 'bold', textAlign: 'center' }}>{frontMatter.title}</div>
+      <div
+        style={{
+          backgroundColor: '#f2f2f2',
+          padding: 10,
+          fontSize: '0.8rem',
+          lineHeight: 0.5
+        }}
+      >
+        <span style={{}}>{metadata.description}</span>
+        <span style={{ marginTop: '1rem', display: 'block', fontSize: '0.75rem' }}>
+          <a style={{ color: "blue" }} href={metadata.permalink}>see full article >></a></span>
+      </div></div>}
+  </span>
+}
+
+function InfoIcon() {
+  return <span style={{ display: 'inline-flex', flexDirection: 'column', alignItems: 'center' }}>
+    <svg xmlns="http://www.w3.org/2000/svg" height="0.75rem" width="0.75rem" viewBox="0 0 20 20" fill="currentColor">
+      <path fillRule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a1 1 0 000 2v3a1 1 0 001 1h1a1 1 0 100-2v-3a1 1 0 00-1-1H9z" clipRule="evenodd" />
+    </svg></span>
+}

--- a/src/theme/MDXComponents/index.js
+++ b/src/theme/MDXComponents/index.js
@@ -9,6 +9,7 @@ import Link from '@docusaurus/Link';
 import CodeBlock from '@theme/CodeBlock';
 import Heading from '@theme/Heading';
 import Details from '@theme/Details';
+
 const MDXComponents = {
   code: (props) => {
     const { children } = props; // For retrocompatibility purposes (pretty rare use case)
@@ -60,7 +61,8 @@ const MDXComponents = {
 export default MDXComponents;
 
 
-function Preview({ page: {
+
+export function Preview({ page: {
   frontMatter,
   metadata,
   // contentTitle // doesnt seem to work yet
@@ -76,6 +78,7 @@ function Preview({ page: {
         position: 'absolute',
         zIndex: 1,
         width: 'max-content',
+        maxWidth: '350px',
         display: 'flex', flexDirection: 'column',
         borderRadius: '8px',
         backgroundColor: '#f2f2f2',
@@ -87,8 +90,7 @@ function Preview({ page: {
         style={{
           backgroundColor: '#f2f2f2',
           padding: 10,
-          fontSize: '0.8rem',
-          lineHeight: 0.5
+          fontSize: '0.8rem'
         }}
       >
         <span style={{}}>{metadata.description}</span>


### PR DESCRIPTION
## Special Preview link


import a page and add the new `<preview>` tag:

```mdx
<!-- prettier-ignore -->
import * as WorkflowTask from "../content/what-is-a-workflow-task.md"

blah blah blah this is markdown with a <preview page={WorkflowTask}>MAGIC PREVIEW</preview> link blah blah.
```

https://deploy-preview-673--mystifying-fermi-1bc096.netlify.app/docs/concepts/workflows#task-timeout

![image](https://user-images.githubusercontent.com/6764957/136598334-3bd61bbe-0932-4b64-90d6-b22f1440874e.png)

## Related Read List

swap out `<RelatedReadList>` with `RelatedReadContainer` and `RelatedReadItem`.

```mdx

<!-- prettier-ignore -->
import * as WWID from './what-is-a-workflow-id.md'

<RelatedReadContainer>
  <RelatedReadItem page={WWID} />
</RelatedReadContainer>
```

https://deploy-preview-673--mystifying-fermi-1bc096.netlify.app/docs/content/how-to-set-startworkflowoptions-in-go/#id

![image](https://user-images.githubusercontent.com/6764957/136602871-58ae539a-9140-4cba-94ba-ea455d0c7fd8.png)

If there are multiple items, the container auto switches to a bulleted list.
By default, RelatedReadItem uses the title of the page as its link text. to customize it, give it a child:


```mdx
<RelatedReadContainer>
  <RelatedReadItem page={Bar}>hi Cully</RelatedReadItem>
  <RelatedReadItem page={Foo}>hi Dail</RelatedReadItem>
</RelatedReadContainer>
```

## Notes to reviewers

see diffs for what to take out and what to put in. mind your imports and your closing tags. it doesnt really matter what you name the imported MDX files, just make sure you use `import * as Foo from '...'` instead of `import Foo from '...'`.
