### PR TITLE
Tctl admin cluster

### DIFF
--- a/docs/tctl/admin/cluster/add-search-attributes.md
+++ b/docs/tctl/admin/cluster/add-search-attributes.md
@@ -10,7 +10,8 @@ tags:
 
 The `tctl admin cluster add-search-attributes` command allows custom search attributes to be added to a given Cluster.
 
-### Modifiers
+
+## Modifiers
 
 #### `--skip-schema-update`
 Allows the user to skip the Elasticsearch index schema update.
@@ -18,6 +19,7 @@ Allows the user to skip the Elasticsearch index schema update.
 :::note
 This will only register in metadata.
 :::
+
 
 #### `--name value`
 Alias: `-n value`

--- a/docs/tctl/admin/cluster/add-search-attributes.md
+++ b/docs/tctl/admin/cluster/add-search-attributes.md
@@ -1,0 +1,32 @@
+---
+id: add-search-attributes
+title: tctl admin cluster add-search-attributes
+description: Adding custom search attrubutes to a cluster.
+tags:
+  - reference
+  - tctl
+  - admin
+---
+
+The `tctl admin cluster add-search-attributes` command allows custom search attributes to be added to a given Cluster.
+
+### Modifiers
+
+#### `--skip-schema-update`
+Allows the user to skip the Elasticsearch index schema update.
+
+:::note
+This will only register in metadata.
+:::
+
+#### `--name value`
+Alias: `-n value`
+
+The name of the search attribute to add. Multiple values are supported.
+
+#### `--type value`
+Alias: `-t value`
+
+The type of search attribute to add. Multiple values can be added at once.
+
+Values: Text, Keyword, Int, Double, Bool, Datetime

--- a/docs/tctl/admin/cluster/describe.md
+++ b/docs/tctl/admin/cluster/describe.md
@@ -1,0 +1,16 @@
+---
+id: describe
+title: tctl admin cluster describe
+description: Displaying Cluster information.
+tags:
+  - reference
+  - tctl
+  - admin
+---
+
+The `tctl admin cluster describe` command provides information for the current Cluster.
+
+The following modifier changes the behavior of the command:
+- `cluster value`
+The name of the remote Cluster within the current Cluster.
+This modifier is optional, and can default to the return of current Cluster information.

--- a/docs/tctl/admin/cluster/describe.md
+++ b/docs/tctl/admin/cluster/describe.md
@@ -10,7 +10,11 @@ tags:
 
 The `tctl admin cluster describe` command provides information for the current Cluster.
 
+
 The following modifier changes the behavior of the command:
+
 - `cluster value`
+
 The name of the remote Cluster within the current Cluster.
+
 This modifier is optional, and can default to the return of current Cluster information.

--- a/docs/tctl/admin/cluster/get-search-attributes.md
+++ b/docs/tctl/admin/cluster/get-search-attributes.md
@@ -1,0 +1,17 @@
+---
+id: get-search-attributes
+title: tctl admin
+description: Showing existing search attributes.
+tags:
+  - reference
+  - tctl
+  - admin
+---
+
+The `tctl admin cluster get-search-attributes` command retrieves existing search attributes for a given Cluster.
+
+The following modifier will change the behavior of the command:
+
+- `--print_json value`
+Alias: `--pjson value`
+Prints the existing search attributes in JSON format.

--- a/docs/tctl/admin/cluster/get-search-attributes.md
+++ b/docs/tctl/admin/cluster/get-search-attributes.md
@@ -10,8 +10,11 @@ tags:
 
 The `tctl admin cluster get-search-attributes` command retrieves existing search attributes for a given Cluster.
 
+
 The following modifier will change the behavior of the command:
 
 - `--print_json value`
-Alias: `--pjson value`
-Prints the existing search attributes in JSON format.
+
+    Alias: `--pjson value`
+
+    Prints the existing search attributes in JSON format.

--- a/docs/tctl/admin/cluster/index.md
+++ b/docs/tctl/admin/cluster/index.md
@@ -14,10 +14,10 @@ The `tctl admin cluster` command runs admin operations on a given Cluster.
 `tctl admin cluster command [command modifiers] [arguments...]`
 
 ### Commands
