### PR TITLE
Update docs to use public alias for workflow.Execution

### DIFF
--- a/docs/go/how-to-spawn-a-child-workflow-execution-in-go.md
+++ b/docs/go/how-to-spawn-a-child-workflow-execution-in-go.md
@@ -88,7 +88,7 @@ func YourWorkflowDefinition(ctx workflow.Context, params ParentParams) (ParentRe
 
   childWorkflowFuture := workflow.ExecuteChildWorkflow(ctx, YourOtherWorkflowDefinition, ChildParams{})
   // Wait for the Child Workflow Execution to spawn
-  var childWE WorkflowExecution
+  var childWE workflow.Execution
   if err := childWorkflowFuture.GetChildWorkflowExecution().Get(ctx, &childWE); err != nil {
      return err
   }


### PR DESCRIPTION
## What does this PR do?

In the docs describing the async use of `ChildWorkflowExecution`, there is a reference to a type
called `WorkflowExecution`.  This is available in `internal`, but when it is exported through the `workflow`
package, it is actually renamed to `workflow.Execution`.

See: https://github.com/temporalio/sdk-go/blob/c453756356db4e5ae9fcabd416a6a8e57db5cc35/workflow/workflow.go#L45

## Notes to reviewers

A PR to apply the same change to the docstring is here: https://github.com/temporalio/sdk-go/pull/752