### PR TITLE
 tctl command reference: top-level page and pages for Activity, Workflow, Taskqueue, and Batch

### DIFF
--- a/docs/devtools/tctl.md
+++ b/docs/devtools/tctl.md
@@ -8,6 +8,8 @@ The Temporal CLI is a command-line tool you can use to perform various tasks on 
 It can perform namespace operations such as register, update, and describe as well as Workflow operations like start
 Workflow, show Workflow history, and signal Workflow.
 
+A new reference is in progress: [tctl reference](/docs/reference/tctl)
+
 ## Run the CLI
 
 You can run the CLI in four ways.

--- a/docs/reference/tctl.md
+++ b/docs/reference/tctl.md
@@ -1,0 +1,21 @@
+---
+id: tctl
+title: tctl reference
+description: What are the tctl commands?
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as TctlWorkflow from './tctl/workflow.md'
+import * as TctlActivity from './tctl/activity.md'
+
+import WhatIsTctl from '/docs/content/what-is-tctl.md'
+
+<WhatIsTctl/>
+
+## tctl commands
+
+- <preview page={TctlWorkflow}>`tctl workflow`</preview>
+- <preview page={TctlActivity}>`tctl activity`</preview>

--- a/docs/reference/tctl.md
+++ b/docs/reference/tctl.md
@@ -17,5 +17,5 @@ import WhatIsTctl from '/docs/content/what-is-tctl.md'
 
 ## tctl commands
 
-- <preview page={TctlWorkflow}>`tctl workflow`</preview>
-- <preview page={TctlActivity}>`tctl activity`</preview>
+- <preview page={TctlWorkflow}>tctl workflow</preview>
+- <preview page={TctlActivity}>tctl activity</preview>

--- a/docs/reference/tctl.md
+++ b/docs/reference/tctl.md
@@ -7,9 +7,13 @@ tags:
   - tctl
 ---
 
+import RelatedReadList from '../components/RelatedReadList.js'
+
 <!-- prettier-ignore -->
 import * as TctlWorkflow from './tctl/workflow.md'
 import * as TctlActivity from './tctl/activity.md'
+import * as TctlTaskqueue from './tctl/taskqueue.md'
+import * as TctlBatch from './tctl/batch.md'
 
 import WhatIsTctl from '/docs/content/what-is-tctl.md'
 
@@ -17,5 +21,28 @@ import WhatIsTctl from '/docs/content/what-is-tctl.md'
 
 ## tctl commands
 
+- tctl namespace
 - <preview page={TctlWorkflow}>tctl workflow</preview>
 - <preview page={TctlActivity}>tctl activity</preview>
+- <preview page={TctlTaskqueue}>tctl taskqueue</preview>
+- <preview page={TctlBatch}>tctl batch</preview>
+- tctl cluster
+- tctl dataconverter
+- tctl help
+- tctl admin cluster
+- tctl admin db
+- tctl admin decode
+- tctl admin dlq
+- tctl admin elasticsearch
+- tctl admin history_host
+- tctl admin membership
+- tctl admin namespace
+- tctl admin shard
+- tctl admin taskqueue
+- tctl admin workflow
+
+## tctl environment variables
+
+import EnvironmentVariables from './tctl/environment-variables.md'
+
+<EnvironmentVariables/>

--- a/docs/reference/tctl/activity.md
+++ b/docs/reference/tctl/activity.md
@@ -1,0 +1,25 @@
+---
+id: activity
+title: tctl activity
+description: How to operate Activity Executions using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as WhatIsAnActivityExecution from '/docs/content/what-is-an-activity-execution.md'
+
+The `tctl activity` commands operate <preview page={WhatIsAnActivityExecution}>Activity Executions</preview>.
+
+## `complete`
+
+import TctlActivityComplete from './activity/complete.md'
+
+<TctlActivityComplete/>
+
+## `fail`
+
+import TctlActivityFail from './activity/fail.md'
+
+<TctlActivityFail/>