-- add-search-attributes
-- remove-search-attributes
-- get-search-attributes
-- describe
-- list
-- upsert-remote-cluster
-- remove-remote-cluster
+- [`add-search-attributes](/docs/tctl/admin/cluster/add-search-attributes)
+- [`remove-search-attributes`](/docs/tctl/admin/cluster/remove-search-attributes)
+- [`get-search-attributes`](/docs/tctl/admin/cluster/get-search-attributes)
+- [`describe`](/docs/tctl/admin/cluster/describe)
+- [`list`](/docs/tctl/admin/cluster/list)
+- [`upsert-remote-cluster`](/docs/tctl/admin/cluster/upsert-remove-cluster)
+- [`remove-remote-cluster`](/docs/tctl/admin/cluster/upsert-remove-cluster)

--- a/docs/tctl/admin/cluster/index.md
+++ b/docs/tctl/admin/cluster/index.md
@@ -1,0 +1,23 @@
+---
+id: index
+title: tctl admin cluster
+description: Running admin-level operations on clusters.
+tags:
+  - reference
+  - tctl
+  - admin
+---
+
+The `tctl admin cluster` command runs admin operations on a given Cluster.
+
+### Usage
+`tctl admin cluster command [command modifiers] [arguments...]`
+
+### Commands
+- add-search-attributes
+- remove-search-attributes
+- get-search-attributes
+- describe
+- list
+- upsert-remote-cluster
+- remove-remote-cluster

--- a/docs/tctl/admin/cluster/index.md
+++ b/docs/tctl/admin/cluster/index.md
@@ -10,11 +10,13 @@ tags:
 
 The `tctl admin cluster` command runs admin operations on a given Cluster.
 
+
 ### Usage
 `tctl admin cluster command [command modifiers] [arguments...]`
 
+
 ### Commands
-- [`add-search-attributes](/docs/tctl/admin/cluster/add-search-attributes)
+- [`add-search-attributes`](/docs/tctl/admin/cluster/add-search-attributes)
 - [`remove-search-attributes`](/docs/tctl/admin/cluster/remove-search-attributes)
 - [`get-search-attributes`](/docs/tctl/admin/cluster/get-search-attributes)
 - [`describe`](/docs/tctl/admin/cluster/describe)

--- a/docs/tctl/admin/cluster/list.md
+++ b/docs/tctl/admin/cluster/list.md
@@ -1,0 +1,17 @@
+---
+id: list
+title: tctl admin cluster list
+description: Listing Cluster information.
+tags:
+  - reference
+  - tctl
+  - admin
+---
+
+The `tctl admin cluster list` command lists Cluster information for the current Cluster.
+
+The modifier below changes the behavior of the command:
+- `--pagesize value`
+The size of the page that the list is printed on.
+
+Default: 100

--- a/docs/tctl/admin/cluster/list.md
+++ b/docs/tctl/admin/cluster/list.md
@@ -10,8 +10,10 @@ tags:
 
 The `tctl admin cluster list` command lists Cluster information for the current Cluster.
 
+Default: 100
+
 The modifier below changes the behavior of the command:
 - `--pagesize value`
 The size of the page that the list is printed on.
 
-Default: 100
+

--- a/docs/tctl/admin/cluster/remove-remote-cluster.md
+++ b/docs/tctl/admin/cluster/remove-remote-cluster.md
@@ -1,0 +1,15 @@
+---
+id: remove-remote-cluster
+title: tctl admin cluster remove-remote-cluster
+description: Removing remote Clusters.
+tags:
+  - reference
+  - tctl
+  - admin
+---
+
+The `tctl admin cluster remove-remote-cluster` command removes remote Cluster information from the current Cluster.
+
+The modifier below changes the behavior of the operation:
+- `--cluster value`
+The name of the remote cluster to remove.

--- a/docs/tctl/admin/cluster/remove-remote-cluster.md
+++ b/docs/tctl/admin/cluster/remove-remote-cluster.md
@@ -10,6 +10,7 @@ tags:
 
 The `tctl admin cluster remove-remote-cluster` command removes remote Cluster information from the current Cluster.
 
+
 The modifier below changes the behavior of the operation:
 - `--cluster value`
 The name of the remote cluster to remove.

--- a/docs/tctl/admin/cluster/remove-search-attributes.md
+++ b/docs/tctl/admin/cluster/remove-search-attributes.md
@@ -1,0 +1,16 @@
+---
+id: remove-search-attributes
+title: tctl admin cluster remove-search-attributes
+description: Removing custom search metadat from a Cluster.
+tags:
+  - reference
+  - tctl
+  - admin
+---
+The `tctl admin cluster remove-search-attributes` command removes custom search metadata from a given Cluster.
+This operation has no effect on Elasticsearch index schema.
+
+The following modifier changes the behavior of the operation:
+
+- `--name value`
+Name of the search attribute to remove.

