### PR TITLE
Clarify that all providers use Tally's interface

### DIFF
--- a/docs/server/production-deploy.md
+++ b/docs/server/production-deploy.md
@@ -83,7 +83,7 @@ Please [consult our configuration docs](https://docs.temporal.io/docs/server/con
 The requirements of your Temporal system will vary widely based on your intended production workload.
 You will want to run your own proof of concept tests and watch for key metrics to understand the system health and scaling needs.
 
-- **[Configure your metrics subsystem](https://docs.temporal.io/docs/server/configuration/#metrics).** Temporal supports three metrics providers out of the box: [StatsD](https://github.com/statsd/statsd), [Prometheus](https://prometheus.io/), and [M3](https://m3db.io/), via [Uber's Tally](https://github.com/uber-go/tally) interface.
+- **[Configure your metrics subsystem](https://docs.temporal.io/docs/server/configuration/#metrics).** Temporal supports three metrics providers out of the box via [Uber's Tally](https://github.com/uber-go/tally) interface: [StatsD](https://github.com/statsd/statsd), [Prometheus](https://prometheus.io/), and [M3](https://m3db.io/).
   Tally offers [extensible custom metrics reporting](https://github.com/uber-go/tally#report-your-metrics), which we expose via [`temporal.WithCustomMetricsReporter`](https://docs.temporal.io/docs/server/options/#withcustommetricsreporter).
   OpenTelemetry support is planned in future.
 - **Set up monitoring.** You can use these [Grafana dashboards](https://github.com/temporalio/dashboards) as a starting point.


### PR DESCRIPTION
When reading the sentence, it sounded like only M3 relies on Tally, while the reality is that all the providers use it (as far as I understand the code).

## What does this PR do?
Clarify a sentence, to help other devs navigate Temporal's code faster.