### PR TITLE
Fix visibility docs after refactoring

### DIFF
--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -6,7 +6,7 @@ description: The core abstraction of the Temporal solution is a fault-oblivious 
 ---
 
 When you start a Workflow, you can pass along parameters that tell the Temporal Server how to handle the Workflow.
-This includes the ability to set timeouts for Workflow execution, a Retry Policy, the Task Queue name, a data converter, search attributes, and Child Workflow options.
+This includes the ability to set timeouts for Workflow execution, a Retry Policy, the Task Queue name, a data converter, Search Attributes, and Child Workflow options.
 
 ### Timeout settings
 
@@ -152,10 +152,10 @@ Scheduling is based on UTC time.
 
 :::
 
-### Search attributes
+### Search Attributes
 
-When you start a Workflow, you can configure it with search attributes that can be used in complex Workflow visibility search queries.
-Read the [search attributes guide](/docs/temporal-explained/visibility) to learn how to enable search attributes in Workflows.
+When you start a Workflow, you can configure it with Search Attributes that can be used in complex Workflow visibility search queries.
+Read the [Search Attributes guide](/docs/temporal-explained/visibility) to learn how to enable Search Attributes in Workflows.
 
 ### Memos
 

--- a/docs/content/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md
+++ b/docs/content/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md
@@ -1,7 +1,7 @@
 ---
 id: how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl
 title: How to add a custom Search Attribute to a Cluster using tctl
-description: Use the `tctl admin cluster add-search-attributes` command to add a custom Search Attribute to your Temporal Cluster.
+description: Use the `tctl admin cluster add-search-attributes` command to add a custom Search Attributes to your Temporal Cluster.
 
 tags:
   - operation-guides
@@ -13,13 +13,13 @@ tags:
 <!-- prettier-ignore -->
 import * as WhatIsASearchAttribute from './what-is-a-search-attribute.md'
 
-Use the following command to add a custom <preview page={WhatIsASearchAttribute}>Search Attribute</preview> to your Temporal Cluster.
+Use the following command to add a custom <preview page={WhatIsASearchAttribute}>Search Attributes</preview> to your Temporal Cluster.
 
 ```bash
-tctl admin cluster add-search-attributes --name <SearchAttributeKeyName> --type <SearchAttributeValueType>
+tctl admin cluster add-search-attributes --name <SearchAttributeName> --type <SearchAttributeValueType>
 ```
 
-Search Attribute key names are case sensitive.
+Search Attribute names are case sensitive.
 
 The possible values for `--type` are:
 
@@ -32,7 +32,7 @@ The possible values for `--type` are:
 
 :::note
 
-Due to Elasticsearch limitations you can only add new custom search attributes but not rename or remove existing ones.
+Due to Elasticsearch limitations you can only add new custom Search Attributes but not rename or remove existing ones.
 
 :::
 

--- a/docs/content/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md
+++ b/docs/content/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md
@@ -1,7 +1,7 @@
 ---
 id: how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl
 title: How to add a custom Search Attribute to a Cluster using tctl
-description: Use the `tctl admin cluster add-search-attributes` command to add a custom Search Attributes to your Temporal Cluster.
+description: Use the `tctl admin cluster add-search-attributes` command to add a custom Search Attribute to your Temporal Cluster.
 
 tags:
   - operation-guides
@@ -13,7 +13,7 @@ tags:
 <!-- prettier-ignore -->
 import * as WhatIsASearchAttribute from './what-is-a-search-attribute.md'
 
