### PR TITLE
Add certificate-filters to tcld namespace

### DIFF
--- a/docs/cloud/tcld/namespace/certificate-filters/clear.md
+++ b/docs/cloud/tcld/namespace/certificate-filters/clear.md
@@ -7,5 +7,50 @@ tags:
   - tcld
 ---
 
-The `tcld namespace certificate-filters clear` command clears all certificate filters from a [Namespace](/concepts/what-is-a-namespace) in Temporal Cloud. Using this command allows *any* client certificate that chains up to a configured CA certificate to connect to the Namespace.
+The `tcld namespace certificate-filters clear` command clears all certificate filters from a [Namespace](/concepts/what-is-a-namespace) in Temporal Cloud.
 
+:::info Be aware 
+
+Using this command allows *any* client certificate that chains up to a configured CA certificate to connect to the Namespace.
+
+:::
+
+`tcld namespace certificate-filters clear`
+
+The following modifiers control the behavior of the command.
+
+### `--namespace`
+
+Specify a Namespace hosted on Temporal Cloud. If not specified, the value of the environment variable $TEMPORAL_CLOUD_NAMESPACE is used.
+
+Alias: `-n`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters clear --namespace <namespace_id>
+```
+
+### `--request-id`
+
+Specify a request identifier to use for the asynchronous operation. If not specified, the server assigns a request identifier.
+
+Alias: `-r`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters clear --request-id <request_id>
+```
+
+### `--resource-version`
+
+Specify a resource version (ETag) to update from. If not specified, the latest version is used.
+
+Alias: `-v`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters clear --resource-version <etag>
+```

--- a/docs/cloud/tcld/namespace/certificate-filters/clear.md
+++ b/docs/cloud/tcld/namespace/certificate-filters/clear.md
@@ -1,0 +1,11 @@
+---
+id: clear
+title: tcld namespace certificate-filters clear
+description: How to clear all certificate filters from a Namespace in Temporal Cloud using tcld.
+tags:
+  - reference
+  - tcld
+---
+
+The `tcld namespace certificate-filters clear` command clears all certificate filters from a [Namespace](/concepts/what-is-a-namespace) in Temporal Cloud. Using this command allows *any* client certificate that chains up to a configured CA certificate to connect to the Namespace.
+

--- a/docs/cloud/tcld/namespace/certificate-filters/export.md
+++ b/docs/cloud/tcld/namespace/certificate-filters/export.md
@@ -1,0 +1,11 @@
+---
+id: export
+title: tcld namespace certificate-filters export
+description: How to export existing certificate filters from a Namespace in Temporal Cloud using tcld.
+tags:
+  - reference
+  - tcld
+---
+
+The `tcld namespace certificate-filters export` command exports existing certificate filters from a [Namespace](/concepts/what-is-a-namespace) in Temporal Cloud.
+

--- a/docs/cloud/tcld/namespace/certificate-filters/export.md
+++ b/docs/cloud/tcld/namespace/certificate-filters/export.md
@@ -1,7 +1,7 @@
 ---
 id: export
 title: tcld namespace certificate-filters export
-description: How to export existing certificate filters from a Namespace in Temporal Cloud using tcld.
+description: How to export certificate filters from a Namespace in Temporal Cloud using tcld.
 tags:
   - reference
   - tcld
@@ -9,3 +9,56 @@ tags:
 
 The `tcld namespace certificate-filters export` command exports existing certificate filters from a [Namespace](/concepts/what-is-a-namespace) in Temporal Cloud.
 
+`tcld namespace certificate-filters export --certificate-filter-file <path>`
+
+Alias: `exp`
+
+The following modifiers control the behavior of the command.
+
+### `--certificate-filter-file`
+
+Specify a path to a JSON file where tcld can export the certificate filters.
+
+Aliases: `--file`, `-f`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters export --certificate-filter-file <path>
+```
+
+### `--namespace`
+
+Specify a Namespace hosted on Temporal Cloud. If not specified, the value of the environment variable $TEMPORAL_CLOUD_NAMESPACE is used.
+
+Alias: `-n`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters import --namespace <namespace_id> --certificate-filter-input <json>
+```
+
+### `--request-id`
+
+Specify a request identifier to use for the asynchronous operation. If not specified, the server assigns a request identifier.
+
+Alias: `-r`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters import --request-id <request_id> --certificate-filter-input <json>
+```
+
+### `--resource-version`
+
+Specify a resource version (ETag) to update from. If not specified, the latest version is used.
+
+Alias: `-v`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters import --resource-version <etag> --certificate-filter-input <json>
+```

--- a/docs/cloud/tcld/namespace/certificate-filters/import.md
+++ b/docs/cloud/tcld/namespace/certificate-filters/import.md
@@ -11,6 +11,15 @@ The `tcld namespace certificate-filters import` command sets certificate filters
 
 `tcld namespace certificate-filters import --certificate-filter-file <path>`
 
+Alias: `imp`
+
+A certificate filter can include any combination (and at least one) of the following:
+
+- `commonName`
+- `organization`
+- `organizationalUnit`
+- `subjectAlternativeName`
+
 The following modifiers control the behavior of the command.
 
 ### `--certificate-filter-file`

--- a/docs/cloud/tcld/namespace/certificate-filters/import.md
+++ b/docs/cloud/tcld/namespace/certificate-filters/import.md
@@ -1,0 +1,81 @@
+---
+id: import
+title: tcld namespace certificate-filters import
+description: How to set certificate filters for a Namespace in Temporal Cloud using tcld.
+tags:
+  - reference
+  - tcld
+---
+
+The `tcld namespace certificate-filters import` command sets certificate filters for a [Namespace](/concepts/what-is-a-namespace) in Temporal Cloud.
+
+`tcld namespace certificate-filters import --certificate-filter-file <path>`
+
+The following modifiers control the behavior of the command.
+
+### `--certificate-filter-file`
+
+_Required modifier unless `--certificate-filter-input` is specified_
+
+Specify a path to a JSON file that defines certificate filters to be applied to the Namespace, such as `{ "filters": [ { "commonName": "test1" } ] }`. The specified filters replace any existing filters.
+
+If both `--certificate-filter-file` and `--certificate-filter-input` are specified, the command returns an error.
+
+Aliases: `--file`, `-f`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters import --certificate-filter-file <path>
+```
+### `--certificate-filter-input`
+
+_Required modifier unless `--certificate-filter-file` is specified_
+
+Specify a JSON string that defines certificate filters to be applied to the Namespace, such as `{ "filters": [ { "commonName": "test1" } ] }`. The specified filters replace any existing filters.
+
+If both `--certificate-filter-input` and `--certificate-filter-file` are specified, the command returns an error.
+
+Aliases: `--input`, `-i`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters import --certificate-filter-input <json>
+```
+
+### `--namespace`
+
+Specify a Namespace hosted on Temporal Cloud. If not specified, the value of the environment variable $TEMPORAL_CLOUD_NAMESPACE is used.
+
+Alias: `-n`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters import --namespace <namespace_id> --certificate-filter-input <json>
+```
+
+### `--request-id`
+
+Specify a request identifier to use for the asynchronous operation. If not specified, the server assigns a request identifier.
+
+Alias: `-r`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters import --request-id <request_id> --certificate-filter-input <json>
+```
+
+### `--resource-version`
+
+Specify a resource version (ETag) to update from. If not specified, the latest version is used.
+
+Alias: `-v`
+
+**Example**
+
+```bash
+tcld namespace certificate-filters import --resource-version <etag> --certificate-filter-input <json>
+```

--- a/docs/cloud/tcld/namespace/certificate-filters/index.md
+++ b/docs/cloud/tcld/namespace/certificate-filters/index.md
@@ -1,0 +1,16 @@
+---
+id: index
+title: tcld namespace certificate-filters
+description: How to manage certificate filters for a Namespace in Temporal Cloud using tcld.
+tags:
+  - reference
+  - tcld
+---
+
+The `tcld namespace certificate-filters` commands manage optional certificate filters for the specified [Namespace](/concepts/what-is-a-namespace) in Temporal Cloud. The Namespace can use certificate filters to authorize client certificates based on distinguished name (DN) fields.
+
+Alias: `cf`
+
+- [`tcld namespace certificate-filters import`](/cloud/tcld/namespace/certificate-filters/import)
+- [`tcld namespace certificate-filters export`](/cloud/tcld/namespace/certificate-filters/export)
+- [`tcld namespace certificate-filters clear`](/cloud/tcld/namespace/certificate-filters/clear)

--- a/docs/cloud/tcld/namespace/index.md
+++ b/docs/cloud/tcld/namespace/index.md
@@ -14,4 +14,5 @@ Alias: `n`
 - [`tcld namespace list`](/cloud/tcld/namespace/list)
 - [`tcld namespace get`](/cloud/tcld/namespace/get)
 - [`tcld namespace accepted-client-ca`](/cloud/tcld/namespace/accepted-client-ca)
+- [`tcld namespace certificate-filters`](/cloud/tcld/namespace/certificate-filters)
 - [`tcld namespace search-attributes`](/cloud/tcld/namespace/search-attributes)

--- a/sidebars.js
+++ b/sidebars.js
@@ -46,6 +46,11 @@ module.exports = {
         id: "cloud/index",
       },
       items: [
+        {
+          type: "link",
+          label: "Release notes",
+          href: "https://docs.temporal.io/cloud/release-notes",
+        },
         "cloud/tcld/how-to-install-tcld",
         {
           type: "category",
@@ -84,6 +89,21 @@ module.exports = {
                     "cloud/tcld/namespace/accepted-client-ca/list",
                     "cloud/tcld/namespace/accepted-client-ca/set",
                     "cloud/tcld/namespace/accepted-client-ca/remove",
+                  ],
+                },
+                {
+                  type: "category",
+                  label: "certificate-filters",
+                  collapsible: true,
+                  collapsed: true,
+                  link: {
+                    type: "doc",
+                    id: "cloud/tcld/namespace/certificate-filters/index",
+                  },
+                  items: [
+                    "cloud/tcld/namespace/certificate-filters/import",
+                    "cloud/tcld/namespace/certificate-filters/export",
+                    "cloud/tcld/namespace/certificate-filters/clear",
                   ],
                 },
                 {


### PR DESCRIPTION
## What does this PR do?

- Per v0.1.4, add `tcld namespace certificate-filters` and three sub-commands: `import`, `export`, and `clear`
- Add link to release notes for Temporal Cloud to sidebar (left nav)
