### PR TITLE
Update MySignal struct in signals documentation

### DIFF
--- a/docs/go/signals.md
+++ b/docs/go/signals.md
@@ -81,6 +81,7 @@ Note that Temporal only serializes public fields.
 // letters are private in Go.
 MySignal struct {
 	Message string
+	message string
 }
 
 signalChan := workflow.GetSignalChannel(ctx, signalName)


### PR DESCRIPTION
## What does this PR do?

This commit updates the `MySignal` struct that is used in the Signals documentation to add a `message` field since the comment on the struct references such a field:

> Temporal serializes `Message`, not `message` because fields that start with lowercase letters are private in Go.

Before this change:

<img width="567" alt="Screen Shot 2021-12-26 at 5 10 45 PM" src="https://user-images.githubusercontent.com/7217598/147421205-ae6c10aa-52a3-4f9c-9368-6cf61122ee68.png">

After this change:

<img width="591" alt="Screen Shot 2021-12-26 at 5 10 55 PM" src="https://user-images.githubusercontent.com/7217598/147421206-7840f60d-c3fb-406d-86c4-3354d64ac59f.png">

## Notes to reviewers

<!-- delete if n/a -->
