### PR TITLE
Add Workflow default Retry Policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ To ensure that each change is relevant and properly peer reviewed, we request th
 This means that if you are outside the Temporal organization, you must fork the repository and create pull requests from branches on your own fork.
 GitHub's [first-contributions repo README](https://github.com/firstcontributions/first-contributions) provides an example of how to do that.
 
-When it comes to crafting content, please follow our [style guidelines](style-guidance).
+When it comes to crafting content, please follow our [style guidance](#style-guidance).
 
 ## Preview changes locally
 

--- a/docs/concepts/what-is-a-retry-policy.md
+++ b/docs/concepts/what-is-a-retry-policy.md
@@ -43,13 +43,25 @@ There are some subtle nuances to how Events are recorded to an Event History whe
   But the first Workflow Task won't be scheduled until the backoff duration is exhausted.
   That duration is recorded as the `firstWorkflowTaskBackoff` field of the new run's `WorkflowExecutionStartedEventAttributes` event.
 
-### Default values for Retry Policy\*\*
+### Default Values
+
+#### Default Activity Retry Policy
 
 ```
 Initial Interval     = 1 second
 Backoff Coefficient  = 2.0
 Maximum Interval     = 100 × Initial Interval
 Maximum Attempts     = ∞
+Non-Retryable Errors = []
+```
+
+#### Default Workflow Retry Policy
+
+```
+Initial Interval     = 1 second
+Backoff Coefficient  = 2.0
+Maximum Interval     = 100 × Initial Interval
+Maximum Attempts     = 1
 Non-Retryable Errors = []
 ```
 

--- a/docs/concepts/what-is-a-retry-policy.md
+++ b/docs/concepts/what-is-a-retry-policy.md
@@ -43,7 +43,7 @@ There are some subtle nuances to how Events are recorded to an Event History whe
   But the first Workflow Task won't be scheduled until the backoff duration is exhausted.
   That duration is recorded as the `firstWorkflowTaskBackoff` field of the new run's `WorkflowExecutionStartedEventAttributes` event.
 
-### Default Values
+### Default values for Retry Policy
 
 #### Activities Retry Policy
 

--- a/docs/concepts/what-is-a-retry-policy.md
+++ b/docs/concepts/what-is-a-retry-policy.md
@@ -43,9 +43,7 @@ There are some subtle nuances to how Events are recorded to an Event History whe
   But the first Workflow Task won't be scheduled until the backoff duration is exhausted.
   That duration is recorded as the `firstWorkflowTaskBackoff` field of the new run's `WorkflowExecutionStartedEventAttributes` event.
 
-### Default values for Retry Policy
-
-#### Activities Retry Policy
+### Default Values for Retry Policy
 
 ```
 Initial Interval     = 1 second
@@ -54,10 +52,6 @@ Maximum Interval     = ∞
 Maximum Attempts     = ∞
 Non-Retryable Errors = []
 ```
-
-#### Workflow Execution Retry Policy
-
-There is no default Workflow Execution Retry Policy: unless the Client specifies a Retry Policy when it starts the Workflow Execution, the Execution will not be retried.
 
 ### Initial Interval
 

--- a/docs/concepts/what-is-a-retry-policy.md
+++ b/docs/concepts/what-is-a-retry-policy.md
@@ -45,25 +45,19 @@ There are some subtle nuances to how Events are recorded to an Event History whe
 
 ### Default Values
 
-#### Default Activity Retry Policy
+#### Activities Retry Policy
 
 ```
 Initial Interval     = 1 second
 Backoff Coefficient  = 2.0
-Maximum Interval     = 100 × Initial Interval
+Maximum Interval     = ∞
 Maximum Attempts     = ∞
 Non-Retryable Errors = []
 ```
 
-#### Default Workflow Retry Policy
+#### Workflow Execution Retry Policy
 
-```
-Initial Interval     = 1 second
-Backoff Coefficient  = 2.0
-Maximum Interval     = 100 × Initial Interval
-Maximum Attempts     = 1
-Non-Retryable Errors = []
-```
+There is no default Workflow Execution Retry Policy: unless the Client specifies a Retry Policy when it starts the Workflow Execution, the Execution will not be retried.
 
 ### Initial Interval
 

--- a/docs/concepts/what-is-a-retry-policy.md
+++ b/docs/concepts/what-is-a-retry-policy.md
@@ -43,7 +43,7 @@ There are some subtle nuances to how Events are recorded to an Event History whe
   But the first Workflow Task won't be scheduled until the backoff duration is exhausted.
   That duration is recorded as the `firstWorkflowTaskBackoff` field of the new run's `WorkflowExecutionStartedEventAttributes` event.
 
-### Default Values for Retry Policy
+### Default values for Retry Policy
 
 ```
 Initial Interval     = 1 second


### PR DESCRIPTION
I don't actually know all the default values, so someone please edit this. I just know that by default, failed Workflow Executions don't get retried.