### PR TITLE
Added notes to Go and TS docs about mutating workflows

### DIFF
--- a/docs/go/how-to-handle-a-query-in-a-workflow-in-go.md
+++ b/docs/go/how-to-handle-a-query-in-a-workflow-in-go.md
@@ -15,7 +15,9 @@ The handler must be a function that returns two values:
 1. A serializable result
 2. An error
 
-The handler function can receive any number of input parameters, but all input parameters must be serializable.
+Do not include Side Effects or command generation within a query handler. This could mutate the Workflow state and lead to unexpected behaviors on subsequent runs.
+
+The handler function can receive any number of input parameters, but all input parameters must be serializable. 
 The following sample code sets up a Query Handler that handles the `current_state` Query type:
 
 ```go

--- a/docs/typescript/workflows.md
+++ b/docs/typescript/workflows.md
@@ -429,7 +429,7 @@ Temporal guarantees read-after-write consistency of Signals-followed-by-Queries.
 
 #### Notes on Queries
 
-> 🚨 WARNING: NEVER mutate Workflow state inside a query! This would be a source of non-determinism.
+> 🚨 WARNING: NEVER mutate Workflow state inside a query! Generating commands in query handlers can lead to unexpected behaviors on subsequent executions.
 
 :::danger How NOT to write a Query
 


### PR DESCRIPTION
Added a note to the Go and TS Workflow docs about not including Side Effects and command generation, and why that would be a bad idea.
