### PR TITLE
Add /build to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@
 blog
 .docusaurus
 .github
+/build


### PR DESCRIPTION
`npm run format` was formatting a lot of build js files.