### PR TITLE
Clarify Worker activity limit options

### DIFF
--- a/docs/go/how-to-set-workeroptions-in-go.md
+++ b/docs/go/how-to-set-workeroptions-in-go.md
@@ -55,7 +55,7 @@ w := worker.New(c, "your_task_queue_name", workerOptions)
 
 ### `WorkerActivitiesPerSecond`
 
-Rate limits the number of Activity Task Executions per second for the Worker.
+Rate limits the number of Activity Task Executions started per second for the Worker.
 
 - Type: `float64`
 - Default: `100000`
@@ -124,7 +124,7 @@ w := worker.New(c, "your_task_queue_name", workerOptions)
 
 ### `TaskQueueActivitiesPerSecond`
 
-Rate limits the number of Activity Executions that can be executed per second
+Rate limits the number of Activity Executions that can be started per second.
 
 - Type: `float64`
 - Default: `100000`

--- a/docs/operation/how-to-tune-workers.md
+++ b/docs/operation/how-to-tune-workers.md
@@ -89,8 +89,8 @@ then consider increasing the number of pollers by adjusting `maxConcurrentWorkfl
 
 If, after adjusting the poller and executors count as specified earlier, you still observe an elevated `schedule_to_start`, underutilized Worker hosts, or high `worker_task_slots_available`, you might want to check the following:
 
-1. If server-side rate limiting per Task Queue is set by `WorkerOptions#maxTaskQueueActivitiesPerSecond`, remove the limit or adjust the value up. (See [Go](/docs/go/how-to-set-workeroptions-in-go/#taskqueueactivitiespersecond) and [Java](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html).)
-2. If Worker-side rate limiting per Worker is set by `WorkerOptions#maxWorkerActivitiesPerSecond`, remove the limit. (See [Go](/docs/go/how-to-set-workeroptions-in-go/#workeractivitiespersecond), [TypeScript](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#maxconcurrentactivitytaskexecutions), and [Java](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html).)
+- If server-side rate limiting per Task Queue is set by `WorkerOptions#maxTaskQueueActivitiesPerSecond`, remove the limit or adjust the value up. (See [Go](/docs/go/how-to-set-workeroptions-in-go/#taskqueueactivitiespersecond) and [Java](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html).)
+- If Worker-side rate limiting per Worker is set by `WorkerOptions#maxWorkerActivitiesPerSecond`, remove the limit. (See [Go](/docs/go/how-to-set-workeroptions-in-go/#workeractivitiespersecond), [TypeScript](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#maxconcurrentactivitytaskexecutions), and [Java](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html).)
 
 ## Workflow Cache Tuning
 

--- a/docs/operation/how-to-tune-workers.md
+++ b/docs/operation/how-to-tune-workers.md
@@ -87,10 +87,10 @@ then consider increasing the number of pollers by adjusting `maxConcurrentWorkfl
 
 ### Rate Limiting
 
-If, after adjusting the poller and executors count as specified above, you still observe an elevated `schedule_to_start`, underutilized Worker hosts, or high `worker_task_slots_available`, you may want to check
+If, after adjusting the poller and executors count as specified above, you still observe an elevated `schedule_to_start`, underutilized Worker hosts, or high `worker_task_slots_available`, you may want to check:
 
-1. If server-side rate limiting per Task Queue is set by `WorkerOptions#maxTaskQueueActivitiesPerSecond` and remove the limit or adjust the value up.
-2. If Worker-side rate limiting per Worker is set by `WorkerOptions#maxWorkerActivitiesPerSecond` and remove the limit. [GoSDK only]
+1. If server-side rate limiting per Task Queue is set by `WorkerOptions#maxTaskQueueActivitiesPerSecond`, remove the limit or adjust the value up. (See [Go](/docs/go/how-to-set-workeroptions-in-go/#taskqueueactivitiespersecond) and [Java](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html).)
+2. If Worker-side rate limiting per Worker is set by `WorkerOptions#maxWorkerActivitiesPerSecond`, remove the limit. (See [Go](/docs/go/how-to-set-workeroptions-in-go/#workeractivitiespersecond), [TypeScript](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#maxconcurrentactivitytaskexecutions), and [Java](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html).)
 
 ## Workflow Cache Tuning
 

--- a/docs/operation/how-to-tune-workers.md
+++ b/docs/operation/how-to-tune-workers.md
@@ -87,7 +87,7 @@ then consider increasing the number of pollers by adjusting `maxConcurrentWorkfl
 
 ### Rate Limiting
 
-If, after adjusting the poller and executors count as specified above, you still observe an elevated `schedule_to_start`, underutilized Worker hosts, or high `worker_task_slots_available`, you may want to check:
+If, after adjusting the poller and executors count as specified earlier, you still observe an elevated `schedule_to_start`, underutilized Worker hosts, or high `worker_task_slots_available`, you might want to check the following:
 
 1. If server-side rate limiting per Task Queue is set by `WorkerOptions#maxTaskQueueActivitiesPerSecond`, remove the limit or adjust the value up. (See [Go](/docs/go/how-to-set-workeroptions-in-go/#taskqueueactivitiespersecond) and [Java](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html).)
 2. If Worker-side rate limiting per Worker is set by `WorkerOptions#maxWorkerActivitiesPerSecond`, remove the limit. (See [Go](/docs/go/how-to-set-workeroptions-in-go/#workeractivitiespersecond), [TypeScript](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#maxconcurrentactivitytaskexecutions), and [Java](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerOptions.Builder.html).)


### PR DESCRIPTION
TODO: edit further if `TaskQueueActivitiesPerSecond` is per shard. cc @robholland 