-Use the following command to add a custom <preview page={WhatIsASearchAttribute}>Search Attributes</preview> to your Temporal Cluster.
+Use the following command to add a custom <preview page={WhatIsASearchAttribute}>Search Attribute</preview> to your Temporal Cluster.
 
 ```bash
 tctl admin cluster add-search-attributes --name <SearchAttributeName> --type <SearchAttributeValueType>

--- a/docs/content/how-to-integrate-elasticsearch-into-a-temporal-cluster.md
+++ b/docs/content/how-to-integrate-elasticsearch-into-a-temporal-cluster.md
@@ -84,14 +84,15 @@ Ensure that the following privileges are granted for the Elasticsearch Temporal 
 
 ### Add custom Search Attributes (optional)
 
-This step is optional if you want to use custom Search Attributes.
+This step is optional.
+Here we are adding custom Search Attributes to your Cluster.
 
 Run the following `tctl` command to add `ProductId` custom Search Attributes to the Temporal Cluster (and Elasticsearch Temporal index):
 ```bash
 tctl admin cluster add-search-attributes --name ProductId --type Keyword
 ```
 
-Run the following `tctl` command to add custom Search Attributes used but samples and SDK integration tests:
+Run the following `tctl` command to add custom Search Attributes used by samples and SDK integration tests:
 
 <!--SNIPSTART add-custom-search-attributes-for-testing-command-->
 <!--SNIPEND-->

--- a/docs/content/how-to-integrate-elasticsearch-into-a-temporal-cluster.md
+++ b/docs/content/how-to-integrate-elasticsearch-into-a-temporal-cluster.md
@@ -84,9 +84,14 @@ Ensure that the following privileges are granted for the Elasticsearch Temporal 
 
 ### Add custom Search Attributes (optional)
 
-This step is optional and useful for testing custom Search Attributes.
+This step is optional if you want to use custom Search Attributes.
 
-Run the following `tctl` command to add six custom Search Attributes to the Elasticsearch Temporal index:
+Run the following `tctl` command to add `ProductId` custom Search Attributes to the Temporal Cluster (and Elasticsearch Temporal index):
+```bash
+tctl admin cluster add-search-attributes --name ProductId --type Keyword
+```
+
+Run the following `tctl` command to add custom Search Attributes used but samples and SDK integration tests:
 
 <!--SNIPSTART add-custom-search-attributes-for-testing-command-->
 <!--SNIPEND-->

--- a/docs/content/how-to-list-workflow-executions-using-tctl.md
+++ b/docs/content/how-to-list-workflow-executions-using-tctl.md
@@ -41,7 +41,7 @@ The use of this flag overrides all other filter flags.
 
 :::note
 
-`--query` flag is supported only when advanced visibility is configured on the server.
+The `--query` flag is supported only when Advanced Visibility is configured with the Cluster.
 
 :::
 

--- a/docs/content/how-to-list-workflow-executions-using-tctl.md
+++ b/docs/content/how-to-list-workflow-executions-using-tctl.md
@@ -39,6 +39,12 @@ tctl workflow list --more
 Use the `--query` flag to list Workflows using an SQL-like query.
 The use of this flag will override all other filter flags.
 
+:::note
+
+`--query` flag is supported only when advanced visibility is configured on the server.
+
+:::
+
 ```bash
 tctl workflow list --query "WorflowId=YourWorkflowId"
 ```

--- a/docs/content/how-to-list-workflow-executions-using-tctl.md
+++ b/docs/content/how-to-list-workflow-executions-using-tctl.md
@@ -37,7 +37,7 @@ tctl workflow list --more
 ### `--query`
 
 Use the `--query` flag to list Workflows using an SQL-like query.
-The use of this flag will override all other filter flags.
+The use of this flag overrides all other filter flags.
 
 :::note
 

--- a/docs/content/how-to-remove-a-search-attribute-from-a-cluster-using-tctl.md
+++ b/docs/content/how-to-remove-a-search-attribute-from-a-cluster-using-tctl.md
@@ -1,7 +1,7 @@
 ---
 id: how-to-remove-a-search-attribute-from-a-cluster-using-tctl
 title: How to remove a Search Attribute from a Cluster's metadata using tctl
-description: Use the `tctl admin cluster remove-search-attributes` command to remove a Search Attributes from a Cluster's metadata.
+description: Use the `tctl admin cluster remove-search-attributes` command to remove a Search Attribute from a Cluster's metadata.
 tags:
   - tctl
   - visibility
@@ -11,7 +11,7 @@ tags:
 <!-- prettier-ignore -->
 import * as WhatIsASearchAttribute from './what-is-a-search-attribute.md'
 
-Use the following command to remove a <preview page={WhatIsASearchAttribute}>Search Attributes</preview> from a Cluster's metadata:
+Use the following command to remove a <preview page={WhatIsASearchAttribute}>Search Attribute</preview> from a Cluster's metadata:
 
 ```bash
 tctl admin cluster remove-search-attributes --name <SearchAttributeKey>

--- a/docs/content/how-to-remove-a-search-attribute-from-a-cluster-using-tctl.md
+++ b/docs/content/how-to-remove-a-search-attribute-from-a-cluster-using-tctl.md
@@ -1,7 +1,7 @@
 ---
 id: how-to-remove-a-search-attribute-from-a-cluster-using-tctl
