### PR TITLE
Fix typo reported by richja

### DIFF
--- a/docs/tctl/workflow/list.md
+++ b/docs/tctl/workflow/list.md
@@ -86,7 +86,7 @@ tctl workflow list --print_full
 
 Print the raw JSON objects.
 
-Alias: `pjson`
+Alias: `--pjson`
 
 **Example**
 

--- a/docs/tctl/workflow/listall.md
+++ b/docs/tctl/workflow/listall.md
@@ -83,7 +83,7 @@ tctl workflow listall --print_full
 
 Print the raw JSON objects.
 
-Alias: `pjson`
+Alias: `--pjson`
 
 **Example**
 

--- a/docs/tctl/workflow/listarchived.md
+++ b/docs/tctl/workflow/listarchived.md
@@ -85,7 +85,7 @@ tctl workflow listarchived --print_full
 
 Print the raw JSON objects.
 
-Alias: `pjson`
+Alias: `--pjson`
 
 **Example**
 

--- a/docs/tctl/workflow/scan.md
+++ b/docs/tctl/workflow/scan.md
@@ -84,7 +84,7 @@ tctl workflow scan --print_full
 
 Print the raw JSON objects.
 
-Alias: `pjson`
+Alias: `--pjson`
 
 **Example**
 

--- a/versioned_docs/version-june-2022/tctl/workflow/list.md
+++ b/versioned_docs/version-june-2022/tctl/workflow/list.md
@@ -86,7 +86,7 @@ tctl workflow list --print_full
 
 Print the raw JSON objects.
 
-Alias: `pjson`
+Alias: `--pjson`
 
 **Example**
 

--- a/versioned_docs/version-june-2022/tctl/workflow/listall.md
+++ b/versioned_docs/version-june-2022/tctl/workflow/listall.md
@@ -83,7 +83,7 @@ tctl workflow listall --print_full
 
 Print the raw JSON objects.
 
-Alias: `pjson`
+Alias: `--pjson`
 
 **Example**
 

--- a/versioned_docs/version-june-2022/tctl/workflow/listarchived.md
+++ b/versioned_docs/version-june-2022/tctl/workflow/listarchived.md
@@ -85,7 +85,7 @@ tctl workflow listarchived --print_full
 
 Print the raw JSON objects.
 
-Alias: `pjson`
+Alias: `--pjson`
 
 **Example**
 

--- a/versioned_docs/version-june-2022/tctl/workflow/scan.md
+++ b/versioned_docs/version-june-2022/tctl/workflow/scan.md
@@ -84,7 +84,7 @@ tctl workflow scan --print_full
 
 Print the raw JSON objects.
 
-Alias: `pjson`
+Alias: `--pjson`
 
 **Example**
 


### PR DESCRIPTION
## What does this PR do?

Fixes a typo reported by @richja in #1284: alias `pjson` should be `--pjson`.
