### PR TITLE
use `randomUUID()` instead of `Math.random()` for generating workflow ids

### DIFF
--- a/blog/2022-02-28-temporal-rest.md
+++ b/blog/2022-02-28-temporal-rest.md
@@ -162,7 +162,7 @@ To create a new counter with this Workflow, we would normally send an `increment
 ```ts
 const handle = await client.start(counterWorkflow, {
   taskQueue: 'tutorial',
-  workflowId: 'workflow-' + crypto.randomUUID(),
+  workflowId: 'counter-' + crypto.randomUUID(),
 });
 
 // Increment a new counter

--- a/blog/2022-02-28-temporal-rest.md
+++ b/blog/2022-02-28-temporal-rest.md
@@ -55,7 +55,8 @@ async function run() {
 
   const handle = await client.start(counterWorkflow, {
     taskQueue: 'tutorial',
-    workflowId: 'workflow-' + crypto.randomUUID(),
+    // Usually, we use a business ID. In this example, we don't have one, so we generate an ID.
+    workflowId: 'counter-' + crypto.randomUUID(),
   });
 
   // Increment the counter

--- a/blog/2022-02-28-temporal-rest.md
+++ b/blog/2022-02-28-temporal-rest.md
@@ -48,13 +48,14 @@ To execute an instance of `counterWorkflow`, use `WorkflowClient` to start the W
 ```ts
 import { WorkflowClient } from '@temporalio/client';
 import { counterWorkflow } from './workflows';
+import crypto from 'crypto';
 
 async function run() {
   const client = new WorkflowClient();
 
   const handle = await client.start(counterWorkflow, {
     taskQueue: 'tutorial',
-    workflowId: 'wf-id-' + Math.floor(Math.random() * 1000),
+    workflowId: 'workflow-' + crypto.randomUUID(),
   });
 
   // Increment the counter
@@ -161,7 +162,7 @@ To create a new counter with this Workflow, we would normally send an `increment
 ```ts
 const handle = await client.start(counterWorkflow, {
   taskQueue: 'tutorial',
-  workflowId: 'wf-id-' + Math.floor(Math.random() * 1000),
+  workflowId: 'workflow-' + crypto.randomUUID(),
 });
 
 // Increment a new counter

--- a/docs/php/workers.md
+++ b/docs/php/workers.md
@@ -30,7 +30,7 @@ $worker = $factory->newWorker();
 // Workflows are stateful. So you need a type to create instances.
 $worker->registerWorkflowTypes(App\DemoWorkflow::class);
 
-// Activities are stateless and thread safe. 
+// Activities are stateless and thread safe.
 $worker->registerActivity(App\DemoActivity::class);
 // In case an activity class requires some external dependencies provide a callback - factory
 // that creates or builds a new activity instance. The factory should be a callable which accepts
@@ -38,7 +38,7 @@ $worker->registerActivity(App\DemoActivity::class);
 $worker->registerActivity(App\DemoActivity::class, fn(ReflectionClass $class) => $container->create($class->getClass()));
 // If you want to clean up some resources after activity is done, you may register
 // a finalizer. This callback is called after each activity invocation.
-$worker->registerActivityFinalizer(fn () => $kernel->showtdown()); 
+$worker->registerActivityFinalizer(fn () => $kernel->showtdown());
 
 // start primary loop
 $factory->run();


### PR DESCRIPTION
Re: temporalio/samples-typescript#110

## What does this PR do?

A couple of examples in this blog post use `Math.random()` to generate workflow ids. This is bad practice, we don't want people using `Math.random()` to generate workflow ids in production. This PR uses [Node's built-in `randomUUID()` function](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions) instead to provide unique workflow ids without additional dependencies.

## Notes to reviewers

<!-- delete if n/a -->
