### PR TITLE
Change fn() to function with use in await example

### DIFF
--- a/versioned_docs/version-june-2022/php/workflows.md
+++ b/versioned_docs/version-june-2022/php/workflows.md
@@ -238,8 +238,13 @@ Workflow::async(
     }
 );
 
-// wait for $done to become true
-yield Workflow::await(fn() => $done);
+// Wait for $done to become true
+// We not using arrow function here, because $done is
+// a local variable, and fn() will capture it by value so
+// await will not be affected by the async variable change.
+yield Workflow::await(function() use (&$done) {
+    return $done;
+});
 ```
 
 You can not use any activity, timer or child workflow invocation inside `await` or `awaitWithTimeout` method.


### PR DESCRIPTION
As been discussed in the slack,
```
yield Workflow::await(fn() => $done);
```

will not reflect the changes of the `$done` variable that happens outside the scope of the arrow function.

So old example could work only because `composeGreeting` is a local activity and `$done` becomes true before `await` starts.