### PR TITLE
Fix two minor issues

### DIFF
--- a/docs/app-dev-context/set-workflow-id.md
+++ b/docs/app-dev-context/set-workflow-id.md
@@ -1,1 +1,1 @@
-Also it is not required, we recommend providing your own [Workflow Id](/concepts/what-is-a-workflow-id) that maps to a business process or business entity identifier, such as an order identifier or customer identifier.
+Although it is not required, we recommend providing your own [Workflow Id](/concepts/what-is-a-workflow-id) that maps to a business process or business entity identifier, such as an order identifier or customer identifier.

--- a/docs/tctl/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md
+++ b/docs/tctl/how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md
@@ -27,7 +27,7 @@ Search Attribute names are case sensitive.
 
 The possible values for `--type` are:
 
-- String
+- Text
 - Keyword
 - Int
 - Double


### PR DESCRIPTION
## What does this PR do?

- how-to-add-a-custom-search-attribute-to-a-cluster-using-tctl.md: For `--type`, change "String" to "Text". ("String" is temporarily an alias of "Text" but will go away in a few months.)
- set-workflow-id: Fix word choice.
