### PR TITLE
fix minor styling issues with list-disc

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -79,10 +79,6 @@ html[data-theme="light"] {
   font-display: swap;
 }
 
-li {
-  list-style: none; /* taken care of using Tailwind typography */
-}
-
 .docs-page {
   @apply my-12;
 }


### PR DESCRIPTION
## What does this PR do?

currently list bullets arent showing up because the `list-style: none` style overrides in specificity.

![image](https://user-images.githubusercontent.com/6764957/146824604-84486157-687e-46d8-b28e-10b328d3e8f0.png)


## Notes to reviewers

<!-- delete if n/a -->
