### PR TITLE
exclude shared content from rendering

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,6 +150,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "docs",
+          exclude: ['**/docs/shared/**'], // do not render "shared" content
           editUrl: "https://github.com/temporalio/documentation/blob/master",
           /**
            * Whether to display the author who last updated the doc.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,7 +150,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "docs",
-          exclude: ['**/docs/shared/**'], // do not render "shared" content
+          exclude: ["**/docs/shared/**"], // do not render "shared" content
           editUrl: "https://github.com/temporalio/documentation/blob/master",
           /**
            * Whether to display the author who last updated the doc.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -150,7 +150,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "docs",
-          exclude: ["**/docs/shared/**"], // do not render "shared" content
+          exclude: ["**/shared/**"], // do not render "shared" content
           editUrl: "https://github.com/temporalio/documentation/blob/master",
           /**
            * Whether to display the author who last updated the doc.


### PR DESCRIPTION
## What does this PR do?

exclude shared content from rendering

https://docs.temporal.io/docs/shared/continue-as-new/ is not meant to be viewed as a standalone page...

## Notes to reviewers

<!-- delete if n/a -->
