### PR TITLE
Use team for CODEOWNERS; add loren to TS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @flossypurse
-/docs @flossypurse @djmagee @aarohib @rachfop @DJSanti
+/docs/ @temporalio/docs
+/docs/typescript/ @temporalio/docs @lorensr
 /blog/ @rylandg


### PR DESCRIPTION
- Use team for CODEOWNERS, so that we don't need to update both GH team and the file
- Adding myself to TS docs, so that I get notified about relevant PRs