### PR TITLE
doc(workers): fix wrong class name used in sample code

### DIFF
--- a/docs/java/workers.md
+++ b/docs/java/workers.md
@@ -51,7 +51,7 @@ WorkerFactory factory = WorkerFactory.newInstance(client);
 
 Worker worker = factory.newWorker(TASK_QUEUE_NAME);
 
-worker.registerWorkflowImplementationTypes(GreetingWorkflowImpl.class);
+worker.registerWorkflowImplementationTypes(EmployeeWorkflowImpl.class);
 ```
 
 Note that in order to execute our `EmployeeWorkflowImpl` Workflow implementation, there is no need to register any Activities.


### PR DESCRIPTION
## What does this PR do?

Fix documentation typo in workers page for java

## Notes to reviewers

<!-- delete if n/a -->
