### PR TITLE
Correct paths to TLS sample key and cert

### DIFF
--- a/docs/server/configuration.md
+++ b/docs/server/configuration.md
@@ -60,7 +60,7 @@ Each of these subsections contain a `server` section and a `client` section. The
 - `clientCaFiles` - A list of paths to files containing the PEM-encoded public key of the Certificate Authorities you wish to trust for client authentication. This value is ignored if `requireClientAuth` is not enabled.
 
 :::tip
-See the [customization samples repo](https://github.com/temporalio/customization-samples/tree/master/tls) for sample TLS configurations.
+See the [server samples repo](https://github.com/temporalio/samples-server/tree/master/tls) for sample TLS configurations.
 :::
 
 Below is an example enabling Server TLS (https) between SDKs and the Frontend APIs:

--- a/docs/server/security.md
+++ b/docs/server/security.md
@@ -49,7 +49,7 @@ To prevent spoofing and [MITM attacks](https://en.wikipedia.org/wiki/Man-in-the-
 This enables established connections to authenticate the endpoint, ensuring that the server certificate presented to any connecting client has the given server name in its CN property.
 It can be used for both `internode` and `frontend` endpoints.
 
-More guidance on mTLS setup can be found in [the `customization-samples` repo](https://github.com/temporalio/customization-samples/tree/master/tls) and you can reach out to us for further guidance.
+More guidance on mTLS setup can be found in [the `samples-server` repo](https://github.com/temporalio/samples-server/tree/master/tls) and you can reach out to us for further guidance.
 
 ### Client connections
 

--- a/docs/typescript/security.md
+++ b/docs/typescript/security.md
@@ -196,8 +196,8 @@ Follow this tutorial for setting up mTLS (Mutual TLS authentication) with Tempor
 **For Temporal Cloud customers, there is a separate tutorial above.**
 
 1. Set up Temporal Server with mTLS encryption locally
-   - Clone the [customization samples repo](https://github.com/temporalio/customization-samples/) and change to the `tls/tls-simple` directory
-   - Follow [these instructions](https://github.com/temporalio/customization-samples/tree/master/tls/tls-simple#readme) to set up a local server with mTLS
+   - Clone the [server samples repo](https://github.com/temporalio/samples-server/) and change to the `tls/tls-simple` directory
+   - Follow [these instructions](https://github.com/temporalio/samples-server/tree/master/tls/tls-simple#readme) to set up a local server with mTLS
    - The sample does not register the default namespace on startup, register it with: `docker exec -it tls-simple_temporal-admin-tools_1 tctl n re --retention 1 default`
 1. Configure your Temporal Client and Worker to connect with mTLS
    - Scaffold a new Temporal project with `npx @temporalio/create@latest` using the `hello-world-mtls` template, or copy the relevant configuration from the snippets below into an existing project.
@@ -205,10 +205,10 @@ Follow this tutorial for setting up mTLS (Mutual TLS authentication) with Tempor
      ```bash
      export TEMPORAL_ADDRESS=localhost
      export TEMPORAL_NAMESPACE=default
-     export TEMPORAL_CLIENT_CERT_PATH=/path/to/customization-samples/tls/tls-simple/certs/client.pem
-     export TEMPORAL_CLIENT_KEY_PATH=/path/to/customization-samples/tls/tls-simple/certs/client.key
+     export TEMPORAL_CLIENT_CERT_PATH=/path/to/samples-server/tls/tls-simple/certs/client.pem
+     export TEMPORAL_CLIENT_KEY_PATH=/path/to/samples-server/tls/tls-simple/certs/client.key
      # just for the local mTLS sample
-     export TEMPORAL_SERVER_ROOT_CA_CERT_PATH=/path/to/customization-samples/tls/tls-simple/certs/ca.cert
+     export TEMPORAL_SERVER_ROOT_CA_CERT_PATH=/path/to/samples-server/tls/tls-simple/certs/ca.cert
      export TEMPORAL_SERVER_NAME_OVERRIDE=tls-sample
      ```
 1. Test the connection with `npm run start.watch` and `npm run workflow`.


### PR DESCRIPTION
## What does this PR do?

Corrects the script that set Typescript TLS env variables
https://docs.temporal.io/docs/typescript/security/#local-mtls-sample-tutorial

incorrect version:
![image](https://user-images.githubusercontent.com/11838981/154614304-c0e87cba-0200-4122-9af7-58c78ffeaad5.png)

## Notes to reviewers

<!-- delete if n/a -->
