### PR TITLE
add script to set tab language from query string

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -343,6 +343,11 @@ module.exports = {
       async: true,
       defer: true,
     },
+    {
+      src: "/scripts/set-tab-language.js",
+      async: true,
+      defer: true,
+    }
     // {
     //   src: "/scripts/feedback.js",
     //   async: true,

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -347,7 +347,7 @@ module.exports = {
       src: "/scripts/set-tab-language.js",
       async: true,
       defer: true,
-    }
+    },
     // {
     //   src: "/scripts/feedback.js",
     //   async: true,

--- a/static/scripts/set-tab-language.js
+++ b/static/scripts/set-tab-language.js
@@ -18,4 +18,8 @@
   } else if (entries.language === "ts") {
     window.localStorage.setItem("docusaurus.tab.language", "ts");
   }
+
+  if (entries.lang) {
+    window.localStorage.setItem("docusaurus.tab.site-lang", entries.lang);
+  }
 })();

--- a/static/scripts/set-tab-language.js
+++ b/static/scripts/set-tab-language.js
@@ -1,0 +1,18 @@
+(function () {
+  const querystring = window.location.search;
+  if (!querystring) {
+    return;
+  }
+
+  const entries = querystring.slice(1).split('&').reduce((entries, str) => {
+    const [key, value] = str.split('=').map(v => decodeURIComponent(v));
+    entries[key] = value;
+    return entries;
+  }, {});
+
+  if (entries.language === 'js') {
+    window.localStorage.setItem('docusaurus.tab.language', 'js');
+  } else if (entries.language === 'ts') {
+    window.localStorage.setItem('docusaurus.tab.language', 'ts');
+  }
+})();

--- a/static/scripts/set-tab-language.js
+++ b/static/scripts/set-tab-language.js
@@ -19,7 +19,23 @@
     window.localStorage.setItem("docusaurus.tab.language", "ts");
   }
 
-  if (entries.lang) {
-    window.localStorage.setItem("docusaurus.tab.site-lang", entries.lang);
+  // for app dev guide
+  if (typeof entries.lang === "string") {
+    const lang = entries.lang.toLowerCase();
+    const validSiteLangs = [
+      "go",
+      "java",
+      "php",
+      "typescript",
+      "python",
+      "dotnet",
+      "ruby",
+      "rust",
+    ];
+    const isValid = validSiteLangs.indexOf(lang) !== -1;
+
+    if (isValid) {
+      window.localStorage.setItem("docusaurus.tab.site-lang", lang);
+    }
   }
 })();

--- a/static/scripts/set-tab-language.js
+++ b/static/scripts/set-tab-language.js
@@ -4,15 +4,18 @@
     return;
   }
 
-  const entries = querystring.slice(1).split('&').reduce((entries, str) => {
-    const [key, value] = str.split('=').map(v => decodeURIComponent(v));
-    entries[key] = value;
-    return entries;
-  }, {});
+  const entries = querystring
+    .slice(1)
+    .split("&")
+    .reduce((entries, str) => {
+      const [key, value] = str.split("=").map((v) => decodeURIComponent(v));
+      entries[key] = value;
+      return entries;
+    }, {});
 
-  if (entries.language === 'js') {
-    window.localStorage.setItem('docusaurus.tab.language', 'js');
-  } else if (entries.language === 'ts') {
-    window.localStorage.setItem('docusaurus.tab.language', 'ts');
+  if (entries.language === "js") {
+    window.localStorage.setItem("docusaurus.tab.language", "js");
+  } else if (entries.language === "ts") {
+    window.localStorage.setItem("docusaurus.tab.language", "ts");
   }
 })();


### PR DESCRIPTION
Re: #1220

## What does this PR do?

Going to https://docs.temporal.io/typescript/workflows?language=js will set the language to js in tabs.

I wasn't able to figure out how to do this in React. For some reason, pulling in `import { useTabGroupChoice } from '@docusaurus/theme-common'` and using `useTabGroupChoice()` in a component was giving me an [invalid hook call warning error](https://reactjs.org/warnings/invalid-hook-call-warning.html). But, luckily, we can just set the correct localStorage key before React hydrates.

## Notes to reviewers

<!-- delete if n/a -->
