### PR TITLE
docs: fix small style differences & typos in TypeScript docs

### DIFF
--- a/docs/typescript/activities.md
+++ b/docs/typescript/activities.md
@@ -7,7 +7,7 @@ description: Activities are the only way to interact with external resources in 
 
 > **@temporalio/activity** [![NPM](https://img.shields.io/npm/v/@temporalio/activity)](https://www.npmjs.com/package/@temporalio/activity) [API reference](https://typescript.temporal.io/api/namespaces/activity) | [GitHub](https://github.com/temporalio/sdk-typescript/tree/main/packages/activity)
 
-**Activities are the only way to interact with external resources in Temporal**, like making an HTTP request or accessing the file system.
+**Activities are the only way to interact with external resources in Temporal**, such as making an HTTP request or accessing the file system.
 
 - Unlike [Workflows](/docs/typescript/determinism), Activities execute in the standard Node.js environment, not a [V8 isolate](https://www.npmjs.com/package/isolated-vm). Any code that needs to talk to the outside world needs to be in an Activity, not a Workflow.
 - **Separate from Workflows**: Activities cannot be in the same file as Workflows and must be separately registered (see below for [How to register an Activity on a Worker](#how-to-register-an-activity-on-a-worker))
@@ -177,12 +177,12 @@ export async function DynamicWorkflow(activityName, ...args) {
 Type safety is still supported here, but you are encouraged to validate and handle mismatches in Activity names. An invalid Activity name will lead to a `NotFoundError` with a message that looks like:
 
 ```
-ApplicationFailure: Activity function fakeProgresss is not registered on this Worker, available activities: ["fakeProgress"]
+ApplicationFailure: Activity function fakeProgress is not registered on this Worker, available activities: ["fakeProgress"]
 ```
 
 ### Using pure ESM Node Modules
 
-The TypeScript ecosystem is increasingly moving towards publishing ES Modules over CommonJS, for example `node-fetch@3` is ESM while `node-fetch@2` is CJS.
+The JavaScript ecosystem is increasingly moving towards publishing ES Modules over CommonJS, for example `node-fetch@3` is ESM while `node-fetch@2` is CJS.
 
 **If you are importing a pure ESM dependency, see our [fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample** for necessary config changes you will need:
 
@@ -244,7 +244,7 @@ Temporal SDK also exports a [`Context`](https://typescript.temporal.io/api/class
 | Activity Context properties            | Description                                                                                                                                                                                    |
 | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Context.current().cancellationSignal` | An `AbortSignal` which can be used to cancel requests on Activity cancellation. Typically used by the `fetch` and `child_process` libraries but is supported by a few other libraries as well. |
-| `Context.current().cancelled`          | Await this promise in an Activity to get notified of cancellation. This promise will never be resolved, it will only be rejected with a `CancelledFailure`.                                    |
+| `Context.current().cancelled`          | Await this promise in an Activity to get notified of cancellation. This promise will never be resolved; it will only be rejected with a `CancelledFailure`.                                    |
 | `Context.current().heartbeat()`        | Send a heartbeat from an Activity.                                                                                                                                                             |
 | `Context.current().info`               | Holds [information](https://typescript.temporal.io/api/interfaces/activity.Info) about the current executing Activity                                                                          |
 | `Context.current().sleep()`            | Helper function for sleeping in an Activity - resolves when deadline is reached or rejects when the Context is cancelled. Prefer this to `setTimeout`.                                         |
@@ -273,7 +273,7 @@ Suitable for heartbeating:
 - Read a large file from S3
 - Run a ML training job on some local GPUs
 
-Not suitable for heatbeating:
+Not suitable for heartbeating:
 
 - Reading a small file from disk
 - Making a quick API call

--- a/docs/typescript/clients.md
+++ b/docs/typescript/clients.md
@@ -34,6 +34,7 @@ Create a [`WorkflowClient`](https://typescript.temporal.io/api/classes/client.wo
 
 ```ts
 import { Connection, WorkflowClient } from '@temporalio/client';
+
 const connection = new Connection();
 const client = new WorkflowClient(connection.service, {
   workflowDefaults: { taskQueue: 'tutorial' },

--- a/docs/typescript/determinism.md
+++ b/docs/typescript/determinism.md
@@ -23,7 +23,7 @@ Workflow code is bundled on Worker creation using [Webpack](https://webpack.js.o
 - `uuid4` - provided by the runtime
 - `Date` - replaced by the runtime
   - `new Date()` and `Date.now()` are both set on the first invocation of the Workflow Task
-- `WeakRef | FinalizationRegistery` - cannot be used, as GC is non-deterministic and the Workflow code may observe its effect; deleted by the runtime
+- `WeakRef | FinalizationRegistry` - cannot be used, as GC is non-deterministic and the Workflow code may observe its effect; deleted by the runtime
 - Timers - `setTimeout` and `clearTimeout` are replaced by the runtime.
   - We recommend you use the `@temporal/workflow` package's exported `sleep` function because it plays well with [cancellation scopes](/docs/typescript/cancellation-scopes): `import { sleep } from '@temporalio/workflow'`
 - Activities - use to run non-deterministic code; results are replayed from history

--- a/docs/typescript/troubleshooting.md
+++ b/docs/typescript/troubleshooting.md
@@ -116,7 +116,7 @@ const config = fs.readFileSync('config.json', 'utf8');
 
 :::
 
-This is invalid because reading from the filesystem is a non-deterministic operation, the file may change from the time of the original Workflow execution to when the Workflow is replayed.
+This is invalid because reading from the filesystem is a non-deterministic operation: the file may change from the time of the original Workflow execution to when the Workflow is replayed.
 
 You'll typically see an error in this form in the Webpack output:
 

--- a/docs/typescript/workers.md
+++ b/docs/typescript/workers.md
@@ -42,7 +42,8 @@ import Content from '../content/how-to-develop-a-worker-program-in-typescript.md
 
 <details>
 <summary>
-The Worker package embeds the <a href="https://github.com/temporalio/sdk-core">Temporal Rust Core SDK</a>, it comes pre-compiled for most installations.
+The Worker package embeds the <a href="https://github.com/temporalio/sdk-core">Temporal Rust Core SDK</a>.
+It comes pre-compiled for most installations.
 </summary>
 
 We've provided pre-compiled binaries for:
@@ -141,7 +142,7 @@ const result = await client.execute(myWorkflow); // taskQueue will resolve to 't
 
 // Option 2
 const result = await client.execute(myWorkflow, {
-  taskQueue: 'tutorial', // overrides wahtever was set as default
+  taskQueue: 'tutorial', // overrides whatever was set as default
 });
 ```
 

--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -684,7 +684,7 @@ export async function countdownWorkflow(): Promise<void> {
     console.log('timer now set for: ' + new Date(deadline).toString());
   });
   setListener(timeLeftQuery, () => timer.deadline - Date.now());
-  await timer; // if you send in a signal witha  new time, this timer will resolve earlier!
+  await timer; // if you send in a signal with a new time, this timer will resolve earlier!
   console.log('countdown done!');
 }
 
@@ -781,7 +781,7 @@ Child Workflows have similar APIs with [Temporal Clients](/docs/typescript/clien
 [`startChild`](https://typescript.temporal.io/api/namespaces/workflow/#startchild) starts a child workflow without awaiting completion, and returns a [`ChildWorkflowHandle`](https://typescript.temporal.io/api/interfaces/workflow.ChildWorkflowHandle):
 
 ```ts
-import { executeChild } from '@temporalio/workflow';
+import { startChild } from '@temporalio/workflow';
 
 export async function parentWorkflow(names: string[]) {
   const childHandle = await startChild(childWorkflow, {


### PR DESCRIPTION
## What does this PR do?

Fixes a few small style differences & typos I found while going through the high-level TypeScript docs.

## Notes to reviewers

Doing this helps me focus when reading technical documentation 😄. I've commented anything that's not an immediate clear typo or style deviation inline.
