### PR TITLE
fix broken JS/TS switch in TypeScript examples

### DIFF
--- a/docs/typescript/activities.md
+++ b/docs/typescript/activities.md
@@ -148,11 +148,8 @@ Activities are Promises and you may retrieve multiple Activities from the same h
 ```ts
 export async function Workflow(name: string): Promise<string> {
   // destructuring multiple activities with the same options
-  const {
-    act1,
-    act2,
-    act3,
-  } = proxyActivities<typeof activities>(/* activityOptions */);
+  const { act1, act2, act3 } =
+    proxyActivities<typeof activities>(/* activityOptions */);
   await act1();
   await Promise.all([act2, act3]);
 }

--- a/docs/typescript/activities.md
+++ b/docs/typescript/activities.md
@@ -147,8 +147,9 @@ Activities are Promises and you may retrieve multiple Activities from the same h
 
 ```ts
 export async function Workflow(name: string): Promise<string> {
+  // destructuring multiple activities with the same options
   const {
-    act1, // destructuring multiple activities with the same options
+    act1,
     act2,
     act3,
   } = proxyActivities<typeof activities>(/* activityOptions */);

--- a/docs/typescript/subscription-tutorial.md
+++ b/docs/typescript/subscription-tutorial.md
@@ -347,8 +347,8 @@ export async function SubscriptionWorkflow(customer: Customer) {
 }
 
 async function BillingCycle(_customer: Customer) {
-  const customer = useState("customer", _customer); // wrapped up signals + queries + state
-  const period = useState("period", 0); // same
+  const customer = useState('customer', _customer); // wrapped up signals + queries + state
+  const period = useState('period', 0); // same
   let isCanceled = false;
   wf.setHandler(cancelSignal, () => void (isCanceled = true));
   for (; period.value < customer.value.maxBillingPeriods; period.value++) {

--- a/docs/typescript/subscription-tutorial.md
+++ b/docs/typescript/subscription-tutorial.md
@@ -272,7 +272,7 @@ export async function SubscriptionWorkflow(customer: Customer) {
 async function BillingCycle(customer: Customer) {
   let isCanceled = false;
   wf.setHandler(cancelSignal, () => void (isCanceled = true)); // signals are reusable!
-  for (let num = 0; num < customer.maxBillingPeriods, num++) {
+  for (let num = 0; num < customer.maxBillingPeriods; num++) {
     await acts.chargeCustomerForBillingPeriod(customer);
     // Wait 1 billing period to charge customer or if they cancel subscription
     // whichever comes first
@@ -351,7 +351,7 @@ async function BillingCycle(_customer: Customer) {
   const period = useState("period", 0); // same
   let isCanceled = false;
   wf.setHandler(cancelSignal, () => void (isCanceled = true));
-  for (; period.value < customer.value.maxBillingPeriods, period.value++) {
+  for (; period.value < customer.value.maxBillingPeriods; period.value++) {
     await acts.chargeCustomerForBillingPeriod(customer);
     // Wait 1 billing period to charge customer or if they cancel subscription
     // whichever comes first

--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -782,12 +782,12 @@ import { executeChild } from '@temporalio/workflow';
 
 export async function parentWorkflow(names: string[]) {
   const childHandle = await startChild(childWorkflow, {
-        args: [name],
-        // workflowId, // add business-meaningful workflow id here
-        // // regular workflow options apply here, with two additions (defaults shown):
-        // cancellationType: ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED,
-        // parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE
-      });
+    args: [name],
+    // workflowId, // add business-meaningful workflow id here
+    // // regular workflow options apply here, with two additions (defaults shown):
+    // cancellationType: ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED,
+    // parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE
+  });
   // you can use childHandle to signal, query, cancel, terminate, or get result here
 }
 ```

--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -400,7 +400,7 @@ export function badExample() {
 
 Because Signal and Query Definitions are separate from Workflow Definitions, we can now compose them together:
 
-```js
+```ts
 // basic reusable Workflow component
 export async function unblocked() {
   let isBlocked = true;
@@ -631,7 +631,7 @@ const userInteraction = new Trigger<boolean>();
 const completeUserInteraction = defineSignal('completeUserInteraction');
 
 export async function myWorkflow(userId: string) {
-  setHandler(completeUserInteraction, () => userInteraction.resolve(true);) // programmatic resolve
+  setHandler(completeUserInteraction, () => userInteraction.resolve(true)); // programmatic resolve
   const userInteracted = await Promise.race([
     userInteraction,
     sleep('30 days'),
@@ -700,7 +700,7 @@ export class UpdatableTimer implements PromiseLike<void> {
       this.deadlineUpdated = false;
       if (
         !(await condition(
-          () => this.deadlineUpdated
+          () => this.deadlineUpdated,
           this.#deadline - Date.now()
         ))
       ) {
@@ -748,7 +748,7 @@ const userInteraction = new Trigger<boolean>();
 const completeUserInteraction = defineSignal('completeUserInteraction');
 
 export async function myWorkflow(userId: string) {
-  setHandler(completeUserInteraction, () => userInteraction.resolve(true);) // programmatic resolve
+  setHandler(completeUserInteraction, () => userInteraction.resolve(true)); // programmatic resolve
   const userInteracted = await Promise.race([
     userInteraction,
     sleep('30 days'),
@@ -787,9 +787,7 @@ export async function parentWorkflow(names: string[]) {
         // // regular workflow options apply here, with two additions (defaults shown):
         // cancellationType: ChildWorkflowCancellationType.WAIT_CANCELLATION_COMPLETED,
         // parentClosePolicy: ParentClosePolicy.PARENT_CLOSE_POLICY_TERMINATE
-      })
-    )
-  );
+      });
   // you can use childHandle to signal, query, cancel, terminate, or get result here
 }
 ```

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -168,69 +168,69 @@ module.exports = {
           includeCurrentVersion: true, // excludeNextVersionDocs is now deprecated
           // // below remark plugin disabled until we can figure out why it is not transpiling to ESNext properly - swyx
           // // original PR https://github.com/temporalio/documentation/pull/496/files
-          // remarkPlugins: [
-          //   [
-          //     () =>
-          //       function addTSNoCheck(tree) {
-          //         // Disable TS type checking for any TypeScript code blocks.
-          //         // This is because imports are messy with snipsync: we don't
-          //         // have a way to pull in a separate config for every example
-          //         // snipsync pulls from.
-          //         function visitor(node) {
-          //           if (!/^ts$/.test(node.lang)) {
-          //             return;
-          //           }
-          //           node.value = "// @ts-nocheck\n" + node.value.trim();
-          //         }
+          remarkPlugins: [
+            [
+              () =>
+                function addTSNoCheck(tree) {
+                  // Disable TS type checking for any TypeScript code blocks.
+                  // This is because imports are messy with snipsync: we don't
+                  // have a way to pull in a separate config for every example
+                  // snipsync pulls from.
+                  function visitor(node) {
+                    if (!/^ts$/.test(node.lang)) {
+                      return;
+                    }
+                    node.value = "// @ts-nocheck\n" + node.value.trim();
+                  }
 
-          //         visit(tree, "code", visitor);
-          //       },
-          //     {},
-          //   ],
-          //   [
-          //     require("remark-typescript-tools").transpileCodeblocks,
-          //     {
-          //       compilerSettings: {
-          //         tsconfig: path.join(
-          //           __dirname,
-          //           "docs",
-          //           "node",
-          //           "tsconfig.json"
-          //         ),
-          //         externalResolutions: {},
-          //       },
-          //       fileExtensions: [".md", ".mdx"],
-          //       // remark-typescript-tools automatically running prettier with a custom config that doesn't
-          //       // line up with ours. This disables any post processing, including the default prettier step.
-          //       postProcessTs: (files) => files,
-          //       postProcessTranspiledJs: (files) => files,
-          //     },
-          //   ],
-          //   [
-          //     () =>
-          //       function removeTSNoCheck(tree) {
-          //         function visitor(node) {
-          //           if (!/^ts$/.test(node.lang) && !/^js$/.test(node.lang)) {
-          //             return;
-          //           }
-          //           if (node.value.startsWith("// @ts-nocheck\n")) {
-          //             node.value = node.value.slice("// @ts-nocheck\n".length);
-          //           }
-          //           // If TS compiled output is empty, replace it with a more helpful comment
-          //           if (
-          //             node.lang === "js" &&
-          //             node.value.trim() === "export {};"
-          //           ) {
-          //             node.value = "// Not required in JavaScript";
-          //           } else if (node.lang === "js") {
-          //             node.value = convertIndent4ToIndent2(node.value).trim();
-          //           }
-          //         }
-          //         visit(tree, "code", visitor);
-          //       },
-          //     {},
-          //   ],
-          // ],
+                  visit(tree, "code", visitor);
+                },
+              {},
+            ],
+            [
+              require("remark-typescript-tools").transpileCodeblocks,
+              {
+                compilerSettings: {
+                  tsconfig: path.join(
+                    __dirname,
+                    "docs",
+                    "typescript",
+                    "tsconfig.json"
+                  ),
+                  externalResolutions: {},
+                },
+                fileExtensions: [".md", ".mdx"],
+                // remark-typescript-tools automatically running prettier with a custom config that doesn't
+                // line up with ours. This disables any post processing, including the default prettier step.
+                postProcessTs: (files) => files,
+                postProcessTranspiledJs: (files) => files,
+              },
+            ],
+            [
+              () =>
+                function removeTSNoCheck(tree) {
+                  function visitor(node) {
+                    if (!/^ts$/.test(node.lang) && !/^js$/.test(node.lang)) {
+                      return;
+                    }
+                    if (node.value.startsWith("// @ts-nocheck\n")) {
+                      node.value = node.value.slice("// @ts-nocheck\n".length);
+                    }
+                    // If TS compiled output is empty, replace it with a more helpful comment
+                    if (
+                      node.lang === "js" &&
+                      node.value.trim() === "export {};"
+                    ) {
+                      node.value = "// Not required in JavaScript";
+                    } else if (node.lang === "js") {
+                      node.value = convertIndent4ToIndent2(node.value).trim();
+                    }
+                  }
+                  visit(tree, "code", visitor);
+                },
+              {},
+            ],
+          ],
         },
         // Will be passed to @docusaurus/plugin-content-blog
         // options: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog


### PR DESCRIPTION
## What does this PR do?

Turns out there were a couple of issues with the JS/TS compiler:

1) Needed to change "node" to "typescript" in the tsconfig path:

```javascript
              {
                compilerSettings: {
                  tsconfig: path.join(
                    __dirname,
                    "docs",
                    "typescript", // <-- this was still "node"
                    "tsconfig.json"
                  ),
                  externalResolutions: {},
                }
```

2) Several syntax errors in the tutorials were causing the build to fail

Here's what it looks like on my machine. Will confirm that it works on Netlify deploy preview as well.

![image](https://user-images.githubusercontent.com/1620265/142508453-82c0184a-971c-4d84-b475-3d1f2081b2f0.png)


## Notes to reviewers

<!-- delete if n/a -->
