### PR TITLE
Updated /security to have details on SOC2 type 2

### DIFF
--- a/src/pages/security.js
+++ b/src/pages/security.js
@@ -61,14 +61,14 @@ export default function Security() {
           </div>
           <div className="row">
             <div className={clsx("col col--5", styles.securityPageHeaders)}>
-              <h2>SOC2 Type 1</h2>
+              <h2>SOC2 Type 2</h2>
             </div>
             <div className={clsx("col col--4", styles.justifyLeft)}>
               <p>
-                Temporal Technologies Inc was issued a clean SOC2 Type 1 report
-                on Janurary 31st 2021 from{" "}
-                <a href="https://www.connor-consulting.com/">
-                  Connor Consulting
+                Temporal Technologies Inc was issued a clean SOC2 Type 2 report
+                on July 31, 2021 from{" "}
+                <a href="https://www.schneiderdowns.com/">
+                  Schneider Downs
                 </a>
               </p>
               <div className={styles.justifyCenter}>

--- a/src/pages/security.js
+++ b/src/pages/security.js
@@ -66,7 +66,7 @@ export default function Security() {
             <div className={clsx("col col--4", styles.justifyLeft)}>
               <p>
                 Temporal Technologies Inc was issued a clean SOC2 Type 2 report
-                on July 31, 2021 from{" "}
+                on July 31, 2021, from{" "}
                 <a href="https://www.schneiderdowns.com/">Schneider Downs</a>
               </p>
               <div className={styles.justifyCenter}>

--- a/src/pages/security.js
+++ b/src/pages/security.js
@@ -67,9 +67,7 @@ export default function Security() {
               <p>
                 Temporal Technologies Inc was issued a clean SOC2 Type 2 report
                 on July 31, 2021 from{" "}
-                <a href="https://www.schneiderdowns.com/">
-                  Schneider Downs
-                </a>
+                <a href="https://www.schneiderdowns.com/">Schneider Downs</a>
               </p>
               <div className={styles.justifyCenter}>
                 <img


### PR DESCRIPTION
## What does this PR do?
Updates our /security page to include SOC2 Type 2 information, and removes out of date information on SOC2 Type 1.
