### PR TITLE
Update docs for tctl workflow count

### DIFF
--- a/docs/tctl/workflow/count.md
+++ b/docs/tctl/workflow/count.md
@@ -28,5 +28,5 @@ Alias: `-q`
 To count all open [Workflow Executions](/docs/concepts/what-is-a-workflow-execution):
 
 ```bash
-tctl workflow count --query 'CloseTime = missing'; 'WorkflowType="wtype" and CloseTime > 0'
+tctl workflow count --query 'ExecutionStatus="Running"';
 ```

--- a/docs/tctl/workflow/count.md
+++ b/docs/tctl/workflow/count.md
@@ -28,5 +28,5 @@ Alias: `-q`
 To count all open [Workflow Executions](/docs/concepts/what-is-a-workflow-execution):
 
 ```bash
-tctl workflow count --query 'ExecutionStatus="Running"';
+tctl workflow count --query 'ExecutionStatus="Running"'
 ```


### PR DESCRIPTION
Update count.md. I believe this is actually the correct syntax to check for active workflows. The original text, which comes directly from tctl help definitely does not work as written and produces an extremely slow query. I believe its intent was to search for executions where the close time was _missing_. But it seems much more sensible and crazy faster to search for ExecutionStatus="Running". I validated this command works in my environment. 

## What does this PR do?

## Notes to reviewers

<!-- delete if n/a -->
