### PR TITLE
Make search attribute Types section

### DIFF
--- a/docs/concepts/what-is-a-search-attribute.md
+++ b/docs/concepts/what-is-a-search-attribute.md
@@ -71,15 +71,6 @@ It is not possible to rename Search Attributes or remove them from the index sch
 
 :::
 
-Search Attributes must be one of the following types:
-
-- Text
-- Keyword
-- Int
-- Double
-- Bool
-- Datetime
-
 The [temporalio/auto-setup](https://hub.docker.com/r/temporalio/auto-setup) Docker image uses a pre-defined set of custom Search Attributes that are handy for testing.
 Their names indicate their types:
 
@@ -89,6 +80,17 @@ Their names indicate their types:
 - CustomDoubleField
 - CustomBoolField
 - CustomDatetimeField
+
+### Types
+
+Search Attributes must be one of the following types:
+
+- Text
+- Keyword
+- Int
+- Double
+- Bool
+- Datetime
 
 Note:
 

--- a/docs/go/how-to-set-startworkflowoptions-in-go.md
+++ b/docs/go/how-to-set-startworkflowoptions-in-go.md
@@ -254,7 +254,7 @@ if err != nil {
 - Type: `map[string]interface{}`
 - Default: Empty.
 
-These are the corresponding Search Attribute value types in Go:
+These are the corresponding [Search Attribute value types](/docs/concepts/what-is-a-search-attribute/#types) in Go:
 
 - Keyword = string
 - Int = int64

--- a/docs/go/search-apis.md
+++ b/docs/go/search-apis.md
@@ -20,7 +20,7 @@ Go samples for Search Attributes can be found at [`temporalio/samples-go`](https
 
 ## Value types
 
-Here are the Search Attribute value types and their corresponding types in Go:
+Here are the [Search Attribute value types](/docs/concepts/what-is-a-search-attribute/#types) and their corresponding types in Go:
 
 - Keyword = string
 - Int = int64


### PR DESCRIPTION
## What does this PR do?

Better surface SA types to address:

> the page here https://docs.temporal.io/docs/go/search-apis/#value-types lists the search-attribute types that temporal support. But I believe its missing information on how the type `text` is different from `keyword`. I have seen a few customers asking about this exact difference.

