### PR TITLE
Fix code typo

### DIFF
--- a/docs/go/queries.md
+++ b/docs/go/queries.md
@@ -114,7 +114,7 @@ import (
 // ...
 
 // https://golang.org/doc/faq#convert_slice_of_interface
-args := [...]string{"foo"}
+_args := [...]string{"foo"}
 args := make([]interface{}, len(_args))
 for i, v := range _args {
 	args[i] = v


### PR DESCRIPTION
This pull request fixes a variable name in a code snippet under go/queries.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1212931695750974">EDU-5442 Fix code typo</a>