--- a/docs/reference/tctl/activity/complete.md
+++ b/docs/reference/tctl/activity/complete.md
@@ -1,0 +1,76 @@
+---
+id: complete
+title: tctl activity complete
+description: How to complete an Activity Execution using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as WhatIsAnActivityExecution from '/docs/content/what-is-an-activity-execution.md'
+import * as WhatIsAWorkflowId from '/docs/content/what-is-a-workflow-id.md'
+import * as WhatIsARunId from '/docs/content/what-is-a-run-id.md'
+import * as WhatIsAnActivityId from '/docs/content/what-is-an-activity-id.md'
+
+The `tctl activity complete` command completes an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview>.
+
+`tctl activity complete <options> <arguments...>`
+
+The following options modify the behavior of the command.
+
+### `workflow_id`
+
+How to specify the <preview page={WhatIsAWorkflowId}>Workflow Id</preview> of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> to complete using tctl.
+
+Aliases: `--wid`, `-w`
+
+**Example**
+
+```
+tctl activity complete --workflow_id <id>
+```
+
+### `--run_id`
+
+How to specify the <preview page={WhatIsARunId}>Run Id</preview> of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> to complete using tctl.
+
+Aliases: `--rid`, `-r`
+
+**Example**
+
+```
+tctl activity complete --run_id <id>
+```
+
+### `--activity_id`
+
+How to specify the <preview page={WhatIsAnActivityId}>Activity Id</preview> of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> to complete using tctl.
+
+Alias: `--aid`
+
+**Example**
+
+```
+tctl activity complete --activity_id <id>
+```
+
+### `result`
+
+How to specify the result of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> when using tctl to complete the Activity Execution.
+
+**Example**
+
+```
+tctl activity complete --result <value>
+```
+
+### `identity`
+
+How to specify the identity of the operator when using tctl to complete an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview>.
+
+**Example**
+
+```
+tctl activity complete --identity <value>
+```

