### PR TITLE
avoid hard coded color styles in retry simulator for better dark mode support

### DIFF
--- a/docs/components/RetrySimulator/retry-simulator.module.css
+++ b/docs/components/RetrySimulator/retry-simulator.module.css
@@ -35,7 +35,7 @@
   padding-top: 15px;
   border: 1px solid #ddd;
   margin-bottom: 15px;
-  background-color: #f0f0f0;
+  background-color: var(--ifm-badge-background-color);
 }
 
 .retry {
@@ -59,6 +59,7 @@
 
 .success {
   background-color: #D4EDDC;
+  color: black;
 }
 
 .fail {
@@ -93,7 +94,7 @@
 .dropdown {
   padding: 0.25em 0.5em;
   border: 1px solid #ddd;
-  background-color: white;
+  background-color: var(--ifm-background-color);
   margin-bottom: 1em;
 }
 


### PR DESCRIPTION
## What does this PR do?

Someone pointed out in Slack that the retry simulator had some issues in dark mode. Before:

![image](https://user-images.githubusercontent.com/1620265/165830389-050be4f3-427f-430b-bbad-dcbb6e0af523.png)

After this PR:

![image](https://user-images.githubusercontent.com/1620265/165830431-e8b91c01-0914-4b3d-839e-66d1fa864885.png)


## Notes to reviewers

<!-- delete if n/a -->
