### PR TITLE
Add clarification about schedule_to_start

### DIFF
--- a/docs/content/what-is-a-schedule-to-start-timeout.md
+++ b/docs/content/what-is-a-schedule-to-start-timeout.md
@@ -23,13 +23,11 @@ title="Schedule-To-Start Timeout period"
 />
 
 
-:::warning "Schedule" in Schedule-To-Start and Schedule-To-Close may reference different moments
+"Schedule" in Schedule-To-Start and Schedule-To-Close have different frequency guarantees.
 
-Schedule-To-Start Timeout is enforced for each Activity Task, whereas Schedule-To-Close Timeout is enforced once per Activity Execution.
+The Schedule-To-Start Timeout is enforced for each Activity Task, whereas the Schedule-To-Close Timeout is enforced once per Activity Execution.
 Thus, "Schedule" in Schedule-To-Start refers to the scheduling moment of *every* Activity Task in the sequence of Activity Tasks that make up the Activity Execution, while
 "Schedule" in Schedule-To-Close refers to the *first* Activity Task in that sequence.
-
-:::
 
 
 [Retry Policy](/docs/content/what-is-a-retry-policy) attached to an Activity Execution retries an Activity Task.

--- a/docs/content/what-is-a-schedule-to-start-timeout.md
+++ b/docs/content/what-is-a-schedule-to-start-timeout.md
@@ -13,7 +13,7 @@ import RelatedReadList from '../components/RelatedReadList.js'
 A Schedule-To-Start Timeout is the maximum amount of time that is allowed from when an [Activity Task](/docs/content/what-is-an-activity-task) is scheduled (that is, placed in a Task Queue) to when a [Worker](/docs/content/what-is-a-worker) starts (that is, picks up from the Task Queue) that Activity Task.
 In other words, it's a limit for how long an Activity Task can be enqueued.
 
-The moment that the Task is picked by the Worker from the task queue is considered to be the Start of the Activity Task for the Schedule To Start timeout and associated metrics.
+The moment that the Task is picked by the Worker from the Task Queue is considered to be the start of the Activity Task for the purposes of the Schedule-To-Start Timeout and associated metrics.
 This definition of "Start" avoids issues that a clock difference between the Temporal Cluster and a Worker might create.
 
 <CenteredImage

--- a/docs/content/what-is-a-schedule-to-start-timeout.md
+++ b/docs/content/what-is-a-schedule-to-start-timeout.md
@@ -1,7 +1,7 @@
 ---
 id: what-is-a-schedule-to-start-timeout
 title: What is a Schedule To Start Timeout?
-description: A Schedule To Start Timeout is the maximum amount of time that is allowed, from when an Activity Task is scheduled to when a Worker starts executing the Activity Task.
+description: A Schedule To Start Timeout is the maximum amount of time that is allowed, from when an Activity Task is placed in a Task Queue to when a Worker picks it up from the Task Queue.
 tags:
   - explanation
   - timeouts
@@ -10,7 +10,9 @@ tags:
 import CenteredImage from "../components/CenteredImage.js"
 import RelatedReadList from '../components/RelatedReadList.js'
 
-A Schedule To Start Timeout is the maximum amount of time that is allowed, from when an [Activity Task](/docs/content/what-is-an-activity-task) is scheduled (placed in a Task Queue) to when a [Worker](/docs/content/what-is-a-worker) starts executing that Activity Task.
+A Schedule To Start Timeout is the maximum amount of time that is allowed, from when an [Activity Task](/docs/content/what-is-an-activity-task) is scheduled (placed in a Task Queue) to when a [Worker](/docs/content/what-is-a-worker) starts (picks it up from the Task Queue) that Activity Task.
+In other words, it's a limit for how long an Activity Task can be enqueued.
+The moment that the Task is picked by the Worker from the task queue is considered to be the start of the Activity Task for the Schedule To Start timeout and associated metrics to avoid clock difference between the Server and the Worker.
 
 <CenteredImage
 imagePath="/diagrams/schedule-to-start-timeout.svg"
@@ -18,8 +20,15 @@ imageSize="100"
 title="Schedule-To-Start Timeout period"
 />
 
