### PR TITLE
Change 'Go' to 'TypeScript' in TS SDK section

### DIFF
--- a/docs/application-development-guide.md
+++ b/docs/application-development-guide.md
@@ -232,7 +232,7 @@ To download the latest version of the Temporal TypeScript Command, run the follo
 npm i temporalio
 ```
 
-Or clone the Go SDK repo to your preferred location:
+Or clone the TypeScript SDK repo to your preferred location:
 
 ```bash
 git clone git@github.com:temporalio/sdk-typescript.git


### PR DESCRIPTION
## What does this PR do?

The TypeScript section referenced 'Go' instead of TypeScript for the samples. This fixes it.




