### PR TITLE
Update cluster metadata configuration

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -215,7 +215,7 @@ The `log` section is optional and contains the following possible values:
 
 ## clusterMetadata
 
-`clusterMetadata` contains the local cluster definition, including those which participate in [Multi-cluster Replication](/docs/server/multi-cluster).
+`clusterMetadata` contains the local cluster information. The information will be used in [Multi-cluster Replication](/docs/server/multi-cluster).
 
 An example `clusterMetadata` section:
 

--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -215,7 +215,7 @@ The `log` section is optional and contains the following possible values:
 
 ## clusterMetadata
 
-`clusterMetadata` contains all cluster definitions, including those which participate in [Multi-cluster Replication](/docs/server/multi-cluster).
+`clusterMetadata` contains the local cluster definition, including those which participate in [Multi-cluster Replication](/docs/server/multi-cluster).
 
 An example `clusterMetadata` section:
 
@@ -239,7 +239,7 @@ clusterMetadata:
 - `replicationConsumer` - determines which method to use to consume replication tasks. The type may be either `kafka` or `rpc`.
 - `failoverVersionIncrement` - the increment of each cluster version when failover happens.
 - `masterClusterName` - the master cluster name, only the master cluster can register/update namespace. All clusters can do namespace failover.
-- `clusterInformation` - contains a map of cluster names to `ClusterInformation` definitions. `ClusterInformation` sections consist of:
+- `clusterInformation` - contains the local cluster name to `ClusterInformation` definition. The local cluster name should be consistent with `currentClusterName`. `ClusterInformation` sections consist of:
   - `enabled` - _boolean_ - whether a remote cluster is enabled for replication.
   - `initialFailoverVersion`
   - `rpcAddress` - indicate the remote service address (host:port). Host can be DNS name. Use `dns:///` prefix to enable round-robin between IP address for DNS name.

--- a/docs/server/multi-cluster.md
+++ b/docs/server/multi-cluster.md
@@ -13,7 +13,7 @@ Temporal's Multi-cluster Replication feature is considered **experimental** and 
 </CustomWarning>
 
 This guide introduces Temporal's Multi-cluster Replication capabilities.
-You can set this up with [`clusterMetadata` configuration](/docs/server/configuration#clustermetadata). Detailed examples can be found in below section [Cluster setup](#Cluster-setup)
+You can set this up with `tctl admin cluster upsert-remote-cluster` command. A two -cluster-setup example can be found in below section [Cluster setup](#Cluster-setup)
 
 ## Overview
 
@@ -477,7 +477,7 @@ clusterMetadata:
       rpcAddress: "127.0.0.1:8233"
 ```
 
-Then you can use the `tctl admin` tool to add cluster connections. All operations should be executed on both ends.
+Then you can use the `tctl admin` tool to add cluster connections. All operations should be executed in both clusters.
 
 ```shell
 # Add cluster B connection into cluster A

--- a/docs/server/multi-cluster.md
+++ b/docs/server/multi-cluster.md
@@ -13,7 +13,7 @@ Temporal's Multi-cluster Replication feature is considered **experimental** and 
 </CustomWarning>
 
 This guide introduces Temporal's Multi-cluster Replication capabilities.
-You can set this up with `tctl admin cluster upsert-remote-cluster` command. A two -cluster-setup example can be found in below section [Cluster setup](#Cluster-setup)
+You can set this up with `tctl admin cluster upsert-remote-cluster` command. A two-cluster-setup example can be found in below section [Cluster setup](#Cluster-setup)
 
 ## Overview
 


### PR DESCRIPTION
## What does this PR do?
Update cluster metadata configuration with new TCTL command.

## Notes to reviewers
With latest release, we are switching to config multi-cluster via TCTL. The cluster metadata only contains local cluster information.

<!-- delete if n/a -->