-A [Retry Policy](/docs/content/what-is-a-retry-policy) attached to an Activity Execution retries an Activity Task Execution.
-Thus the Schedule-To-Start Timeout is applied to each Activity Task Execution within an Activity Execution.
+A [Retry Policy](/docs/content/what-is-a-retry-policy) attached to an Activity Execution retries an Activity Task.
+Thus, the Schedule-To-Start Timeout and latency metrics are applied to each Activity Task separately within an Activity Execution.
+
+:::warning "Schedule" in Schedule-To-Start and Schedule-To-Close may reference different moments
+
+"Schedule" in Schedule-To-Start references the scheduling of a single Activity Task (each Activity retry has a separate scheduling moment).
+"Schedule" in Schedule-To-Close references the scheduling of the whole Activity Execution.
+
+:::
 
 <CenteredImage
 imagePath="/diagrams/schedule-to-start-timeout-with-retry.svg"
@@ -27,7 +36,7 @@ imageSize="100"
 title="Start-To-Close Timeout period with retries"
 />
 
-There are two primary uses case of this timeout:
+There are two primary use cases of this timeout:
 
 1. Detect whether an individual Worker has crashed.
 2. Detect whether the fleet of Workers polling the Task Queue is not able to keep up with the rate of Activity Tasks.
@@ -36,9 +45,9 @@ There are two primary uses case of this timeout:
 
 If this timeout is used, we recommend setting this timeout to the maximum time a Workflow Execution is willing to wait for an Activity Execution in the presence of all possible Worker outages, and have a concrete plan in place to reroute Activity Tasks to a different Task Queue.
 This timeout **does not** trigger any retries regardless of the Retry Policy, as a retry would place the Activity Task back into the same Task Queue.
-As a reminder, we do not recommend using this timeout unless you know what you are doing.
+We do not recommend using this timeout unless you know what you are doing.
 
