### PR TITLE
fix mobile layout for retry simulator

### DIFF
--- a/docs/components/RetrySimulator/retry-simulator.module.css
+++ b/docs/components/RetrySimulator/retry-simulator.module.css
@@ -30,6 +30,25 @@
   margin-left: 0.25em;
 }
 
+@media screen and (max-width: 966px) {
+  .retryRow {
+    display: block;
+  }
+
+  .retryCol {
+    width: 100%;
+    margin-top: 25px;
+  }
+
+  .retryCol:first-of-type {
+    margin-right: 0;
+  }
+
+  .retryCol:not(:first-of-type) {
+    margin-left: 0;
+  }
+}
+
 .scheduleTime {
   padding: 10px;
   padding-top: 15px;


### PR DESCRIPTION
## What does this PR do?

Quick fix to make the retry simulator usable on mobile. Before:

![image](https://user-images.githubusercontent.com/1620265/170895834-13de0fce-22c4-4309-8e99-dcaa920d39b0.png)

After:

![image](https://user-images.githubusercontent.com/1620265/170895864-81f30497-1a63-4ec1-92ba-2f9a42fe25f2.png)

## Notes to reviewers

<!-- delete if n/a -->
