### PR TITLE
Fix typescript clients link

### DIFF
--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -41,7 +41,7 @@ These constraints don't apply inside Activities.
 
 ## How to Start and Cancel Workflows
 
-See the [TypeScript SDK Client docs](/docs/typescript/client) for how to use `WorkflowHandle`s to start, cancel, signal, query, describe and more.
+See the [TypeScript SDK Client docs](/docs/typescript/clients) for how to use `WorkflowHandle`s to start, cancel, signal, query, describe and more.
 
 ## Workflow APIs
 


### PR DESCRIPTION
## What does this PR do?

Fixes `TypeScript SDK Client docs` link in https://docs.temporal.io/docs/typescript/workflows/#how-to-start-and-cancel-workflows

## Notes to reviewers

<!-- delete if n/a -->
