### PR TITLE
Add missing export and make the parameter to getHandle more clear

### DIFF
--- a/docs/typescript/tutorial-subscription.md
+++ b/docs/typescript/tutorial-subscription.md
@@ -169,7 +169,7 @@ To invoke the Signal from here, we have to get a handle to the running Workflow 
 import { cancelSubscription } from '../workflows';
 // ...
 
-const handle = client.getHandle('business-meaningful-id'); // match the workflow id
+const handle = client.getHandle('business-meaningful-id'); // match the Workflow id
 await handle.signal(cancelSubscription);
 ```
 

--- a/docs/typescript/tutorial-subscription.md
+++ b/docs/typescript/tutorial-subscription.md
@@ -139,7 +139,7 @@ const acts = wf.proxyActivities<typeof activities>({
   startToCloseTimeout: '1 minute',
 });
 
-const cancelSubscription = wf.defineSignal('cancelSignal'); // new
+export const cancelSubscription = wf.defineSignal('cancelSignal'); // new
 
 export async function SubscriptionWorkflow(
   email: string,
@@ -169,7 +169,7 @@ To invoke the Signal from here, we have to get a handle to the running Workflow 
 import { cancelSubscription } from '../workflows';
 // ...
 
-const handle = client.getHandle('SubscriptionsWorkflow'); // match the name
+const handle = client.getHandle('business-meaningful-id'); // match the workflow id
 await handle.signal(cancelSubscription);
 ```
 


### PR DESCRIPTION
## What does this PR do?
Fixes a missing export of a signal subscription.
Uses the example of `business-meaningful-id` from previous client example to make the `getHandle` arg more clear.