-title: How to remove a Search Attribute from a Cluster using tctl
-description: Use the `tctl admin cluster remove-search-attributes` command to remove a Search Attribute from a Cluster.
+title: How to remove a Search Attribute from a Cluster's metadata using tctl
+description: Use the `tctl admin cluster remove-search-attributes` command to remove a Search Attributes from a Cluster's metadata.
 tags:
   - tctl
   - visibility
@@ -11,13 +11,13 @@ tags:
 <!-- prettier-ignore -->
 import * as WhatIsASearchAttribute from './what-is-a-search-attribute.md'
 
-Use the following command to remove a <preview page={WhatIsASearchAttribute}>Search Attribute</preview> from a Cluster:
+Use the following command to remove a <preview page={WhatIsASearchAttribute}>Search Attributes</preview> from a Cluster's metadata:
 
 ```bash
 tctl admin cluster remove-search-attributes --name <SearchAttributeKey>
 ```
 
-Only custom Search Attributes can be removed from a Cluster.
+Only custom Search Attributes can be removed from a Cluster's metadata.
 Default Search Attributes cannot be removed.
 
 Removing a Search Attribute removes it from the Cluster's metadata but does not remove it from the Elasticsearch index.

--- a/docs/content/how-to-view-search-attributes-of-a-cluster-using-tctl.md
+++ b/docs/content/how-to-view-search-attributes-of-a-cluster-using-tctl.md
@@ -1,7 +1,7 @@
 ---
 id: how-to-view-search-attributes-of-a-cluster-using-tctl
 title: How to view Search Attributes of a Cluster using tctl
-description: Use the `tctl cluster get-search-attributes` command to view Search Attribute keys currently indexed by the Cluster.
+description: Use the `tctl cluster get-search-attributes` command to view Search Attributes currently indexed by the Cluster.
 tags:
   - operation-guide
   - filtered-lists
@@ -12,7 +12,7 @@ tags:
 <!-- prettier-ignore -->
 import * as WhatIsASearchAttribute from './what-is-a-search-attribute.md'
 
