### PR TITLE
Typos and trailing words

### DIFF
--- a/docs/typescript/cancellation-scopes.md
+++ b/docs/typescript/cancellation-scopes.md
@@ -21,7 +21,7 @@ Other APIs you can use:
 - `CancellationScope.current()`: get the current scope
 - `scope.cancel()`: cancel all operations inside a `scope`
 - `scope.run(fn)`: run an async function within a `scope`, returns the result of `fn`
-- `scope.cancelRequested`: a promise that resolves when a scope cancellation is requested, e.g when Workflow code calls `cancel()` or the entire Workflow is cancelled by an external client.
+- `scope.cancelRequested`: a promise that resolves when a scope cancellation is requested, e.g. when Workflow code calls `cancel()` or the entire Workflow is cancelled by an external client.
 
 When a `CancellationScope` is cancelled, it propagates cancellation in any child scopes and of any _cancellable operations_ created within it, such as:
 

--- a/docs/typescript/clients.md
+++ b/docs/typescript/clients.md
@@ -10,27 +10,27 @@ import * as WhatIsATemporalCronJob from '../concepts/what-is-a-temporal-cron-job
 
 **`@temporalio/client`** [![NPM](https://img.shields.io/npm/v/@temporalio/client)](https://www.npmjs.com/package/@temporalio/client) [API reference](https://typescript.temporal.io/api/namespaces/client) | [GitHub](https://github.com/temporalio/sdk-typescript/tree/main/packages/client)
 
-**Workflow Clients are embedded in your application code, and connect to Temporal Server via gRPC**.
+**Workflow Clients are embedded in your application code and connect to Temporal Server via gRPC**.
 They are the only way to schedule new Workflow Executions with Temporal Server.
 
 - Workflow Clients can run in any Node.js application, for example, in a serverless function, Express.js API route handler or CLI/script run.
 - The primary use of Workflow Clients is to start new Workflow Executions (including [Cron Workflows](#scheduling-cron-workflows)).
   Given a `workflowId`, a Workflow Client can also get a Handle to a running Workflow Execution or retrieve/wait for its result.
 - **Workflow Handles** are bindings to specific Workflow Executions that expose more APIs for control.
-  **We strongly recommend familiarising yourself with Workflow Handle APIs** because they are the main way you will signal, query, describe, cancel, terminate and await the result of running Workflow Executions.
+  **We strongly recommend familiarizing yourself with Workflow Handle APIs** because they are the main way you will signal, query, describe, cancel, terminate, and await the result of running Workflow Executions.
 - Advanced users can also use the `WorkflowService` exposed by a Workflow Client to make **raw gRPC calls** (usually for introspection).
 
-Workflow Clients are separate from Workers, but communicate with them via Task Queues to start Workflow Executions.
+Workflow Clients are separate from Workers, but communicate with them through Task Queues to start Workflow Executions.
 For more information, see [Workers and Task Queues in TypeScript](/docs/typescript/workers) and [Workflows in TypeScript](/docs/typescript/workflows).
 
 ## Full Example
 
-Here is example WorkflowClient code from our Hello World sample:
+The following code is a `WorkflowClient` example, from our Hello World sample:
 
 <!--SNIPSTART typescript-hello-client {"enable_source_link": false}-->
 <!--SNIPEND-->
 
-The rest of this doc explains each step in detail with practical usage tips.
+The rest of this document explains each step in detail with practical usage tips.
 
 ## Create a new Workflow Client
 
@@ -42,11 +42,11 @@ const connection = new Connection(); // to configure for production
 const client = new WorkflowClient(connection.service);
 ```
 
-If you omit the connection and just call `new WorkflowClient()`, it creates a default connection that will work locally. Just remember you will need to configure your Connection and namespace when [deploying to production](/docs/typescript/security#encryption-in-transit-with-mtls).
+If you omit the connection and just call `new WorkflowClient()`, it creates a default connection that will work locally. Just remember you will need to configure your Connection and Namespace when [deploying to production](/docs/typescript/security#encryption-in-transit-with-mtls).
 
 ## Start a Workflow Execution
 
-When you have a Workflow Client, you can schedule the start of a workflow with `client.start`, specifying `workflowId`, `taskQueue`, and `args` and returning a Workflow Handle (see below) immediately after the Server acknowledges receipt.
+When you have a Workflow Client, you can schedule the start of a Workflow with `client.start`, specifying `workflowId`, `taskQueue`, and `args` and returning a Workflow Handle (see below) immediately after the Server acknowledges receipt.
 
 ```ts
 // // STEP ONE: client.start
@@ -99,10 +99,12 @@ A brief guide to the [WorkflowOptions](https://typescript.temporal.io/api/interf
   - `cronSchedule` (see important notes in [Cron Workflows](#scheduling-cron-workflows) section below)
 - Advanced features you probably won't need: `followRuns` and `workflowIdReusePolicy`.
 
-:::caution Workflow-level Retries and Timeouts not recommended
+:::caution
+
+Workflow-level Retries and Timeouts are not recommended.
 
 You will see that there are `workflowRunTimeout`, `workflowExecutionTimeout`, `workflowTaskTimeout`, and `retryPolicy` options in [WorkflowOptions](https://typescript.temporal.io/api/interfaces/client.WorkflowOptions).
-We strongly recommend not using them unless you know what you are doing.
+We discourage using them unless you know what you are doing.
 Do not rely on Workflows to timeout or fail - you probably want to push this logic down to an Activity instead.
 
 :::
@@ -130,13 +132,13 @@ The [Workflow Handle APIs](https://typescript.temporal.io/api/interfaces/client.
 | Handle API      | Description                                                                                                                               |
 | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
 | `client`        | Readonly accessor to the underlying WorkflowClient.                                                                                       |
-| `workflowId`    | The workflowId of the current Workflow.                                                                                                   |
-| `originalRunId` | The runId of the initial run of the bound Workflow.                                                                                       |
+| `workflowId`    | The `workflowId` of the current Workflow.                                                                                                 |
+| `originalRunId` | The `runId` of the initial run of the bound Workflow.                                                                                     |
 | `query()`       | Call to query a Workflow after it's been started even if it has already completed. `const value = await handle.query(getValue, ...args);` |
 | `signal()`      | Call to signal a _running_ Workflow. `await handle.signal(increment, ...args);`                                                           |
-| `cancel()`      | Cancel a running Workflow.                                                                                                                |
-| `terminate()`   | Terminate a running Workflow                                                                                                              |
-| `describe()`    | Describe the current workflow execution                                                                                                   |
+| `cancel()`      | Cancels a running Workflow.                                                                                                               |
+| `terminate()`   | Terminates a running Workflow                                                                                                             |
+| `describe()`    | Describes the current Workflow execution                                                                                                  |
 | `result()`      | Promise that resolves when Workflow execution completes                                                                                   |
 
 The following covers how to use many of these APIs, you will want to be fluent with them as they cover the basics of Workflow manipulation.
@@ -145,7 +147,7 @@ The following covers how to use many of these APIs, you will want to be fluent w
 
 Workflow functions may or may not return a result when they complete.
 
-If you started a Workflow with `handle.start`, you can choose to wait for the result anytime with `handle.result()`. This
+If you started a Workflow with `handle.start`, you can choose to wait for the result anytime with `handle.result()`.
 
 ```ts
 const handle = client.getHandle(workflowId);
@@ -156,6 +158,7 @@ Using a Workflow Handle isn't necessary with `client.execute` by definition.
 
 - **Don't forget to handle errors here.**
   If you call `result()` on a Workflow that prematurely ended for some reason, it throws a [WorkflowFailedError](https://typescript.temporal.io/api/classes/client.WorkflowFailedError) error that reflects that reason.
+
   ```ts
   const handle = client.getHandle(workflowId);
   try {
@@ -172,6 +175,7 @@ Using a Workflow Handle isn't necessary with `client.execute` by definition.
     }
   }
   ```
+
 - You can also specify a `runId`, but you will almost never need it, because most people only want the results of the latest run (a Workflow may run multiple times if failed or continued as new).
 
 ### Cancel a Workflow
@@ -251,7 +255,7 @@ export async function example(WFname: string, args: string[]): Promise<string> {
 
 You should use [cancellationScopes](/docs/typescript/cancellation-scopes) if you need to cancel Child Workflows.
 
-The same concept of "Workflow Handles" applies to retrieving handles for Child and External Workflows—as long as you have the Workflow ID:
+The same concept of "Workflow Handles" applies to retrieving handles for Child and External Workflows—as long as you have the Workflow Id:
 
 ```ts
 // inside Workflow code

--- a/docs/typescript/determinism.md
+++ b/docs/typescript/determinism.md
@@ -24,7 +24,7 @@ export async function ExampleWorkflow() {
 ```
 
 For this to be possible, Workflow code must be completely deterministic, meaning it does the exact same thing every time it is rerun.
-Determinism brings limitations: you can't just call an external service, get the current time, or generate a random number, as these are all dependant on the state of the world at the time they're called, and may produce different values.
+Determinism brings limitations: you can't just call an external service, get the current time, or generate a random number, as these are all dependent on the state of the world at the time they're called, and may produce different values.
 The Temporal SDKs come with a set of tools that allow you to overcome these limitations.
 
 ### How a Workflow is executed
@@ -32,7 +32,7 @@ The Temporal SDKs come with a set of tools that allow you to overcome these limi
 The Temporal TypeScript SDK runs each Workflow in a separate v8 isolate — a "sandbox" environment using Node's built in `vm` with its own global variables, just like in the browser.
 
 - When we need to defer execution (such as for a timer or activity), we simply destroy the `vm` context.
-- When we need to continue execution, Temporal Server sends over the Event History and we replay through the code from the start until the end to restore state.
+- When we need to continue execution, Temporal Server sends over the Event History, and we replay through the code from the start until the end to restore state.
   - The serialization takes time, which is why we recommend keeping Event History [under 10,000 events](/docs/server/production-deployment/#server-limits). ["Sticky" optimizations exist to make this faster for common situations](/docs/concepts/what-is-a-sticky-execution).
   - If the execution logic has changed enough to affect Event History, you need to [patch new code](/docs/typescript/patching).
 - The Workflow runtime is completely deterministic: functions like `Math.random`, `Date`, and `setTimeout` are replaced by deterministic versions, and the only way for a Workflow to interact with the world is via Activities.

--- a/docs/typescript/failures.md
+++ b/docs/typescript/failures.md
@@ -74,7 +74,7 @@ The expected behavior is:
 
 ### Pattern: Wrapping Errors with Interceptors
 
-To make other error types fail the workflow, use the WorkflowInboundCallsInterceptor methods (`execute` and `handleSignal`) to catch errors thrown from the Workflow and convert them to `ApplicationFailures`, e.g:
+To make other error types fail the workflow, use the `WorkflowInboundCallsInterceptor` methods (`execute` and `handleSignal`) to catch errors thrown from the Workflow and convert them to `ApplicationFailures`, e.g:
 
 ```ts
 async function wrapError<T>(fn: () => Promise<T>): Promise<T> {

--- a/docs/typescript/interceptors.md
+++ b/docs/typescript/interceptors.md
@@ -20,7 +20,7 @@ The TypeScript SDK comes with an optional interceptor package that adds tracing 
 
 ## How interceptors work
 
-Interceptors are run in a chain, all of the interceptors work in a similar manner, they accept 2 arguments: `input` and `next` where `next` calls the next interceptor in the chain.
+Interceptors are run in a chain, all the interceptors work similarly, they accept 2 arguments: `input` and `next` where `next` calls the next interceptor in the chain.
 All interceptor methods are optional—it's up to the implementor to choose which methods to intercept.
 
 ## Interceptor examples
@@ -101,13 +101,13 @@ Please contact us if you need to discuss this further.
 
 ### Activity and client interceptors registration
 
-- Activity interceptors are registered on Worker creation by passing an array of [`ActivityInboundCallsInterceptor` factory functions](https://typescript.temporal.io/api/interfaces/worker.activityinboundcallsinterceptorfactory) via [WorkerOptions](https://typescript.temporal.io/api/interfaces/worker.workeroptions#interceptors).
+- Activity interceptors are registered on Worker creation by passing an array of [`ActivityInboundCallsInterceptor` factory functions](https://typescript.temporal.io/api/interfaces/worker.activityinboundcallsinterceptorfactory) through [WorkerOptions](https://typescript.temporal.io/api/interfaces/worker.workeroptions#interceptors).
 
 - Client interceptors are registered on `WorkflowClient` construction by passing an array of [`WorkflowClientCallsInterceptor` factory functions](https://typescript.temporal.io/api/interfaces/client.workflowclientcallsinterceptorfactory) via [WorkflowClientOptions](https://typescript.temporal.io/api/interfaces/client.workflowclientoptions#interceptors).
 
 ### Workflow interceptors registration
 
-Workflow interceptor registration is different than the other interceptors because they run in the Workflow isolate. To register Workflow interceptors, export an `interceptors` function from a file located in the `workflows` directory and provide the name of that file to the Worker on creation via [WorkerOptions](https://typescript.temporal.io/api/interfaces/worker.workeroptions#interceptors).
+Workflow interceptor registration is different from the other interceptors because they run in the Workflow isolate. To register Workflow interceptors, export an `interceptors` function from a file located in the `workflows` directory and provide the name of that file to the Worker on creation via [WorkerOptions](https://typescript.temporal.io/api/interfaces/worker.workeroptions#interceptors).
 
 At the time of construction, the Workflow Context is already initialized for the current Workflow.
 Use [`workflowInfo`](https://typescript.temporal.io/api/namespaces/workflow#workflowinfo) to add Workflow specific information in the interceptor.

--- a/docs/typescript/introduction.md
+++ b/docs/typescript/introduction.md
@@ -205,7 +205,7 @@ For long form/FAQs, please search and ask on [the Temporal community forum](http
 
 ## TS SDK Intro Workshop
 
-We held a 2hr intro workshop explaining every core concept from scratch:
+We held a 2-hour introduction workshop explaining every core concept from scratch:
 
 <div style={{width: 500, maxWidth: "100%"}}>
   <ResponsivePlayer url='https://www.youtube.com/watch?v=CeHSmv8oF_4&feature=youtu.be' />
@@ -225,4 +225,4 @@ Timestamps:
 - [01:45:19](https://www.youtube.com/watch?v=CeHSmv8oF_4&t=6319s) Recap and Q&A
 
 And of course you can [join the #typescript-sdk channel](https://temporal.io/slack) to ask any questions as you get set up.
-Design partners are already [putting us in production](https://youtu.be/GpbOkDjpeYU) and we are eager to hear your feedback.
+Design partners are already [putting us in production](https://youtu.be/GpbOkDjpeYU), and we are eager to hear your feedback.

--- a/docs/typescript/logging.md
+++ b/docs/typescript/logging.md
@@ -95,7 +95,7 @@ Some important features of the [InjectedSinkFunction](https://typescript.tempora
 
 The injected sink function contributes to the overall workflow task processing duration.
 
-- If you have a long running sink function, such as one that tries to communicate with external services, you might start seeing workflow task timeouts.
+- If you have a long-running sink function, such as one that tries to communicate with external services, you might start seeing workflow task timeouts.
 - The effect is multiplied when using `callDuringReplay: true` and replaying long Workflow histories because the Workflow Task timer starts when the first history page is delivered to the Worker.
 
 ## Logging in Workers and Clients

--- a/docs/typescript/nextjs.md
+++ b/docs/typescript/nextjs.md
@@ -2,11 +2,11 @@
 id: nextjs-tutorial
 title: Integrating Temporal into an Existing Next.js Application
 sidebar_label: Next.js Tutorial
-description: In this tutorial, we'll talk about how Temporal integrates into an existing Next.js application using Next.js API routes. This gives you the ability to write full-stack, long running applications end to end in TypeScript.
+description: In this tutorial, we'll talk about how Temporal integrates into an existing Next.js application using Next.js API routes. This gives you the ability to write full-stack, long-running applications end to end in TypeScript.
 ---
 
 In this tutorial, we'll talk about how Temporal integrates into an **existing Next.js application** using Next.js API routes.
-This gives you the ability to write full-stack, long running applications end to end in TypeScript.
+This gives you the ability to write full-stack, long-running applications end to end in TypeScript.
 
 :::info Notes to user
 

--- a/docs/typescript/package-initializer.md
+++ b/docs/typescript/package-initializer.md
@@ -23,8 +23,8 @@ npx @temporalio/create@latest ./example
   from [github.com/temporalio/samples-typescript](https://github.com/temporalio/samples-typescript) or use a GitHub URL. The URL can have a branch and/or subdirectory: for example, `https://github.com/your-org/your-app/tree/main/foo/bar`.
 - `--list-samples` — List available projects from [our samples repo](https://github.com/temporalio/samples-typescript).
 - `--use-yarn` — Use Yarn instead of npm.
-- `--[no-]git-init` - Initalize an empty git repository
-- `--temporalio-version <version>` - Specify which version of the temporalio npm package to use
+- `--[no-]git-init` - Initialize an empty git repository.
+- `--temporalio-version <version>` - Specify which version of the Temporal npm package to use.
 
 ### Project structure
 

--- a/docs/typescript/patching.md
+++ b/docs/typescript/patching.md
@@ -96,7 +96,7 @@ So we have to keep both the old and new code when migrating Workflows while they
 <summary>30 Min Video: Introduction to Versioning
 </summary>
 
-Because we design for potentially long running workflows at scale, versioning with Temporal works differently than with other workflow systems.
+Because we design for potentially long-running workflows at scale, versioning with Temporal works differently than with other workflow systems.
 We explain more in this optional 30 minute introduction:
 
 import { ResponsivePlayer } from '../../src/components'
@@ -165,4 +165,4 @@ If while we're deploying `v2deprecatedpatch` (below) there are still live Worker
 ## Upgrading Workflow dependencies
 
 Upgrading Workflow dependencies (such as ones installed into `node_modules`) _might_ break determinism in unpredictable ways.
-It is highly recommended to use a lock file (`package-lock.json` or `yarn.lock`) in order to fix Workflow dependency versions and gain control of when they're updated.
+We recommended using a lock file (`package-lock.json` or `yarn.lock`) in order to fix Workflow dependency versions and gain control of when they're updated.

--- a/docs/typescript/production-deploy.md
+++ b/docs/typescript/production-deploy.md
@@ -123,7 +123,7 @@ Here is the [full list of SDK metrics](/docs/reference/sdk-metrics/). Some of th
 
 If you are experiencing system performance issues, make sure that you have checked that the bottleneck is not with your Temporal Cluster before turning to the performance of your Workers.
 
-We endeavor to give you good defaults so you don't have to worry about them, but there are a few key settings you may want to explore if you are pushing system limits:
+We endeavor to give you good defaults, so you don't have to worry about them, but there are a few key settings you may want to explore if you are pushing system limits:
 
 - [Worker Options](https://typescript.temporal.io/api/interfaces/worker.workeroptions/#maxcachedworkflows), for example:
   - `maxCachedWorkflows` to limit Workflow cache size and trade memory for CPU (biggest lever for Worker performance)

--- a/docs/typescript/search-attributes.md
+++ b/docs/typescript/search-attributes.md
@@ -53,7 +53,7 @@ This can be useful for tagging executions with useful attributes you may want to
 ## Future: Upsert Search Attributes during workflow execution
 
 In advanced cases, you may want to dynamically update these attributes as the workflow progresses.
-Temporal has an `UpsertSearchAttributes` capability but it is not yet supported in the TypeScript SDK.
+Temporal has an `UpsertSearchAttributes` capability, but it is not yet supported in the TypeScript SDK.
 
 ## Removing Search Attributes
 

--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -109,7 +109,7 @@ The rest of this document explains the major Workflow APIs you should know:
 - Signals and Queries: `defineSignal`, `defineQuery`, and `setHandler`
 - Deferred Execution: `sleep` and `condition`
 - Child Workflows: `startChild` and `executeChild`
-- Entity (indefinitely long running) Workflows: `continueAsNew`
+- Entity (indefinitely long-running) Workflows: `continueAsNew`
 
 ## Signals and Queries
 
@@ -215,7 +215,7 @@ export function defineQuery<Ret, Args extends any[] = []>(
 Signals/Queries are only instantiated in `setHandler` and are specific to a particular Workflow Execution.
 
 These distinctions may seem minor, but they model how Temporal works under the hood, because Signals and Queries are messages identified by "just strings" and don't have meaning independent of the Workflow having a listener to handle them.
-This will be clearer if you refer to to the Client-side APIs below.
+This will be clearer if you refer to the Client-side APIs below.
 
 #### Why `setHandler` and not OTHER_API?
 


### PR DESCRIPTION
## What does this PR do?
Fixes a variety of typos, trailing words, and punctuation in the TypeScript documentation. 
