### PR TITLE
Update tutorial-subscription.md

### DIFF
--- a/docs/typescript/tutorial-subscription.md
+++ b/docs/typescript/tutorial-subscription.md
@@ -273,8 +273,8 @@ export async function SubscriptionWorkflow(customer: Customer) {
 async function BillingCycle(customer: Customer) {
   let isCanceled = false;
   wf.setHandler(cancelSignal, () => void (isCanceled = true)); // signals are reusable!
+  await acts.chargeCustomerForBillingPeriod(customer);
   for (let num = 0; num < customer.maxBillingPeriods; num++) {
-    await acts.chargeCustomerForBillingPeriod(customer);
     // Wait 1 billing period to charge customer or if they cancel subscription
     // whichever comes first
     if (await wf.condition(() => isCanceled, customer.billingPeriod)) {
@@ -352,8 +352,8 @@ async function BillingCycle(_customer: Customer) {
   const period = useState('period', 0); // same
   let isCanceled = false;
   wf.setHandler(cancelSignal, () => void (isCanceled = true));
+  await acts.chargeCustomerForBillingPeriod(customer);
   for (; period.value < customer.value.maxBillingPeriods; period.value++) {
-    await acts.chargeCustomerForBillingPeriod(customer);
     // Wait 1 billing period to charge customer or if they cancel subscription
     // whichever comes first
     if (await wf.condition(() => isCanceled, customer.billingPeriod)) {


### PR DESCRIPTION
## What does this PR do?
`chargeCustomerForBillingPeriod` is called twice in the `for` loop, which would result in the customer getting charged twice. To achieve the intended behaviour of billing immediately when `BillingCycle` is called and then billing in regular intervals, we either need to bring out the first call outside of the `for` loop, or get rid of the else block after `if (await wf.condition(...)) {` entirely. I went for the first option in this PR.