### PR TITLE
Separating Cluster content into tabs

### DIFF
--- a/docs/application-development-guide.md
+++ b/docs/application-development-guide.md
@@ -46,13 +46,8 @@ There are four ways to quickly install and run a Temporal Cluster:
 
 **We do not recommend using any of these methods in a [full (production) environment](/server/production-deployment).**
 
-#### Helm charts
-
-Use [Temporal Helm charts](https://github.com/temporalio/helm-charts) to deploy the Temporal Server to a [Kubernetes](https://kubernetes.io/) cluster.
-
-Deploying the Temporal Cluster with Helm is not recommended for a production environment, but it is a great way to test the system while developing Workflows.
-
-#### Docker Compose
+<Tabs>
+    <TabItem value="docker" label="Docker Compose" default>
 
 Use Docker Compose and Temporal Cluster Docker images to quickly install and run a Temporal Cluster locally while developing Workflows.
 
@@ -70,15 +65,24 @@ When the Temporal Cluster is running, the Temporal Web UI becomes available in y
 
 The preceding steps start and run a Temporal Cluster using a default configuration.
 To try other configurations (different dependencies and databases), or to try a custom Docker image, follow the [temporalio/docker-compose README](https://github.com/temporalio/docker-compose/blob/main/README.md).
+</TabItem>
+<TabItem value="render" label="Render">
 
-#### Render
+Use Render to quickly install and run a Temporal Cluster locally while developing Workflows.
 
 [temporal-render-simple](https://github.com/temporalio/temporal-render-simple) translates our docker-compose to Render by using the [Auto-Setup Docker image](/blog/auto-setup).
+
 We do not recommend using this technique for production because all four Temporal internal services (Frontend, Matching, History, and Worker) are run in one process, but the benefit is one-click deployments.
 
 [Deploy to Render](https://render.com/deploy?repo=https://github.com/temporalio/temporal-render-simple)
+</TabItem>
+<TabItem value="Helm-chart" label="Helm Charts">
 
-#### Gitpod
+Use [Temporal Helm charts](https://github.com/temporalio/helm-charts) to deploy the Temporal Server to a [Kubernetes](https://kubernetes.io/) cluster.
+
+Deploying the Temporal Cluster with Helm is not recommended for a production environment, but it is a great way to test the system while developing Workflows.
+</TabItem>
+<TabItem value="gitpod" label="Gitpod">
 
 You can run a Temporal Cluster and develop Temporal Applications in your browser using [Gitpod](https://www.gitpod.io/).
 
@@ -88,6 +92,8 @@ A one-click deployment starts a Temporal Cluster using a Temporal Cluster Docker
 
 It can take up to a full minute for the one-click deployments to get fully up and running.
 When it is running, you can customize the application samples.
+</TabItem>
+</Tabs>
 
 ### Add your SDK
 

--- a/docs/clusters/quick-install.md
+++ b/docs/clusters/quick-install.md
@@ -17,13 +17,8 @@ There are four ways to quickly install and run a Temporal Cluster:
 
 **We do not recommend using any of these methods in a [full (production) environment](/server/production-deployment).**
 
-#### Helm charts
-
-Use [Temporal Helm charts](https://github.com/temporalio/helm-charts) to deploy the Temporal Server to a [Kubernetes](https://kubernetes.io/) cluster.
-
-Deploying the Temporal Cluster with Helm is not recommended for a production environment, but it is a great way to test the system while developing Workflows.
-
-#### Docker Compose
+<Tabs>
+    <TabItem value="docker" label="Docker Compose" default>
 
 Use Docker Compose and Temporal Cluster Docker images to quickly install and run a Temporal Cluster locally while developing Workflows.
 
@@ -41,15 +36,24 @@ When the Temporal Cluster is running, the Temporal Web UI becomes available in y
 
 The preceding steps start and run a Temporal Cluster using a default configuration.
 To try other configurations (different dependencies and databases), or to try a custom Docker image, follow the [temporalio/docker-compose README](https://github.com/temporalio/docker-compose/blob/main/README.md).
+</TabItem>
+<TabItem value="render" label="Render">
 
-#### Render
+Use Render to quickly install and run a Temporal Cluster locally while developing Workflows.
 
 [temporal-render-simple](https://github.com/temporalio/temporal-render-simple) translates our docker-compose to Render by using the [Auto-Setup Docker image](/blog/auto-setup).
+
 We do not recommend using this technique for production because all four Temporal internal services (Frontend, Matching, History, and Worker) are run in one process, but the benefit is one-click deployments.
 
 [Deploy to Render](https://render.com/deploy?repo=https://github.com/temporalio/temporal-render-simple)
+</TabItem>
+<TabItem value="Helm-chart" label="Helm Charts">
 
-#### Gitpod
+Use [Temporal Helm charts](https://github.com/temporalio/helm-charts) to deploy the Temporal Server to a [Kubernetes](https://kubernetes.io/) cluster.
+
+Deploying the Temporal Cluster with Helm is not recommended for a production environment, but it is a great way to test the system while developing Workflows.
+</TabItem>
+<TabItem value="gitpod" label="Gitpod">
 
 You can run a Temporal Cluster and develop Temporal Applications in your browser using [Gitpod](https://www.gitpod.io/).
 
@@ -59,3 +63,5 @@ A one-click deployment starts a Temporal Cluster using a Temporal Cluster Docker
 
 It can take up to a full minute for the one-click deployments to get fully up and running.
 When it is running, you can customize the application samples.
+</TabItem>
+</Tabs>


### PR DESCRIPTION
## What does this PR do?
Users are normally selecting 1 of 4 options when choosing to create and connect to a Cluster. Because of that, I thought separating the content by tabs shows that you're selecting an option rather than reading through the content lineally. 

Docker Compose defaults as the first option among the 4. 
I also reordered the content based on the TOC listed just before.

I think this also condenses the page, so that users can get to SDK content quicker.

## [Preview](https://deploy-preview-1242--mystifying-fermi-1bc096.netlify.app/application-development-guide#run-a-dev-cluster)