### PR TITLE
Go heartbeat example refers to nonexistent binding

### DIFF
--- a/docs/go/how-to-heartbeat-an-activity-in-go.md
+++ b/docs/go/how-to-heartbeat-an-activity-in-go.md
@@ -12,7 +12,7 @@ To [Heartbeat](/docs/concepts/what-is-an-activity-heartbeat) in an Activity, use
 
 ```go
 progress := 0
-for hasWork {
+for progress < 100 {
     // Send heartbeat message to the server.
     activity.RecordHeartbeat(ctx, progress)
     // Do some work.


### PR DESCRIPTION
A user on slack was confused by the first sample. 

Understandable since it refers to a nonexistent binding `hasWork`. This fixes that.