### PR TITLE
Changed workflow.context to context.Context

### DIFF
--- a/docs/go/how-to-develop-an-activity-definition-in-go.md
+++ b/docs/go/how-to-develop-an-activity-definition-in-go.md
@@ -20,7 +20,7 @@ In the Temporal Go SDK programming model, an Activity Definition is an exportabl
 
 ```go
 // basic function signature
-func YourActivityDefinition(ctx workflow.Context) error {
+func YourActivityDefinition(ctx context.Context) error {
   // ...
   return nil
 }
@@ -37,11 +37,11 @@ type YourActivityStruct struct {
   ActivityFieldTwo int
 }
 
-func(a *YourActivityStruct) YourActivityDefinition(ctx workflow.Context) error {
+func(a *YourActivityStruct) YourActivityDefinition(ctx context.Context) error {
   // ...
 }
 
-func(a *YourActivityStruct) YourActivityDefinitionTwo(ctx workflow.Context) error {
+func(a *YourActivityStruct) YourActivityDefinitionTwo(ctx context.Context) error {
   // ...
 }
 ```


### PR DESCRIPTION
Changed workflow.context to context.Context in the documentation for the activities.

The use of workflow.Context is incorrect according to the documentation on this page and is quite confusing if you're copy/pasting code.
