### PR TITLE
Add missing connection parameter

### DIFF
--- a/docs/typescript/security.md
+++ b/docs/typescript/security.md
@@ -97,6 +97,7 @@ async function run() {
   });
 
   const worker = await Worker.create({
+    connection,
     namespace: 'foo.bar', // as explained in Namespaces section
     // ...
   });


### PR DESCRIPTION
## What does this PR do?

In the current documentation, you forgot to pass the connection parameter to the worker.
