### PR TITLE
fix code sample syntax for build

### DIFF
--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -155,8 +155,8 @@ wf.setHandler(`genericSignal`, (payload) => {
 });
 
 // "inline definition" solution
-wf.setHandler(wf.defineSignal(`task-${taskAId}`), (payload) => /* do task A things */);
-wf.setHandler(wf.defineSignal(`task-${taskBId}`), (payload) => /* do task B things */);
+wf.setHandler(wf.defineSignal(`task-${taskAId}`), (payload) => {/* do task A things */});
+wf.setHandler(wf.defineSignal(`task-${taskBId}`), (payload) => {/* do task B things */});
 ```
 
 <details>


### PR DESCRIPTION
I was getting this error when trying to build master:

```
TypeScript error in code block in line 16 of /Users/cullywakelin/Temporal/documentation/docs/typescript/workflows.md/codeBlock_1/index.ts
Expression expected.
````

This PR has a small fix for that.
