### PR TITLE
Use less confusing variable name

### DIFF
--- a/docs/go/signals.md
+++ b/docs/go/signals.md
@@ -27,13 +27,13 @@ To uniquely identify the Workflow, we need to pass in the `workflowID` and `runI
 Typically, we signal a Workflow from a different process, like a [starter](/docs/go/hello-world-tutorial/#workflow-starter).
 
 ```go
-temporal, err := client.NewClient(client.Options{})
+c, err := client.NewClient(client.Options{})
 if err != nil {
     log.Fatalln("Unable to create Temporal client", err)
     return
 }
 
-err = temporal.SignalWorkflow(context.Background(), workflowID, runID, signalName, signalVal)
+err = c.SignalWorkflow(context.Background(), workflowID, runID, signalName, signalVal)
 if err != nil {
 	log.Fatalln("Error signaling client", err)
 	return

--- a/docs/go/signals.md
+++ b/docs/go/signals.md
@@ -27,13 +27,13 @@ To uniquely identify the Workflow, we need to pass in the `workflowID` and `runI
 Typically, we signal a Workflow from a different process, like a [starter](/docs/go/hello-world-tutorial/#workflow-starter).
 
 ```go
-c, err := client.NewClient(client.Options{})
+temporalClient, err := client.NewClient(client.Options{})
 if err != nil {
     log.Fatalln("Unable to create Temporal client", err)
     return
 }
 
-err = c.SignalWorkflow(context.Background(), workflowID, runID, signalName, signalVal)
+err = temporalClient.SignalWorkflow(context.Background(), workflowID, runID, signalName, signalVal)
 if err != nil {
 	log.Fatalln("Error signaling client", err)
 	return


### PR DESCRIPTION
## What does this PR do?
Just renames a variable in a code example.

## Notes to reviewers

The variable name "temporal" is the same as the "temporal" package, so when I was skimming the docs quickly, I tried to copy paste just the line `temporal.SignalWorkflow` and I was confused why it didn't work. Using a variable name that's not also the name of a package makes it clearer what's going on IMO. Any variable name would be fine, but since this is such a short example, a 1 letter name seemed appropriate.