-Use the following command to view the <preview page={WhatIsASearchAttribute}>Search Attribute</preview> keys currently indexed by the Cluster:
+Use the following command to view the <preview page={WhatIsASearchAttribute}>Search Attributes</preview> currently indexed by the Cluster:
 
 ```bash
 tctl cluster get-search-attributes

--- a/docs/content/what-is-a-list-filter.md
+++ b/docs/content/what-is-a-list-filter.md
@@ -25,7 +25,7 @@ WorkflowType = "main.YourWorkflowDefinition" and ExecutionStatus != "Running" an
 
 [More example List Filters](#example-list-filters)
 
-A List Filter contains Search Attribute keys, Search Attribute values, and Operators.
+A List Filter contains Search Attribute names, Search Attribute values, and Operators.
 
 <RelatedReadContainer>
   <RelatedReadItem page={WhatIsASearchAttribute} />
@@ -45,7 +45,7 @@ A List Filter contains Search Attribute keys, Search Attribute values, and Opera
 
 - A List Filter that uses a time range has a resolution of 1 ms on Elasticsearch 6 and 1 ns on Elasticsearch 7.
 
-- List Filter Search Attribute key names are case sensitive.
+- List Filter Search Attribute key names are case-sensitive.
 
 - An Advanced List Filter API may take longer than expected if it is retrieving a large number of Workflow Executions (more than 10 million).
 

--- a/docs/content/what-is-a-list-filter.md
+++ b/docs/content/what-is-a-list-filter.md
@@ -45,7 +45,7 @@ A List Filter contains Search Attribute names, Search Attribute values, and Oper
 
 - A List Filter that uses a time range has a resolution of 1 ms on Elasticsearch 6 and 1 ns on Elasticsearch 7.
 
-- List Filter Search Attribute key names are case-sensitive.
+- List Filter Search Attribute names are case sensitive.
 
 - An Advanced List Filter API may take longer than expected if it is retrieving a large number of Workflow Executions (more than 10 million).
 

--- a/docs/content/what-is-a-search-attribute.md
+++ b/docs/content/what-is-a-search-attribute.md
@@ -1,7 +1,7 @@
 ---
 id: what-is-a-search-attribute
 title: What is a Search Attribute?
-description: A Search Attribute is an indexed key used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.
+description: A Search Attribute is an indexed field used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.
 tags:
   - explanation
   - filtered-lists
@@ -16,7 +16,7 @@ import * as WhatIsATemporalCronJob from './what-is-a-temporal-cron-job.md'
 import * as HowToViewSearchAttribtuesUsingTCTL from './how-to-view-search-attributes-of-a-cluster-using-tctl.md'
 import * as HowToAddCustomSearchAttribute from "../content/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md"
 
-A Search Attribute is an indexed key used in a <preview page={WhatIsAListFilter}>List Filter</preview> to filter a list of Workflow Executions that have the Search Attribute in their metadata.
+A Search Attribute is an indexed field used in a <preview page={WhatIsAListFilter}>List Filter</preview> to filter a list of Workflow Executions that have the Search Attribute in their metadata.
 
 :::note
 
@@ -67,26 +67,26 @@ These Search Attributes are created when the initial index is created.
 
 ### Custom Search Attributes
 
-Custom Search Attribute keys must be <preview page={HowToAddCustomSearchAttribute}>added to a Temporal Cluster using `tctl`</preview>.
-Adding a Search Attribute key makes it available to use with Workflow Executions within that Cluster.
+Custom Search Attributes must be <preview page={HowToAddCustomSearchAttribute}>added to a Temporal Cluster using `tctl`</preview>.
+Adding a Search Attributes makes it available to use with Workflow Executions within that Cluster.
 
 There is no hard limit on the number of attributes you can add.
 However, we recommend enforcing the following limits:
 
-- Number of keys: 100 per Workflow
+- Number of Search Attributes: 100 per Workflow
 - Size of each value: 2 KB per value
-- Total size of keys and values: 40 KB per Workflow
+- Total size of names and values: 40 KB per Workflow
 
 :::note
 
 Due to Elasticsearch limitations, you can only add Search Attributes.
-It is not possible to rename Search Attribute keys or remove them from the index schema.
+It is not possible to rename Search Attributes or remove them from the index schema.
 
 :::
 
 Search Attributes must be one of the following types:
 
-- String
+- Text
 - Keyword
 - Int
 - Double
@@ -96,7 +96,7 @@ Search Attributes must be one of the following types:
 The [temporalio/auto-setup](https://hub.docker.com/r/temporalio/auto-setup) Docker image uses a pre-defined set of custom Search Attributes that are handy for testing.
 Their names indicate their types:
 
-- CustomStringField
+- CustomTextField
 - CustomKeywordField
 - CustomIntField
 - CustomDoubleField
@@ -108,13 +108,13 @@ Note:
 - **Double** is backed up by `scaled_float` Elasticsearch type with scale factor 10000 (4 decimal digits).
 - **Datetime** is backed up by `date` type with milliseconds precision in Elasticsearch 6 and `date_nanos` type with nanoseconds precision in Elasticsearch 7.
 - **Int** is 64-bit integer (`long` Elasticsearch type).
-- **Keyword** and **String** types are concepts taken from Elasticsearch. Each word in a **String** is considered a searchable keyword.
+- **Keyword** and **Text** types are concepts taken from Elasticsearch. Each word in a **Text** is considered a searchable keyword.
   For a UUID, that can be problematic because Elasticsearch indexes each portion of the UUID separately.
   To have the whole string considered as a searchable keyword, use the **Keyword** type.
   For example, if the key `ProductId` has the value of `2dd29ab7-2dd8-4668-83e0-89cae261cfb1`:
   - As a **Keyword** it would be matched only by `ProductId = "2dd29ab7-2dd8-4668-83e0-89cae261cfb1`.
-  - As a **String** it would be matched by `ProductId = 2dd8`, which could cause unwanted matches.
-- The **String** type cannot be used in the "Order By" clause.
+  - As a **Text** it would be matched by `ProductId = 2dd8`, which could cause unwanted matches.
+- The **Text** type cannot be used in the "Order By" clause.
 
 <RelatedReadContainer>
   <RelatedReadItem page={HowToViewSearchAttribtuesUsingTCTL} />

--- a/docs/content/what-is-a-search-attribute.md
+++ b/docs/content/what-is-a-search-attribute.md
@@ -1,7 +1,7 @@
 ---
 id: what-is-a-search-attribute
 title: What is a Search Attribute?
-description: A Search Attribute is an indexed field used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.
+description: A Search Attribute is an indexed name used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.
 tags:
   - explanation
   - filtered-lists
@@ -67,8 +67,8 @@ These Search Attributes are created when the initial index is created.
 
 ### Custom Search Attributes
 
