### PR TITLE
Reference the correct variable name

### DIFF
--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -476,7 +476,7 @@ Arguments for both are sent as needed.
 ```ts
 // Signal With Start in Client file
 const client = new WorkflowClient();
-await workflow.signalWithStart(MyWorkflow, {
+await client.signalWithStart(MyWorkflow, {
   workflowId,
   args: [arg1, arg2],
   signal: MySignal,


### PR DESCRIPTION
## What does this PR do?
References `client` instead of undefined `workflow`. This clears up that it is not a function defined on the `@temporalio/workflow` package but on the client.

## Notes to reviewers

<!-- delete if n/a -->
