### PR TITLE
Updating Import for Sinks, from worker -> workflow

### DIFF
--- a/docs/typescript/logging.md
+++ b/docs/typescript/logging.md
@@ -22,7 +22,7 @@ Sinks are objects that contain Sink Functions, which enable one-way export of da
 They are necessary because the Workflow has no way to communicate with the outside World.
 
 ```ts
-import { InjectedSinks, Sinks } from '@temporalio/worker';
+import { Sinks } from '@temporalio/workflow';
 export interface LoggerSinks extends Sinks {
   logger: {
     info(message: string): void;


### PR DESCRIPTION
## What does this PR do?
Minor bug fix: Sinks is not part of `@temporalio/worker`, but rather `@temporalio/workflow`
## Notes to reviewers
Minor bug fix in imports for Sink.
<!-- delete if n/a -->
