### PR TITLE
"Too Many Workers" section and cleanup of Server docs

### DIFF
--- a/docs/operation/how-to-tune-workers.md
+++ b/docs/operation/how-to-tune-workers.md
@@ -48,6 +48,22 @@ The steps are arranged in the recommended order of execution.
 
 If currently provisioned Worker hosts are fully utilized (near full CPU usage, high load average, etc), additional Workers hosts have to be provisioned to increase the capacity of the Workers pool.
 
+**It's possible to have too many Workers**
+
+Monitor the poll success (`poll_success`/`poll_success_sync`) and poll timeout `poll_timeouts` Server metric counters.
+
+Poll Success Rate = (`poll_success` + `poll_success_sync`) / (`poll_success` + `poll_success_sync` + `poll_timeouts`)
+
+Poll Success Rate should be >90% in most cases of systems with a steady load. For high volume and low latency, try to target >95%.
+
+If you see
+
+1. low Poll Success Rate, and
+2. low `schedule_to_start_latency`, and
+3. low Worker hosts resource utilization at the same time,
+
+you might have too many workers, consider to size down.
+
 ### Worker Executor Slots sizing
 
 The main area of tuning should be the number of Worker Executor Slots. If:
@@ -104,7 +120,7 @@ Perform this sanity check after the adjustments to Worker settings.
 
 ## Drawbacks of putting just "large values everywhere"
 
-As with any multithreading system, specifying too large values without monitoring with the SDK and system metrics will lead to constant resources contention/stealing, which decreases the total throughput and increases latency jitter of the system.
+As with any multithreading system, specifying too large values without monitoring with the SDK and system metrics will lead to constant resource contention/stealing, which decreases the total throughput and increases latency jitter of the system.
 
 <RelatedReadList
 readlist={[

--- a/docs/server/production-deploy.md
+++ b/docs/server/production-deploy.md
@@ -124,27 +124,7 @@ With that said, here are some guidelines to some common bottlenecks:
   If you need more instances of each service, spin them up separately with different command line arguments. You can learn more cross referencing [our Helm chart](https://github.com/temporalio/helm-charts) with our [Server Configuration reference](https://docs.temporal.io/docs/server/configuration/).
 - See the **Server Limits** section below for other limits you will want to keep in mind when doing system design, including event history length.
 
-### Scaling Workflow and Activity Workers
-
-Finally you want to set up alerting and monitoring on Worker metrics.
-When Workers are able to keep up, `schedule_to_start_latency` is close to zero.
-The default is 4 Workers (each of which can have 2-4 pollers of Task Queues), which should handle no more than 300 messages per second.
-
-Specifically, the primary scaling metrics are located in the server's dynamic configs:
-
-- `MaxConcurrentActivityTaskPollers` and `MaxConcurrentWorkflowTaskPollers`: [Defaults to 4](https://github.com/temporalio/temporal/blob/fe05751305b1cb50b68efa23f8aa5f1b34f45bc5/service/worker/service.go#L121)
-- `MaxConcurrentActivityExecutionSize` and `MaxConcurrentWorkflowTaskExecutionSize`: [Defaults to 200](https://github.com/temporalio/sdk-java/blob/bef967639fcdbe14ca37b80ac816596412846e5f/temporal-sdk/src/main/java/io/temporal/worker/WorkerOptions.java#L51)
-
-Scaling will depend on your workload — for example, for a Task Queue with 500 messages per second, you might want to scale up to 10 pollers.
-Provided you tune the concurrency of your pollers based on your application, it should be possible to scale them based on standard resource utilization metrics (CPU, Memory, etc).
-
-**It's possible to have too many workers.**
-Monitor the poll success (`poll_success`/`poll_success_sync`) and `poll_timeouts` metrics:
-
-- `poll_success_sync` indicates a "sync match", i.e. a poller waiting for a task to appear, isntead of a task waiting for a poller to appear.
-- Poll Success should be >90% in most cases - for high volume and low latency, try to target >95%
-- if you see low `schedule_to_start_latency` / low percentage of poll success / high percentage of timeouts, you might have too many workers/pollers.
-- with 100% poll success and increasing `schedule_to_start_latency`, you need to scale up.
+Please see the dedicated docs on [Tuning and Scaling Workers](/docs/operation/how-to-tune-workers).
 
 ## FAQs
 


### PR DESCRIPTION
## What does this PR do?

Moved Workers scaling info and specifically **It's possible to have too many Workers** point from Server docs into Workers Tuning Guide.
Replace the Workers tuning instruction with the Workers Tuning Guide link in the Server docs.