-In most cases, we recommend monitoring the `temporal_activity_schedule_to_start_latency` metric to know when Workers are not picking up Activity Tasks, instead of setting this timeout.
+In most cases, we recommend monitoring the `temporal_activity_schedule_to_start_latency` metric to know when Workers slow down picking up Activity Tasks, instead of setting this timeout.
 
 <RelatedReadList
 readlist={[

--- a/docs/content/what-is-a-schedule-to-start-timeout.md
+++ b/docs/content/what-is-a-schedule-to-start-timeout.md
@@ -1,7 +1,7 @@
 ---
 id: what-is-a-schedule-to-start-timeout
-title: What is a Schedule To Start Timeout?
-description: A Schedule To Start Timeout is the maximum amount of time that is allowed, from when an Activity Task is placed in a Task Queue to when a Worker picks it up from the Task Queue.
+title: What is a Schedule-To-Start Timeout?
+description: A Schedule-To-Start Timeout is the maximum amount of time that is allowed from when an Activity Task is placed in a Task Queue to when a Worker picks it up from the Task Queue.
 tags:
   - explanation
   - timeouts
@@ -10,7 +10,7 @@ tags:
 import CenteredImage from "../components/CenteredImage.js"
 import RelatedReadList from '../components/RelatedReadList.js'
 
-A Schedule To Start Timeout is the maximum amount of time that is allowed, from when an [Activity Task](/docs/content/what-is-an-activity-task) is scheduled (placed in a Task Queue) to when a [Worker](/docs/content/what-is-a-worker) starts (picks it up from the Task Queue) that Activity Task.
+A Schedule-To-Start Timeout is the maximum amount of time that is allowed from when an [Activity Task](/docs/content/what-is-an-activity-task) is scheduled (that is, placed in a Task Queue) to when a [Worker](/docs/content/what-is-a-worker) starts (that is, picks up from the Task Queue) that Activity Task.
 In other words, it's a limit for how long an Activity Task can be enqueued.
 The moment that the Task is picked by the Worker from the task queue is considered to be the start of the Activity Task for the Schedule To Start timeout and associated metrics to avoid clock difference between the Server and the Worker.
 
@@ -20,15 +20,12 @@ imageSize="100"
 title="Schedule-To-Start Timeout period"
 />
 
-A [Retry Policy](/docs/content/what-is-a-retry-policy) attached to an Activity Execution retries an Activity Task.
+"Schedule" in Schedule-To-Start and Schedule-To-Close both refer to the scheduling of an Activity Task.
+Schedule-To-Close refers to the scheduling of the *first* Activity Task in the set of Activity Tasks that make up the Activity Execution.
+"Schedule" in Schedule-To-Start refers to the scheduling of *any* Activity Task in the set of Activity Tasks that make up the Activity Execution.
+In other words, Schedule-To-Close Timeout is enforced once per Activity Execution, whereas Schedule-To-Start Timeout is enforced for each Activity Task.
+This is because a [Retry Policy](/docs/content/what-is-a-retry-policy) attached to an Activity Execution retries an Activity Task.
 Thus, the Schedule-To-Start Timeout and latency metrics are applied to each Activity Task separately within an Activity Execution.
-
-:::warning "Schedule" in Schedule-To-Start and Schedule-To-Close may reference different moments
-
-"Schedule" in Schedule-To-Start references the scheduling of a single Activity Task (each Activity retry has a separate scheduling moment).
-"Schedule" in Schedule-To-Close references the scheduling of the whole Activity Execution.
-
-:::
 
 <CenteredImage
 imagePath="/diagrams/schedule-to-start-timeout-with-retry.svg"
@@ -36,7 +33,7 @@ imageSize="100"
 title="Start-To-Close Timeout period with retries"
 />
 
-There are two primary use cases of this timeout:
+This timeout has two primary use cases:
 
 1. Detect whether an individual Worker has crashed.
 2. Detect whether the fleet of Workers polling the Task Queue is not able to keep up with the rate of Activity Tasks.

--- a/docs/content/what-is-a-schedule-to-start-timeout.md
+++ b/docs/content/what-is-a-schedule-to-start-timeout.md
@@ -12,7 +12,9 @@ import RelatedReadList from '../components/RelatedReadList.js'
 
 A Schedule-To-Start Timeout is the maximum amount of time that is allowed from when an [Activity Task](/docs/content/what-is-an-activity-task) is scheduled (that is, placed in a Task Queue) to when a [Worker](/docs/content/what-is-a-worker) starts (that is, picks up from the Task Queue) that Activity Task.
 In other words, it's a limit for how long an Activity Task can be enqueued.
-The moment that the Task is picked by the Worker from the task queue is considered to be the start of the Activity Task for the Schedule To Start timeout and associated metrics to avoid clock difference between the Server and the Worker.
+
+The moment that the Task is picked by the Worker from the task queue is considered to be the Start of the Activity Task for the Schedule To Start timeout and associated metrics.
+This definition of "Start" avoids issues that a clock difference between the Temporal Cluster and a Worker might create.
 
 <CenteredImage
 imagePath="/diagrams/schedule-to-start-timeout.svg"
@@ -20,13 +22,18 @@ imageSize="100"
 title="Schedule-To-Start Timeout period"
 />
 
-"Schedule" in Schedule-To-Start and Schedule-To-Close both refer to the scheduling of an Activity Task.
-Schedule-To-Close refers to the scheduling of the *first* Activity Task in the set of Activity Tasks that make up the Activity Execution.
-"Schedule" in Schedule-To-Start refers to the scheduling of *any* Activity Task in the set of Activity Tasks that make up the Activity Execution.
-In other words, Schedule-To-Close Timeout is enforced once per Activity Execution, whereas Schedule-To-Start Timeout is enforced for each Activity Task.
-This is because a [Retry Policy](/docs/content/what-is-a-retry-policy) attached to an Activity Execution retries an Activity Task.
-Thus, the Schedule-To-Start Timeout and latency metrics are applied to each Activity Task separately within an Activity Execution.
 
+:::warning "Schedule" in Schedule-To-Start and Schedule-To-Close may reference different moments
+
+Schedule-To-Start Timeout is enforced for each Activity Task, whereas Schedule-To-Close Timeout is enforced once per Activity Execution.
+Thus, "Schedule" in Schedule-To-Start refers to the scheduling moment of *every* Activity Task in the sequence of Activity Tasks that make up the Activity Execution, while
+"Schedule" in Schedule-To-Close refers to the *first* Activity Task in that sequence.
+
+:::
+
+
+[Retry Policy](/docs/content/what-is-a-retry-policy) attached to an Activity Execution retries an Activity Task.
+ 
 <CenteredImage
 imagePath="/diagrams/schedule-to-start-timeout-with-retry.svg"
 imageSize="100"


### PR DESCRIPTION
## What does this PR do?

Currently, the documentation states that
```
A Schedule To Start Timeout is the maximum amount of time that is allowed, from when an Activity Task is scheduled (placed in a Task Queue) to when a worker starts executing that Activity Task.
```

This is technically incorrect and may be misleading for the users.
Schedule To Start is a time difference between the moment when the task is put on the queue and the moment it got picked up from the queue. There could be delays of all kinds before the task actually starts executing on the Worker and it's not included either in Schedule To Start Timeout or Schedule To Start Metric.

## Notes to reviewers

Please feel free to just rework this PR completely in any other way that addresses the fact that the original wording is technically incorrect.
