### PR TITLE
Fix modifier typos in tctl reference

### DIFF
--- a/docs/go/how-to-continue-as-new-in-go.md
+++ b/docs/go/how-to-continue-as-new-in-go.md
@@ -22,6 +22,6 @@ To check whether a Workflow Execution was spawned as a result of Continue-As-New
 **Notes**
 
 - To prevent Signal loss, be sure to perform an asynchronous drain on the Signal channel.
-Failure to do so can result in buffered Signals being ignored and lost.
+  Failure to do so can result in buffered Signals being ignored and lost.
 - Make sure that the previous Workflow and the Continue-As-New Workflow are referenced by the same alias.
-Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.
+  Failure to do so can cause the Workflow to Continue-As-New on an entirely different Workflow.

--- a/docs/tctl/taskqueue/list-partition.md
+++ b/docs/tctl/taskqueue/list-partition.md
@@ -14,7 +14,7 @@ The `tctl taskqueue list-partition` command lists the partitions of a [Task Queu
 
 The following modifier controls the behavior of the command.
 
-### `taskqueue`
+### `--taskqueue`
 
 _Required modifier_
 

--- a/docs/tctl/workflow/reset.md
+++ b/docs/tctl/workflow/reset.md
@@ -51,7 +51,7 @@ Valid values are `WorkflowTaskCompleted`, `WorkflowTaskFailed`, and `WorkflowTas
 tctl workflow reset --event_id <id>
 ```
 
-### `reason`
+### `--reason`
 
 Specify a reason for resetting the [Workflow Execution](/concepts/what-is-a-workflow-execution).
 


### PR DESCRIPTION
## What does this PR do?

Adds missing "--" to beginning of one H3 in each of the following tctl reference pages:

- tctl workflow reset (--reason)
- tctl taskqueue list-partition (--taskqueue)
