### PR TITLE
(easy) go mod => go mod tidy?

### DIFF
--- a/docs/go/hello-world-tutorial.md
+++ b/docs/go/hello-world-tutorial.md
@@ -106,7 +106,7 @@ Add the required `testify` packages to your `go.mod` file by running the followi
 ```
 go get github.com/stretchr/testify/mock
 go get github.com/stretchr/testify/require
-go mod
+go mod tidy
 ```
 
 Run this command from the project root to execute the unit tests:


### PR DESCRIPTION
I'm pretty new to go but when I run 'go mod' as part of the tutorial I get a generic printout since I'm missing a command. Does the tutorial mean to say that 'go mod tidy' should be run?

## What does this PR do?

Updates 'go mod' in the tutorial to 'go mod tidy'
