### PR TITLE
Update Retry Policies link

### DIFF
--- a/blog/2021-06-22-activity-timeouts.md
+++ b/blog/2021-06-22-activity-timeouts.md
@@ -19,7 +19,7 @@ One benefit of moving business logic to Temporal is how Temporal implements retr
 
 This post (together with the embedded talk) aims to give you a solid mental model on what each Activity timeout does and when to use it.
 
-> Note: You can also set [Workflow timeouts](https://docs.temporal.io/docs/concepts/workflows#timeout-settings) and [retry policies](https://docs.temporal.io/docs/concepts/activities#retries) you can set. This post deals only with *Activity* timeouts.
+> Note: You can also set [Workflow timeouts](https://docs.temporal.io/docs/concepts/workflows#timeout-settings) and [Retry Policies](https://docs.temporal.io/docs/concepts/what-is-a-retry-policy) you can set. This post deals only with *Activity* timeouts.
 
 ## Talk version: whiteboard session
 


### PR DESCRIPTION
## What does this PR do?
The previous Retry Policies link sent users to the [Activities](https://docs.temporal.io/docs/concepts/what-is-an-activity/#retries) page and Retries section. 

The Retries section on that page does not exist. I suggest that the user guide sends users to the [Retry Policy](https://docs.temporal.io/docs/concepts/what-is-a-retry-policy) page.
## Notes to reviewers 

<!-- delete if n/a -->
