### PR TITLE
Await the results of the promise so it can be caught

### DIFF
--- a/docs/typescript/failures.md
+++ b/docs/typescript/failures.md
@@ -128,7 +128,7 @@ export function myWorkflow(urls: string[], timeoutMs: number): Promise<any[]> {
   });
 
   try {
-    return CancellationScope.withTimeout(timeoutMs, () =>
+    return await CancellationScope.withTimeout(timeoutMs, () =>
       Promise.all(urls.map((url) => httpGetJSON(url)))
     );
   } catch (err) {


### PR DESCRIPTION
## What does this PR do?
`await` the promise inside the function so that the `try`/`catch` can handle a thrown cancellation error.