--- a/docs/tctl/admin/cluster/remove-search-attributes.md
+++ b/docs/tctl/admin/cluster/remove-search-attributes.md
@@ -8,7 +8,9 @@ tags:
   - admin
 ---
 The `tctl admin cluster remove-search-attributes` command removes custom search metadata from a given Cluster.
+
 This operation has no effect on Elasticsearch index schema.
+
 
 The following modifier changes the behavior of the operation:
 

--- a/docs/tctl/admin/cluster/upsert-remote-cluster.md
+++ b/docs/tctl/admin/cluster/upsert-remote-cluster.md
@@ -17,6 +17,7 @@ Alias: `--fad value`
 
 Remote Cluster frontend address.
 
+
 #### `--enable_connection`
 Alias: `--ec`
 

--- a/docs/tctl/admin/cluster/upsert-remote-cluster.md
+++ b/docs/tctl/admin/cluster/upsert-remote-cluster.md
@@ -1,0 +1,23 @@
+---
+id: upsert-remote-cluster
+title: tctl admin cluster upsert-remote-cluster
+description: How to run admin-level tctl commands.
+tags:
+  - reference
+  - tctl
+  - admin
+---
+
+The `tctl admin cluster upsert-remote-cluster` command adds or updates remote Cluster informaation in the current Cluster.
+
+### Modifiers
+
+#### `--frontend_address value`
+Alias: `--fad value`
+
+Remote Cluster frontend address.
+
+#### `--enable_connection`
+Alias: `--ec`
+
+Enables remote Cluster connection.

--- a/docs/tctl/admin/index.md
+++ b/docs/tctl/admin/index.md
@@ -12,18 +12,18 @@ A `tctl admin` command allows the user to run admin operations.
 
 Alias : `adm`
 
-#### tctl admin commands
+## Commands
 
-- tctl admin workflow
-- tctl admin shard
-- tctl history_host
-- tctl taskqueue
-- tctl membership
-- tctl cluster
-- tctl dlq
-- tctl db
-- tctl decode
+- [`tctl admin workflow`](/docs/tctl/admin/workflow/index)
+- [`tctl admin shard`](/docs/tctl/admin/shard/index)
+- `tctl history_host`
+- `tctl taskqueue`
+- `tctl membership`
+- [`tctl cluster`](/docs/tctl/admin/cluster/index)
+- `tctl dlq`
+- `tctl db`
+- `tctl decode`
 
-#### Options
+## Modifiers
 
 Help: `tctl admin [--help | -h]`

--- a/docs/tctl/admin/shard/close_shard.md
+++ b/docs/tctl/admin/shard/close_shard.md
@@ -11,9 +11,14 @@ tags:
 
 The `tctl admin shard close_shard` command closes a shard with an Id that corresponds to the value given in the command.
 
+## Usage
+
 `tctl admin shard close_shard [command options] [arguments...]`
+
+## Modifiers
 
 The modifier below will change the behavior and output of the command.
 
 `--share_id value`
+
 ShareId managed by the Temporal Cluster.

--- a/docs/tctl/admin/shard/describe_task.md
+++ b/docs/tctl/admin/shard/describe_task.md
@@ -19,101 +19,104 @@ The modifiers below control the output and behavior of the command. Enter all mo
 
 `tctl admin shard describe_task [<modifiers>]`
 
-### `--db_engine value`
+#### `--db_engine value`
 
 The type of database (DB) engine for the shard to use.
 
 Default: "cassandra"
+
 Values: "cassandra", "mysql", "postgres"
 
 <!-- todo: examples -->
 
-### `--db_address value`
+#### `--db_address value`
 
 Persistence address for the database.
 
 Default: 127.0.0.1
 
-### `--db_port value`
+
+#### `--db_port value`
 
 Persistence port for the database.
 
 Default: 9042
 
-### `--username value`
+
+#### `--username value`
 
 Username entered into the database.
 
-### `--password value`
+
+#### `--password value`
 
 Password entered into the database.
 
-### `--keyspace value`
+
+#### `--keyspace value`
 
 Keyspace for the database.
 
 default: "temporal"
 
-### `--tls`
+
+#### `--tls`
 
 Enables TLS over the database connection.
 
-### `--tls_cert_path value`
+
+#### `--tls_cert_path value`
 
 DB tls client cert path.
 
 Note: tls must be enabled
 
-### `--tls_key_path value`
 
-DB tls client key path
-
-Note: tls must be enabled
-
-### `--tls_ca_path value`
-
-DB tls client ca path
-
-Note: tls must be enabled
-
-### `--tls_server_name value`
+#### `--tls_server_name value`
 
 DB tls server name
 
 Note: tls must be enabled
 
