### PR TITLE
First release notes for Temporal Cloud

### DIFF
--- a/cloud/release-notes/release-note-2022-06-07.md
+++ b/cloud/release-notes/release-note-2022-06-07.md
@@ -1,0 +1,11 @@
+---
+slug: release-note-2022-06-07
+title: tcld available in beta
+tags:
+  - feature
+date: 2022-06-07T00:00:00Z
+---
+
+The Temporal Cloud CLI (tcld) to manage Temporal Cloud is now available in beta.
+With tcld, you can interact with Temporal Cloud to list Namespaces and update certificates and custom Search Attributes.
+For more information, see [What is tcld?](https://docs.temporal.io/cloud/tcld).

--- a/cloud/release-notes/release-note-2022-07-08.md
+++ b/cloud/release-notes/release-note-2022-07-08.md
@@ -1,0 +1,14 @@
+---
+slug: release-note-2022-07-08
+title: cloud.temporal.io available in beta
+tags:
+  - feature
+date: 2022-07-08T00:00:00Z
+---
+
+[cloud.temporal.io](https://cloud.temporal.io) is now available in beta.
+You can now access the Temporal Cloud UI to manage your Temporal Cloud Account and your Workflows.
+With Temporal Cloud UI, you can also configure the following:
+
+- Certificates to connect to your Namespace
+- Custom Search Attributes

--- a/docs/cloud/index.md
+++ b/docs/cloud/index.md
@@ -19,6 +19,10 @@ You can [join the waitlist](https://pages.temporal.io/cloud-early-access).
 
 :::
 
+## Release notes
+
+For the latest release notes, see [Temporal Cloud release notes](/cloud/release-notes).
+
 ## Upgrade policy
 
 All customers will automatically be upgraded to the latest minor version.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -208,7 +208,7 @@ module.exports = {
     algolia: {
       apiKey: "cd527863e60d95ebe650cdd21c7a6f3f",
       indexName: "temporal",
-      contextualSearch: true, // Optional, If you different version of docs etc (v1 and v2) doesn't display dup results
+      // contextualSearch: true, // Optional, If you different version of docs etc (v1 and v2) doesn't display dup results
       appId: "T5D6KNJCQS", // Optional, if you run the DocSearch crawler on your own
       // algoliaOptions: {}, // Optional, if provided by Algolia
     },
@@ -307,6 +307,7 @@ module.exports = {
         // Will be passed to @docusaurus/plugin-content-blog
         // options: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-content-blog
         blog: {
+          id: "blog",
           routeBasePath: "blog",
           path: "blog",
           postsPerPage: 10,
@@ -343,11 +344,6 @@ module.exports = {
       async: true,
       defer: true,
     },
-    {
-      src: "/scripts/set-tab-language.js",
-      async: true,
-      defer: true,
-    },
     // {
     //   src: "/scripts/feedback.js",
     //   async: true,
@@ -358,6 +354,33 @@ module.exports = {
     //   async: true,
     //   defer: true,
     // },
+  ],
+  plugins: [
+    [
+      "@docusaurus/plugin-content-blog",
+      {
+        /**
+         * Required for any multi-instance plugin
+         */
+        id: "cloud-release-notes",
+        /**
+         * URL route for the blog section of your site.
+         * *DO NOT* include a trailing slash.
+         */
+        routeBasePath: "cloud/release-notes",
+        /**
+         * Path to data on filesystem relative to site dir.
+         */
+        path: "cloud/release-notes",
+        blogTitle: "Temporal Cloud release notes",
+        blogSidebarTitle: "Recent release notes",
+        showReadingTime: false, // Show estimated reading time for the blog post.
+        feedOptions: {
+          type: "all",
+          copyright: `Copyright © ${new Date().getFullYear()} Temporal Technologies Inc.  All rights reserved. Copyright © 2020 Uber Technologies, Inc.`,
+        },
+      },
+    ],
   ],
 };
 

--- a/versioned_docs/version-june-2022/cloud/index.md
+++ b/versioned_docs/version-june-2022/cloud/index.md
@@ -19,6 +19,10 @@ You can [join the waitlist](https://pages.temporal.io/cloud-early-access).
 
 :::
 
+## Release notes
+
+For the latest release notes, see [Temporal Cloud release notes](/cloud/release-notes).
+
 ## Upgrade policy
 
 All customers will automatically be upgraded to the latest minor version.


### PR DESCRIPTION
## What does this PR do?

Adds a temporary location for release notes for Temporal Cloud and the first two release notes.

## Preview links

- Release notes: https://deploy-preview-1289--mystifying-fermi-1bc096.netlify.app/cloud/release-notes
- New link on Temporal Cloud docs landing page: https://deploy-preview-1289--mystifying-fermi-1bc096.netlify.app/cloud