-Custom Search Attributes must be <preview page={HowToAddCustomSearchAttribute}>added to a Temporal Cluster using `tctl`</preview>.
-Adding a Search Attributes makes it available to use with Workflow Executions within that Cluster.
+Custom Search Attributes can be <preview page={HowToAddCustomSearchAttribute}>added to a Temporal Cluster only by using `tctl`</preview>.
+Adding a Search Attribute makes it available to use with Workflow Executions within that Cluster.
 
 There is no hard limit on the number of attributes you can add.
 However, we recommend enforcing the following limits:

--- a/docs/devtools/tctl.md
+++ b/docs/devtools/tctl.md
@@ -397,7 +397,7 @@ import HowToViewSearchAttributesOfAClusterUsingTCTL from '../content/how-to-view
 
 <HowToViewSearchAttributesOfAClusterUsingTCTL/>
 
-### Add custom Search Attribute to a Cluster
+### Add custom Search Attributes to a Cluster
 
 import HowToAddACustomSearchAttributeToAClusterUsingTCTL from '../content/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md'
 

--- a/docs/devtools/tctl.md
+++ b/docs/devtools/tctl.md
@@ -397,19 +397,19 @@ import HowToViewSearchAttributesOfAClusterUsingTCTL from '../content/how-to-view
 
 <HowToViewSearchAttributesOfAClusterUsingTCTL/>
 
-## Add custom Search Attribute to a Cluster
+### Add custom Search Attribute to a Cluster
 
 import HowToAddACustomSearchAttributeToAClusterUsingTCTL from '../content/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md'
 
 <HowToAddACustomSearchAttributeToAClusterUsingTCTL/>
 
-## Remove Search Attributes from a Cluster
+### Remove Search Attributes from a Cluster's Metadata
 
 import HowToRemoveASearchAttributeFromAClusterUsingTCTL from '../content/how-to-remove-a-search-attribute-from-a-cluster-using-tctl.md'
 
 <HowToRemoveASearchAttributeFromAClusterUsingTCTL/>
 
