### PR TITLE
Fix broken link to typescript testing sample

### DIFF
--- a/docs/typescript/testing.md
+++ b/docs/typescript/testing.md
@@ -19,7 +19,7 @@ The TypeScript SDK does not yet have a test suite that allows time skipping.
 - You can test Workflows by running them with a [WorkflowClient](https://typescript.temporal.io/api/classes/client.workflowclient).
 - Check [the SDK's own tests](https://github.com/temporalio/sdk-typescript/tree/52f67499860526cd180912797dc3e6d7fa4fc78f/packages/test/src) for more examples.
 
-However basic unit tests can still be written (see [samples](https://github.com/temporalio/samples-typescript/blob/main/activities-examples/test/workflow.test.ts)):
+However basic unit tests can still be written (see [samples](https://github.com/temporalio/samples-typescript/blob/main/activities-examples/src/test/workflow.test.ts)):
 
 ```ts
 import { Connection, WorkflowClient } from '@temporalio/client';


### PR DESCRIPTION
## What does this PR do?

It fixes a broken link to https://github.com/temporalio/samples-typescript/blob/main/activities-examples/src/test/workflow.test.ts in TypeScript Testing page.

## Notes to reviewers