-### `--tls_disable_host_verification`
+
+#### `--tls_disable_host_verification`
 
 DB tls verify hostname and server cert
 
 Note: tls must be enabled
 
-### `--shard_id value`
+
+#### `--shard_id value`
 
 Identifies the specified shard.
 
 Default: 0
 
-### `--task_id value`
+
+#### `--task_id value`
 
 Describes the task.
 
 Default: 0
 
-### `--task_type value`
+
+#### `--task_type value`
 
 The kind of Task that is targeted within a shard.
 
 Default: transfer
+
 Values: transfer, timer, replication
 
-### `--task_timestamp value`
+
+#### `--task_timestamp value`
 
 Task visibility timestamp in nanoseconds
 
 Default: 0
 
-### `--target_cluster value`
+
+#### `--target_cluster value`
 
 Temporal cluster for the shard to use.
 

--- a/docs/tctl/admin/shard/index.md
+++ b/docs/tctl/admin/shard/index.md
@@ -15,8 +15,8 @@ Alias: `shar`
 
 #### tctl admin shard commands
 
-- describe
-- describe-task
-- list-tasks
-- close-shard
-- remove-task
+- [`describe`](/docs/tctl/admin/shard/describe)
+- [`describe-task`](/docs/tctl/admin/shard/describe_task)
+- [`list-tasks`](/docs/tctl/admin/shard/list_tasks)
+- [`close-shard`](/docs/tctl/admin/shard/close_shard)
+- [`remove-task`](/docs/tctl/admin/shard/remove_task)

--- a/docs/tctl/admin/shard/list_tasks.md
+++ b/docs/tctl/admin/shard/list_tasks.md
@@ -11,47 +11,48 @@ tags:
 
 The `tctl admin shard list_tasks` command will list the Tasks available for a given shard Id and Task type.
 
+
 ## Modifiers
 
 The modifiers below affect the output and behavior of the command.
 
-### `--more`
+#### `--more`
 
 Alias: `-m`
 
 Lists more pages of list tasks.
 The default setting is to list one page of 10 list tasks.
 
-### `--pagesize value`
+#### `--pagesize value`
 
 Alias: `--ps value`
 
 The size of the result page.
 Default: 10
 
-### `--target_cluster value`
+#### `--target_cluster value`
 
 Temporal cluster to use.
 Default: "active"
 
-### `--shard_id value`
+#### `--shard_id value`
 
 The ID of the shard
 
 Default: 0
 
-### `--task_type value`
+#### `--task_type value`
 
 The type of Task.
 
 Default: transfer
 Values: transfer, timer, replication, visibility
 
-### `--min_visibility_ts value`
+#### `--min_visibility_ts value`
 
 The minimum value that can be set as a Task Visibility timestamp.
 
-#### Supported formats:
+Supported formats include:
 
 - '2006-01-02T15:04:05+07:00'
 - Raw UnixNano
@@ -62,11 +63,11 @@ The minimum value that can be set as a Task Visibility timestamp.
   - month/m
   - year/y
 
-### `--max_visibility_ts value`
+#### `--max_visibility_ts value`
 
 The maximum value that can be set as a Task Visibility timestamp.
 
-#### Supported formats:
+ Supported formats:
 
 - '2006-01-02T15:04:05+07:00'
 - Raw UnixNano

--- a/docs/tctl/admin/shard/remove_task.md
+++ b/docs/tctl/admin/shard/remove_task.md
@@ -19,26 +19,27 @@ The Task removed must have values that matches what is given in the command line
 
 The modifiers below change the behavior of the command.
 
-### `--shard_id value`
+#### `--shard_id value`
 
 The shardId for the Task to be removed.
 
 Default: 0
 
-### `--task_id value`
+#### `--task_id value`
 
 The taskId for the Task to be removed.
 
 Default: 0
 
-### `--task_type value`
+#### `--task_type value`
 
 The type of Task to remove.
 
 Default: transfer
+
 Values: transfer, timer, replication
 
-### `--task_timestamp value`
+#### `--task_timestamp value`
 
 The task visibility timestamp, given in nanoseconds.
 

--- a/docs/tctl/admin/workflow/index.md
+++ b/docs/tctl/admin/workflow/index.md
@@ -14,8 +14,7 @@ The `tctl admin workflow` commands enable admin-level operations on Workflow Exe
 Alias: `-wf`
 
 #### Commands
-
-show
-describe
-refresh-tasks
-delete
+- show
+- describe
+- refresh-tasks
+- delete


### PR DESCRIPTION
Adds in docs for the cluster admin commands, along with links and formatting cleanup for other docs currently in main