-### Start Workflow with Search Attributes
+## Start Workflow with Search Attributes
 
 ```bash
 tctl workflow start \

--- a/docs/go/how-to-set-startworkflowoptions-in-go.md
+++ b/docs/go/how-to-set-startworkflowoptions-in-go.md
@@ -250,7 +250,7 @@ if err != nil {
 
 ### `SearchAttributes`
 
-Values of custom Search Attributes which must be [added](TODO:link to add search attributes here) to cluster first. 
+<!-- TODO add link to How to add a custom Search Attribute to a Cluster -->
 
 - Type: `map[string]interface{}`
 - Default: Empty.

--- a/docs/go/how-to-set-startworkflowoptions-in-go.md
+++ b/docs/go/how-to-set-startworkflowoptions-in-go.md
@@ -250,8 +250,10 @@ if err != nil {
 
 ### `SearchAttributes`
 
+Values of custom Search Attributes which must be [added](TODO:link to add search attributes here) to cluster first. 
+
 - Type: `map[string]interface{}`
-- Default: This depends on the Cluster. Search Attribute types are defined in the Elasticsearch Index Schema.
+- Default: Empty.
 
 These are the corresponding Search Attribute value types in Go:
 
@@ -260,7 +262,7 @@ These are the corresponding Search Attribute value types in Go:
 - Double = float64
 - Bool = bool
 - Datetime = time.Time
-- String = string
+- Text = string
 
 ```go
 searchAttributes := map[string]interface{}{

--- a/docs/go/search-apis.md
+++ b/docs/go/search-apis.md
@@ -9,31 +9,31 @@ sidebar_label: Search Attributes
 Search attributes enable complex and business-logic-focused search queries for Workflow Executions.
 These are often queried via the Web UI, but you can also query from within your workflow code (as we show below).
 
-There are many [search attributes](/docs/content/what-is-a-search-attribute) that are added to Workflow Executions by default.
+There are many [Search Attributes](/docs/content/what-is-a-search-attribute) that are added to Workflow Executions by default.
 But these are necessarily focused on Temporal internal state tracking.
 
-For more debugging and monitoring, you may wish add your own domain specific search attributes (e.g. `customerId` or `numItems`) that may serve as useful search filters.
+For more debugging and monitoring, you may wish add your own domain specific Search Attributes (e.g. `customerId` or `numItems`) that may serve as useful search filters.
 
-The [Go SDK Client](https://pkg.go.dev/go.temporal.io/sdk/client#Client) offers APIs for configuring search attributes.
+The [Go SDK Client](https://pkg.go.dev/go.temporal.io/sdk/client#Client) offers APIs for configuring Search Attributes.
 There are also APIs on the SDK client for listing Workflows by status.
-Go samples for search attributes can be found at [`temporalio/samples-go`](https://github.com/temporalio/samples-go/tree/master/searchattributes).
+Go samples for Search Attributes can be found at [`temporalio/samples-go`](https://github.com/temporalio/samples-go/tree/master/searchattributes).
 
 ## Value types
 
-Here are the search attribute value types and their corresponding types in Go:
+Here are the Search Attribute value types and their corresponding types in Go:
 
 - Keyword = string
 - Int = int64
 - Double = float64
 - Bool = bool
 - Datetime = time.Time
-- String = string
+- Text = string
 
-## Tagging search attributes at workflow creation
+## Tagging Search Attributes at workflow creation
 
 You can provide key-value pairs as SearchAttributes in [StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#StartWorkflowOptions).
-In Go, SearchAttributes are represented as `map[string]interface{}`.
-The value provided in the map must be the same type that is registered in the dynamic config.
+In Go, Search Attributes are represented as `map[string]interface{}`.
+The value provided in the map must be the same type that was added to a Cluster.
 
 This can be useful for tagging executions with useful attributes you may want to search up later. For example:
 
@@ -54,10 +54,10 @@ func (c *Client) CallMyWorkflow(ctx context.Context, workflowID string, payload 
 }
 ```
 
-## Upsert search attributes during workflow execution
+## Upsert Search Attributes during workflow execution
 
 In advanced cases, you may want to dynamically update these attributes as the workflow progresses.
-[UpsertSearchAttributes](https://pkg.go.dev/go.temporal.io/sdk/workflow#UpsertSearchAttributes) is used to add or update search attributes from within Workflow code.
+[UpsertSearchAttributes](https://pkg.go.dev/go.temporal.io/sdk/workflow#UpsertSearchAttributes) is used to add or update Search Attributes from within Workflow code.
 
 `UpsertSearchAttributes` will merge attributes to the existing map in the Workflow.
 Consider this example Workflow code:
@@ -89,7 +89,7 @@ map[string]interface{}{
 }
 ```
 
-## Removing search attributes
+## Removing Search Attributes
 
 **There is no support for removing a field.**
 
@@ -97,9 +97,9 @@ However, to achieve a similar effect, set the field to some placeholder value.
 For example, you could set `CustomKeywordField` to `impossibleVal`.
 Then searching `CustomKeywordField != 'impossibleVal'` will match Workflows with `CustomKeywordField` not equal to `impossibleVal`, which includes Workflows without the `CustomKeywordField` set.
 
-## Retrieving search attributes
+## Retrieving Search Attributes
 
-Use the `SearchAttributes` property of `workflow.GetInfo` to get a specific search attribute:
+Use the `SearchAttributes` property of `workflow.GetInfo` to get a specific Search Attribute:
 
 ```go
 // Get search attributes that were provided when workflow was started.
@@ -107,7 +107,7 @@ info := workflow.GetInfo(ctx)
 val := info.SearchAttributes.IndexedFields["CustomIntField"]
 ```
 
-## Querying search attributes within a workflow
+## Querying Search Attributes within a workflow
 
 You can programmatically retrieve attributes from a workflow execution with `GetSearchAttributes`, and log out all fields with `GetIndexedFields`:
 
@@ -125,7 +125,7 @@ for k, v := range searchAttributes.GetIndexedFields() {
 }
 ```
 
-## Testing search attributes
+## Testing Search Attributes
 
 The Go SDK's test suite comes with corresponding methods for mocking and asserting these operations:
 
@@ -163,6 +163,6 @@ func Test_Workflow(t *testing.T) {
 }
 ```
 
-## Full search attributes example code
+## Full Search Attributes example code
 
-You can find full example search attribute sample code [in our `samples-go` repo](https://github.com/temporalio/samples-go/tree/master/searchattributes).
+You can find full example Search Attributes sample code [in our `samples-go` repo](https://github.com/temporalio/samples-go/tree/master/searchattributes).

--- a/docs/go/search-apis.md
+++ b/docs/go/search-apis.md
@@ -9,10 +9,10 @@ sidebar_label: Search Attributes
 Search attributes enable complex and business-logic-focused search queries for Workflow Executions.
 These are often queried via the Web UI, but you can also query from within your workflow code (as we show below).
 
-There are many [Search Attributes](/docs/content/what-is-a-search-attribute) that are added to Workflow Executions by default.
+Many [Search Attributes](/docs/content/what-is-a-search-attribute) are added to Workflow Executions by default.
 But these are necessarily focused on Temporal internal state tracking.
 
-For more debugging and monitoring, you may wish add your own domain specific Search Attributes (e.g. `customerId` or `numItems`) that may serve as useful search filters.
+For more debugging and monitoring, you might want to add your own domain-specific Search Attributes (such as `customerId` or `numItems`) that can serve as useful search filters.
 
 The [Go SDK Client](https://pkg.go.dev/go.temporal.io/sdk/client#Client) offers APIs for configuring Search Attributes.
 There are also APIs on the SDK client for listing Workflows by status.

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -209,4 +209,4 @@ This event type indicates that the Temporal Server cannot Signal the targeted Wo
 
 ### UpsertWorkflowSearchAttributes
 
-This event type indicates that the Workflow search attributes should be updated and synchronized with the visibility store.
+This event type indicates that the Workflow Search Attributes should be updated and synchronized with the visibility store.

--- a/docs/reference/tctl/workflow/start.md
+++ b/docs/reference/tctl/workflow/start.md
@@ -177,10 +177,10 @@ tctl workflow start --memo_file <filename>
 
 ### `--search_attr_key`
 
-How to specify a <preview page={WhatIsASearchAttribute}>Search Attribute</preview> key.
-For multiple keys, concatenate them and use pipes (`|`) as separators.
+How to specify a <preview page={WhatIsASearchAttribute}>Search Attribute</preview> name.
+For multiple names, concatenate them and use pipes (`|`) as separators.
 
-To list valid keys, use the `tctl cluster get-search-attr` command.
+To list valid Search Attributes, use the `tctl cluster get-search-attr` command.
 
 **Example**
 
@@ -194,7 +194,7 @@ How to specify a <preview page={WhatIsASearchAttribute}>Search Attribute</previe
 For multiple values, concatenate them and use pipes (`|`) as separators.
 If a value is an array, use JSON format, such as `["a","b"]`, `[1,2]`, `["true","false"]`, or `["2022-06-07T17:16:34-08:00","2022-06-07T18:16:34-08:00"]`.
 
-To list valid keys and value types, use the `tctl cluster get-search-attr` command.
+To list valid Search Attributes and value types, use the `tctl cluster get-search-attr` command.
 
 **Example**
 

--- a/docs/server/event-types.md
+++ b/docs/server/event-types.md
@@ -209,4 +209,4 @@ This event type indicates that the Temporal Server cannot Signal the targeted Wo
 
 #### EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES
 
-This event type indicates that the Workflow search attributes should be updated and synchronized with the visibility store.
+This event type indicates that the Workflow Search Attributes should be updated and synchronized with the visibility store.

--- a/docs/server/introduction.md
+++ b/docs/server/introduction.md
@@ -27,7 +27,7 @@ Choose from the list below to get started:
 
 - [Namespaces](/docs/server/namespaces): Create basic logical separations within a Temporal cluster, or use Global Namespaces to enable failover across multi-cluster instances.
 - [Security](/docs/server/security): Learn how to keep your self-hosted instance secure with encryption and pluggable auth protocols.
+- [Advanced Workflow search](/docs/temporal-explained/visibility): Integrating Elasticsearch enables the use of customizable Search Attributes and complex search queries.
 - Experimental features:
   - [Archival](/docs/server/archive-data): Want to back up your Workflow event history? You can with a cloud provider of your choice.
   - [Multi-cluster Replication](/docs/server/multi-cluster): Increase availability by asynchronously replicating workflows from active cluster to other passive clusters.
-  - [Enhanced Workflow search](/docs/temporal-explained/visibility): Integrating Elasticsearch enables the use of customizable search attributes and complex search queries.

--- a/docs/typescript/search-attributes.md
+++ b/docs/typescript/search-attributes.md
@@ -11,14 +11,14 @@ import * as WhatIsATemporalCronJob from '../content/what-is-a-temporal-cron-job.
 
 ## Overview
 
-Search attributes enable complex and business-logic-focused search queries for Workflow Executions.
+Search Attributes enable complex and business-logic-focused search queries for Workflow Executions.
 Most Search APIs are not yet available in the TypeScript SDK beta.
 These are often queried via the Web UI, but you can also query from within your workflow code (as we show below).
 
-There are many <preview page={WhatsSearchAttr}>search attributes</preview> that are added to Workflow Executions by default.
+There are many <preview page={WhatsSearchAttr}>Search Attributes</preview> that are added to Workflow Executions by default.
 But these are necessarily focused on Temporal internal state tracking.
 
-For more debugging and monitoring, you may wish add your own domain specific search attributes (e.g. `customerId` or `numItems`) that may serve as useful search filters.
+For more debugging and monitoring, you may wish add your own domain specific Search Attributes (e.g. `customerId` or `numItems`) that may serve as useful search filters.
 
 <details>
 <summary>What is a Search Attribute?
@@ -28,7 +28,7 @@ For more debugging and monitoring, you may wish add your own domain specific sea
 
 </details>
 
-## Tagging search attributes at workflow creation
+## Tagging Search Attributes at workflow creation
 
 You can provide key-value pairs as searchAttributes in [StartWorkflowOptions](https://typescript.temporal.io/api/interfaces/client.WorkflowOptions#searchattributes).
 In TypeScript, SearchAttributes are represented as `Record<string, string | number | boolean>`.
@@ -41,12 +41,12 @@ This can be useful for tagging executions with useful attributes you may want to
 <!--SNIPSTART typescript-search-attributes-at-creation-->
 <!--SNIPEND-->
 
-## Future: Upsert search attributes during workflow execution
+## Future: Upsert Search Attributes during workflow execution
 
 In advanced cases, you may want to dynamically update these attributes as the workflow progresses.
 Temporal has an `UpsertSearchAttributes` capability but it is not yet supported in the TypeScript SDK.
 
-## Removing search attributes
+## Removing Search Attributes
 
 **There is no support for removing a field.**
 
@@ -54,14 +54,14 @@ However, to achieve a similar effect, set the field to some placeholder value.
 For example, you could set `CustomKeywordField` to `impossibleVal`.
 Then searching `CustomKeywordField != 'impossibleVal'` will match Workflows with `CustomKeywordField` not equal to `impossibleVal`, which includes Workflows without the `CustomKeywordField` set.
 
-## Future: Retrieving search attributes
+## Future: Retrieving Search Attributes
 
-Temporal supports using the `SearchAttributes` property of `workflow.GetInfo` to get a specific search attribute, however, this is not yet supported in the TypeScript SDK.
+Temporal supports using the `SearchAttributes` property of `workflow.GetInfo` to get a specific Search Attribute, however, this is not yet supported in the TypeScript SDK.
 
-## Future: Querying search attributes within a workflow
+## Future: Querying Search Attributes within a workflow
 
 You can programmatically retrieve attributes from a workflow execution with `GetSearchAttributes`, and log out all fields with `GetIndexedFields` in Temporal, however, this is not yet supported in the TypeScript SDK.
 
-## Future: Testing search attributes
+## Future: Testing Search Attributes
 
 Testing is not yet supported in the TypeScript SDK.

--- a/docs/typescript/search-attributes.md
+++ b/docs/typescript/search-attributes.md
@@ -15,10 +15,10 @@ Search Attributes enable complex and business-logic-focused search queries for W
 Most Search APIs are not yet available in the TypeScript SDK beta.
 These are often queried via the Web UI, but you can also query from within your workflow code (as we show below).
 
-There are many <preview page={WhatsSearchAttr}>Search Attributes</preview> that are added to Workflow Executions by default.
+Many <preview page={WhatsSearchAttr}>Search Attributes</preview> are added to Workflow Executions by default.
 But these are necessarily focused on Temporal internal state tracking.
 
-For more debugging and monitoring, you may wish add your own domain specific Search Attributes (e.g. `customerId` or `numItems`) that may serve as useful search filters.
+For more debugging and monitoring, you might want to add your own domain-specific Search Attributes (such as `customerId` or `numItems`) that can serve as useful search filters.
 
 <details>
 <summary>What is a Search Attribute?


### PR DESCRIPTION
## What does this PR do?
Fix inaccuracy in visibility related docs.

## Notes to reviewers
1. Use capitalized "Search Attributes" everywhere for consistency.
2. Remove "search attribute key" entity. There are no keys, there are names and types. Yes, they are still in `tctl` but this will be refactored.
3. Replace `String` type to `Text`.
4. Other small improvements and justifications.

<!-- delete if n/a -->
