### PR TITLE
Id -> ID (as common in golang)

### DIFF
--- a/docs/go/queries.md
+++ b/docs/go/queries.md
@@ -166,8 +166,8 @@ In order to run a query using the go client do the following:
 
 ```go
 resp, err := client.QueryWorkflowWithOptions(ctx, &client.QueryWorkflowWithOptionsRequest{
-        WorkflowId:            workflowId,
-        RunId:                 runId,
+        WorkflowID:            workflowID,
+        RunID:                 runID,
         QueryType:             queryType,
         QueryConsistencyLevel: shared.QueryConsistencyLevelStrong.Ptr(),
 })


### PR DESCRIPTION
## What does this PR do?

One of the code-examples had the wrong capitalization of WorkflowID and RunID, and did thus not compile. This PR fixes it such that it now compiles.