--- a/docs/reference/tctl/activity/complete.md
+++ b/docs/reference/tctl/activity/complete.md
@@ -19,7 +19,7 @@ The `tctl activity complete` command completes an <preview page={WhatIsAnActivit
 
 The following options modify the behavior of the command.
 
-### `workflow_id`
+### `--workflow_id`
 
 How to specify the <preview page={WhatIsAWorkflowId}>Workflow Id</preview> of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> to complete using tctl.
 
@@ -55,7 +55,7 @@ Alias: `--aid`
 tctl activity complete --activity_id <id>
 ```
 
-### `result`
+### `--result`
 
 How to specify the result of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> when using tctl to complete the Activity Execution.
 
@@ -65,7 +65,7 @@ How to specify the result of an <preview page={WhatIsAnActivityExecution}>Activi
 tctl activity complete --result <value>
 ```
 
-### `identity`
+### `--identity`
 
 How to specify the identity of the operator when using tctl to complete an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview>.
 

--- a/docs/reference/tctl/activity/fail.md
+++ b/docs/reference/tctl/activity/fail.md
@@ -1,0 +1,86 @@
+---
+id: fail
+title: tctl activity fail
+description: How to fail an Activity Execution using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as WhatIsAnActivityExecution from '/docs/content/what-is-an-activity-execution.md'
+import * as WhatIsAWorkflowId from '/docs/content/what-is-a-workflow-id.md'
+import * as WhatIsARunId from '/docs/content/what-is-a-run-id.md'
+import * as WhatIsAnActivityId from '/docs/content/what-is-an-activity-id.md'
+
+The `tctl activity fail` command fails an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview>.
+
+`tctl activity fail <options> <arguments...>`
+
+The following options modify the behavior of the command.
+
+### `workflow_id`
+
+How to specify the <preview page={WhatIsAWorkflowId}>Workflow Id</preview> of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> to fail using tctl.
+
+Aliases: `--wid`, `-w`
+
+**Example**
+
+```
+tctl activity fail --workflow_id <id>
+```
+
+### `--run_id`
+
+How to specify the <preview page={WhatIsARunId}>Run Id</preview> of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> to fail using tctl.
+
+Aliases: `--rid`, `-r`
+
+**Example**
+
+```
+tctl activity fail --run_id <id>
+```
+
+### `--activity_id`
+
+How to specify the <preview page={WhatIsAnActivityId}>Activity Id</preview> of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> to fail using tctl.
+
+Alias: `--aid`
+
+**Example**
+
+```
+tctl activity fail --activity_id <id>
+```
+
+### `reason`
+
+How to specify the reason for failing an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> when using tctl.
+
+**Example**
+
+```
+tctl activity fail --reason <value>
+```
+
+### `detail`
+
+How to specify details of the reason for failing an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> when using tctl.
+
+**Example**
+
+```
+tctl activity fail --detail <value>
+```
+
+### `identity`
+
+How to specify the identity of the operator when using tctl to fail an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview>.
+
+**Example**
+
+```
+tctl activity complete --identity <value>
+```

--- a/docs/reference/tctl/activity/fail.md
+++ b/docs/reference/tctl/activity/fail.md
@@ -19,7 +19,7 @@ The `tctl activity fail` command fails an <preview page={WhatIsAnActivityExecuti
 
 The following options modify the behavior of the command.
 
-### `workflow_id`
+### `--workflow_id`
 
 How to specify the <preview page={WhatIsAWorkflowId}>Workflow Id</preview> of an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> to fail using tctl.
 
@@ -55,7 +55,7 @@ Alias: `--aid`
 tctl activity fail --activity_id <id>
 ```
 
-### `reason`
+### `--reason`
 
 How to specify the reason for failing an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> when using tctl.
 
@@ -65,7 +65,7 @@ How to specify the reason for failing an <preview page={WhatIsAnActivityExecutio
 tctl activity fail --reason <value>
 ```
 
-### `detail`
+### `--detail`
 
 How to specify details of the reason for failing an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview> when using tctl.
 
@@ -75,7 +75,7 @@ How to specify details of the reason for failing an <preview page={WhatIsAnActiv
 tctl activity fail --detail <value>
 ```
 
-### `identity`
+### `--identity`
 
 How to specify the identity of the operator when using tctl to fail an <preview page={WhatIsAnActivityExecution}>Activity Execution</preview>.
 

--- a/docs/reference/tctl/batch.md
+++ b/docs/reference/tctl/batch.md
@@ -1,0 +1,39 @@
+---
+id: batch
+title: tctl batch
+description: How to operate batch jobs using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as WhatIsAWorkflowExecution from '../../content/what-is-a-workflow-execution.md'
+
+The `tctl batch` commands operate batch jobs. A batch job can signal, cancel, or terminate <preview page={WhatIsAWorkflowExecution}>Workflow Executions</preview>.
+
+Terminating a batch job does not roll back the operation performed by the batch job. However, you can use `tctl workflow reset` to roll back Workflow Executions.
+
+## `start`
+
+import TctlBatchStart from './batch/start.md'
+
+<TctlBatchStart/>
+
+## `list`
+
+import TctlBatchList from './batch/list.md'
+
+<TctlBatchStart/>
+
+## `describe`
+
+import TctlBatchDescribe from './batch/describe.md'
+
+<TctlBatchDescribe/>
+
+## `terminate`
+
+import TctlBatchTerminate from './batch/terminate.md'
+
+<TctlBatchTerminate/>

--- a/docs/reference/tctl/batch.md
+++ b/docs/reference/tctl/batch.md
@@ -24,7 +24,7 @@ import TctlBatchStart from './batch/start.md'
 
 import TctlBatchList from './batch/list.md'
 
-<TctlBatchStart/>
+<TctlBatchList/>
 
 ## `describe`
 

--- a/docs/reference/tctl/batch/describe.md
+++ b/docs/reference/tctl/batch/describe.md
@@ -1,0 +1,25 @@
+---
+id: describe
+title: tctl batch describe
+description: How to describe the progress of a batch job using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+The `tctl batch describe` command describes the progress of a batch job.
+
+`tctl batch describe <options> <arguments...>`
+
+The following option modifies the behavior of the command.
+
+### `--job_id`
+
+How to specify the job ID of a batch job.
+
+Alias: `--jid`
+
+**Example**
+
+```
+tctl batch describe --job_id <id>

--- a/docs/reference/tctl/batch/describe.md
+++ b/docs/reference/tctl/batch/describe.md
@@ -23,3 +23,4 @@ Alias: `--jid`
 
 ```
 tctl batch describe --job_id <id>
+```

--- a/docs/reference/tctl/batch/list.md
+++ b/docs/reference/tctl/batch/list.md
@@ -1,0 +1,26 @@
+---
+id: list
+title: tctl batch list
+description: How to list batch jobs using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+The `tctl batch list` command lists all batch joba.
+
+`tctl batch list <options> <arguments...>`
+
+The following option modifies the behavior of the command.
+
+### `--pagesize`
+
+How to specify the maximum number of batch jobs to list on a page. The default value is 30.
+
+Alias: `--ps`
+
+**Example**
+
+```
+tctl batch list --pagesize <value>
+```

--- a/docs/reference/tctl/batch/start.md
+++ b/docs/reference/tctl/batch/start.md
@@ -1,0 +1,101 @@
+---
+id: start
+title: tctl batch start
+description: How to start a batch job using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as WhatIsAWorkflowExecution from '../../../content/what-is-a-workflow-execution.md'
+import * as WhatIsASearchAttribute from '../../../content/what-is-a-search-attribute.md'
+import * as WhatIsASignal from '../../../content/what-is-a-signal.md'
+
+The `tctl batch start` command starts a batch job.
+
+`tctl batch start <options> <arguments...>`
+
+The following options modify the behavior of the command.
+
+### `--query`
+
+How to specify the <preview page={WhatIsAWorkflowExecution}>Workflow Executions</preview> that this batch job should operate.
+
+The SQL-like query of <preview page={WhatIsASearchAttribute}>Search Attributes</preview> is the same as used by the `tctl workflow list --query` command.
+
+Alias: `-q`
+
+**Example**
+
+```
+tctl batch start --query <value>
+```
+
+### `--reason`
+
+How to specify a reason for running this batch job.
+
+Alias: `--re`
+
+**Example**
+
+```
+tctl batch start --reason <string>
+```
+
+### `--batch_type`
+
+How to specify the operation that this batch job performs. The supported operations are `signal`, `cancel`, and `terminate`.
+
+Alias: `--bt`
+
+**Example**
+
+```
+tctl batch start --batch_type <operation>
+```
+
+### `--signal_name`
+
+How to specify the name of a <preview page={WhatIsASignal}>Signal</preview>. This option is required when `--batch_type` is `signal`.
+
+Alias: `--sig`
+
+**Example**
+
+```
+tctl batch start --signal_name <name>
+```
+
+### `--input`
+
+How to pass input for the <preview page={WhatIsASignal}>Signal</preview>. Input must be in JSON format.
+
+Alias: `-i`
+
+**Example**
+
+```
+tctl batch start --input <json>
+```
+
+### `--rps`
+
+How to specify RPS of processing. The default value is 50.
+
+**Example**
+
+```
+tctl batch start --rps <value>
+```
+
+### `--yes`
+
+How to disable the confirmation prompt.
+
+**Example**
+
+```
+tctl batch start --yes
+```

--- a/docs/reference/tctl/batch/terminate.md
+++ b/docs/reference/tctl/batch/terminate.md
@@ -1,0 +1,38 @@
+---
+id: terminate
+title: tctl batch terminate
+description: How to terminate a batch job using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+The `tctl batch terminate` command terminates a batch job.
+
+`tctl batch terminate <options> <arguments...>`
+
+The following options modify the behavior of the command.
+
+### `--job_id`
+
+How to specify the job ID of a batch job.
+
+Alias: `--jid`
+
+**Example**
+
+```
+tctl batch terminate --job_id <id>
+```
+
+### `--reason`
+
+How to specify a reason for terminating this batch job.
+
+Alias: `--re`
+
+**Example**
+
+```
+tctl batch terminate --reason <string>
+```

--- a/docs/reference/tctl/environment-variables.md
+++ b/docs/reference/tctl/environment-variables.md
@@ -1,0 +1,17 @@
+---
+id: environment-variables
+title: Environment variables for tctl
+description: What are the environment variables for tctl?
+tags:
+  - reference
+  - tctl
+---
+
+Setting environment variables for repeated parameters can shorten tctl commands.
+
+- **TEMPORAL_CLI_ADDRESS** - The host and port for the Temporal frontend service. The default is `127.0.0.1:7233`.
+- **TEMPORAL_CLI_NAMESPACE** - The Workflow Namespace, so you don't need to specify a `--namespace` option. The default namespace is `default`.
+- **TEMPORAL_CLI_TLS_CA** - The path to the server Certificate Authority certificate file.
+- **TEMPORAL_CLI_TLS_CERT** - The path to the public X.509 certificate file for mutual TLS authentication.
+- **TEMPORAL_CLI_TLS_KEY** - The path to the private key file for mutual TLS authentication.
+- **TEMPORAL_CLI_AUTHORIZATION_TOKEN** - Used by the HTTP Basic Authorization plugin. <!-- TODO: Add link to "Securing tctl" page or its equivalent when it exists. -->

--- a/docs/reference/tctl/taskqueue.md
+++ b/docs/reference/tctl/taskqueue.md
@@ -1,0 +1,25 @@
+---
+id: taskqueue
+title: tctl taskqueue
+description: How to operate Task Queues using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as WhatIsATaskQueue from '/docs/content/what-is-a-task-queue.md'
+
+The `tctl taskqueue` commands operate <preview page={WhatIsATaskQueue}>Task Queues</preview>.
+
+## `describe`
+
+import TctlTaskqueueDescribe from './taskqueue/describe.md'
+
+<TctlTaskqueueDescribe/>
+
+## `list-partition`
+
+import TctlTaskqueueListpartition from './taskqueue/list-partition.md'
+
+<TctlTaskqueueListpartition/>

--- a/docs/reference/tctl/taskqueue/describe.md
+++ b/docs/reference/tctl/taskqueue/describe.md
@@ -1,4 +1,4 @@
---
+---
 id: describe
 title: tctl taskqueue describe
 description: How to operate Task Queues using tctl.

--- a/docs/reference/tctl/taskqueue/describe.md
+++ b/docs/reference/tctl/taskqueue/describe.md
@@ -1,0 +1,41 @@
+--
+id: describe
+title: tctl taskqueue describe
+description: How to operate Task Queues using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as WhatIsATaskQueue from '/docs/content/what-is-a-task-queue.md'
+
+The `tctl taskqueue describe` command describes the poller information of a <preview page={WhatIsATaskQueue}>Task Queue</preview>.
+
+`tctl taskqueue describe <options> <arguments...>`
+
+The following options modify the behavior of the command.
+
+### `--taskqueue`
+
+How to specify the description of the <preview page={WhatIsATaskQueue}>Task Queue</preview>.
+
+Alias: `--tq`
+
+**Example**
+
+```
+tctl taskqueue describe --taskqueue <value>
+```
+
+### `--taskqueuetype`
+
+How to specify the type of the <preview page={WhatIsATaskQueue}>Task Queue</preview>. The type can be `workflow` or `activity`. The default is `workflow`.
+
+Alias: `--tqt`
+
+**Example**
+
+```
+tctl taskqueue describe --taskqueuetype <type>
+```

--- a/docs/reference/tctl/taskqueue/list-partition.md
+++ b/docs/reference/tctl/taskqueue/list-partition.md
@@ -1,0 +1,29 @@
+--
+id: list-partition
+title: tctl taskqueue list-partition
+description: How to list Task Queue partitions and the hostname for partitions using tctl.
+tags:
+  - reference
+  - tctl
+---
+
+<!-- prettier-ignore -->
+import * as WhatIsATaskQueue from '/docs/content/what-is-a-task-queue.md'
+
+The `tctl taskqueue list-partition` command lists the partitions of a <preview page={WhatIsATaskQueue}>Task Queue</preview> and the hostname for the partitions.
+
+`tctl taskqueue list-partition <options> <arguments...>`
+
+The following option modifies the behavior of the command.
+
+### `taskqueue`
+
+How to specify a <preview page={WhatIsATaskQueue}>Task Queue</preview>.
+
+Alias: `--tq`
+
+**Example**
+
+```
+tctl taskqueue list-partition --taskqueue <value>
+```

--- a/docs/reference/tctl/taskqueue/list-partition.md
+++ b/docs/reference/tctl/taskqueue/list-partition.md
@@ -1,4 +1,4 @@
---
+---
 id: list-partition
 title: tctl taskqueue list-partition
 description: How to list Task Queue partitions and the hostname for partitions using tctl.

--- a/docs/reference/tctl/workflow/query.md
+++ b/docs/reference/tctl/workflow/query.md
@@ -42,7 +42,7 @@ Aliases: `--rid`, `-r`
 tctl workflow query --run_id <id>
 ```
 
-### `query_type`
+### `--query_type`
 
 How to specify the type of query to run.
 

--- a/docs/reference/tctl/workflow/terminate.md
+++ b/docs/reference/tctl/workflow/terminate.md
@@ -47,7 +47,7 @@ Aliases: `--rid`, `-r`
 tctl workflow terminate --run_id <id>
 ```
 
-### `reason`
+### `--reason`
 
 How to specify a reason for terminating the <preview page={WhatIsAWorkflowExecution}>Workflow Execution</preview>.
 


### PR DESCRIPTION
## What does this PR do?

Adds initial draft of top page for tctl reference and pages for tctl environment variables, `tctl activity`, `tctl taskqueue`, and `tctl batch` commands and their options.