### PR TITLE
Corrected Workflow Client link in the typescript/workflows#signalwithstart

### DIFF
--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -490,7 +490,7 @@ await workflow.signalWithStart(MyWorkflow, {
 });
 ```
 
-See the [Workflow Client](/docs/typescript/workflows) docs for more notes on how starting Workflows and Workflow Options look like.
+See the [Workflow Client](/docs/typescript/clients/#workflow-options) docs for more notes on how starting Workflows and Workflow Options look like.
 
 ## Deferred Execution
 


### PR DESCRIPTION
## What does this PR do?
Corrects the Workflow Client link to direct correctly to https://docs.temporal.io/docs/typescript/clients/#workflow-options.
