### PR TITLE
Fix error in example code

### DIFF
--- a/docs/go/error-handling.md
+++ b/docs/go/error-handling.md
@@ -29,7 +29,7 @@ if err != nil {
 		applicationErr.Details(&detailMsg) // extract strong typed details
 
 		// handle Activity errors (errors created other than using NewApplicationError() API)
-		switch err.Type() {
+		switch applicationErr.Type() {
 		case "CustomErrTypeA":
 			// handle CustomErrTypeA
 		case CustomErrTypeB:


### PR DESCRIPTION
## What does this PR do?

This PR fixes a documentation error in the example code for Temporal error handling.

The code example does not work as currently presented. `.Type()` needs to be called on the `ApplicationError` instead of the basic `Error`. I have updated the documentation to reflect this.
