### PR TITLE
added notes to C.A.N.

### DIFF
--- a/docs/go/how-to-continue-as-new-in-go.md
+++ b/docs/go/how-to-continue-as-new-in-go.md
@@ -19,7 +19,7 @@ func SimpleWorkflow(ctx workflow.Context, value string) error {
 
 To check whether a Workflow Execution was spawned as a result of Continue-As-New, you can check if `workflow.GetInfo(ctx).ContinuedExecutionRunID` is not nil.
 
-## Notes
+**Notes**
 
 - To prevent Signal loss, be sure to perform an asynchronous drain on the Signal channel. Failure to do so can result in buffered Signals being ignored and lost.
 - Make sure that the previous Workflow and the Continue-As-New Workflow are referenced by the same alias. Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.

--- a/docs/go/how-to-continue-as-new-in-go.md
+++ b/docs/go/how-to-continue-as-new-in-go.md
@@ -21,5 +21,6 @@ To check whether a Workflow Execution was spawned as a result of Continue-As-New
 
 **Notes**
 
-- To prevent Signal loss, be sure to perform an asynchronous drain on the Signal channel. Failure to do so can result in buffered Signals being ignored and lost.
+- To prevent Signal loss, be sure to perform an asynchronous drain on the Signal channel.
+Failure to do so can result in buffered Signals being ignored and lost.
 - Make sure that the previous Workflow and the Continue-As-New Workflow are referenced by the same alias. Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.

--- a/docs/go/how-to-continue-as-new-in-go.md
+++ b/docs/go/how-to-continue-as-new-in-go.md
@@ -21,6 +21,5 @@ To check whether a Workflow Execution was spawned as a result of Continue-As-New
 
 ## Notes
 
-- To prevent Signal loss, make sure to perform an asynchronous drain on the Signal channel. Failure to do so can result in buffered Signals being ignored and lost.
-
-- Make sure that the previous Workflow and the Continue-As-New Workflow are both referenced by the same alias. Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.
+- To prevent Signal loss, be sure to perform an asynchronous drain on the Signal channel. Failure to do so can result in buffered Signals being ignored and lost.
+- Make sure that the previous Workflow and the Continue-As-New Workflow are referenced by the same alias. Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.

--- a/docs/go/how-to-continue-as-new-in-go.md
+++ b/docs/go/how-to-continue-as-new-in-go.md
@@ -23,4 +23,5 @@ To check whether a Workflow Execution was spawned as a result of Continue-As-New
 
 - To prevent Signal loss, be sure to perform an asynchronous drain on the Signal channel.
 Failure to do so can result in buffered Signals being ignored and lost.
-- Make sure that the previous Workflow and the Continue-As-New Workflow are referenced by the same alias. Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.
+- Make sure that the previous Workflow and the Continue-As-New Workflow are referenced by the same alias.
+Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.

--- a/docs/go/how-to-continue-as-new-in-go.md
+++ b/docs/go/how-to-continue-as-new-in-go.md
@@ -18,3 +18,9 @@ func SimpleWorkflow(ctx workflow.Context, value string) error {
 ```
 
 To check whether a Workflow Execution was spawned as a result of Continue-As-New, you can check if `workflow.GetInfo(ctx).ContinuedExecutionRunID` is not nil.
+
+## Notes
+
+- To prevent Signal loss, make sure to perform an asynchronous drain on the Signal channel. Failure to do so can result in buffered Signals being ignored and lost.
+
+- Make sure that the previous Workflow and the Continue-As-New Workflow are both referenced by the same alias. Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.


### PR DESCRIPTION
Added notes about async draining to Continue-As-New for Go.