### PR TITLE
Fixing src link to custom archiver

### DIFF
--- a/docs/activities.md
+++ b/docs/activities.md
@@ -211,7 +211,7 @@ If an [Activity Task Execution](/tasks#activity-task-execution) times out due to
 
 Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress"?
 For short-term operations, progress updates are not a requirement.
-However, checking the progress and status of Activity Executions that run over long periods is almost always useful.
+However, checking the progress and status of Activities that run over long periods is almost always useful.
 
 Consider the following when setting Activity Hearbeats:
 

--- a/docs/activities.md
+++ b/docs/activities.md
@@ -211,7 +211,7 @@ If an [Activity Task Execution](/tasks#activity-task-execution) times out due to
 
 Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress"?
 For short-term operations, progress updates are not a requirement.
-However, checking the progress and status of Activities that run over long periods is almost always useful.
+However, checking the progress and status of Activity Executions that run over long periods is almost always useful.
 
 Consider the following when setting Activity Hearbeats:
 

--- a/docs/application-development/features.md
+++ b/docs/application-development/features.md
@@ -236,7 +236,7 @@ In the example above, the Workflow code uses `workflow.GetSignalChannel` to open
 We then use a [`workflow.Selector`](/go/selectors) and the `AddReceive()` to wait on a Signal from this channel.
 The `more` bool in the callback function indicates that channel is not closed and more deliveries are possible.
 
-Before completing the Workflow or [Continuing-As-New](/application-development/features#continue-as-new), make sure to do an asynchronous drain on the Signal channel.
+Before completing the Workflow or using [Continue-As-New](/application-development/features#continue-as-new), make sure to do an asynchronous drain on the Signal channel.
 Otherwise, the Signals will be lost.
 
 </TabItem>

--- a/docs/clusters/how-to-set-up-archival.md
+++ b/docs/clusters/how-to-set-up-archival.md
@@ -26,7 +26,7 @@ Temporal directly supports several providers:
 - **Local file system**: The [filestore archiver](https://github.com/temporalio/temporal/tree/master/common/archiver/filestore) is used to archive data in the file system of whatever host the Temporal server is running on. This provider is used mainly for local installations and testing and should not be relied on for production environments.
 - **Google Cloud**: The [gcloud archiver](https://github.com/temporalio/temporal/tree/master/common/archiver/gcloud) is used to connect and archive data with [Google Cloud](https://cloud.google.com/storage).
 - **S3**: The [s3store archiver](https://github.com/temporalio/temporal/tree/master/common/archiver/s3store) is used to connect and archive data with [S3](https://aws.amazon.com/s3).
-- **Custom**: If you want to use a provider that is not currently supported, you can [create your own archiver](#custom-archiver) to support it.
+- **Custom**: If you want to use a provider that is not currently supported, you can [create your own archiver](/clusters/how-to-create-a-custom-archiver) to support it.
 
 Make sure that you save the provider's storage location URI in a place where you can reference it later, because it is passed as a parameter when you [create a Namespace](#namespace-creation).
 

--- a/docs/concepts/what-is-an-activity-heartbeat.md
+++ b/docs/concepts/what-is-an-activity-heartbeat.md
@@ -33,7 +33,7 @@ If an [Activity Task Execution](/concepts/what-is-an-activity-task-execution) ti
 
 Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress"?
 For short-term operations, progress updates are not a requirement.
-However, checking the progress and status of Activities that run over long periods is almost always useful.
+However, checking the progress and status of Activity Executions that run over long periods is almost always useful.
 
 Consider the following when setting Activity Hearbeats:
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -407,15 +407,15 @@ The main reason for increasing the default value would be to accommodate a Workf
 A Signal is an asynchronous request to a [Workflow Execution](#workflow-executions).
 
 A Signal delivers data to a running Workflow Execution.
-It cannot return data to the caller (use [Queries](#queries) for that).
-The Workflow code that handles a Signal may mutate Workflow state.
+It cannot return data to the caller; to do so, use a [Query](#queries) instead.
+The Workflow code that handles a Signal can mutate Workflow state.
 A Signal can be sent from a Temporal Client or a Workflow.
 When a Signal is sent, it is received by the Cluster and recorded as an Event to the Workflow Execution [Event History](#event-history).
 A successful response from the Cluster means that the Signal has been persisted and will be delivered at least once to the Workflow Execution.[^1]
 The next scheduled Workflow Task will contain the Signal Event.
 
-A Signal must include a destination (Namespace & Workflow Id) and name.
-It may include a list of arguments.
+A Signal must include a destination (Namespace and Workflow Id) and name.
+It can include a list of arguments.
 
 Signal handlers are Workflow functions that listen for Signals by the Signal name.
 Signals are delivered in the order they are received by the Cluster.
@@ -423,7 +423,7 @@ If multiple deliveries of a Signal would be a problem for your Workflow, add ide
 
 - [How to use Signals](/application-development/features#signals)
 
-[^1]: The Cluster usually deduplicates Signals, but does not guarantee deduplication: there can be two Signal Events (and therefore two deliveries to the Workflow Execution) for a single Signal during shard migration, since the deduping info is only stored in memory.
+[^1]: The Cluster usually deduplicates Signals, but does not guarantee deduplication: During shard migration, two Signal Events (and therefore two deliveries to the Workflow Execution) can be recorded for a single Signal because the deduping info is stored only in memory.
 
 ## Queries
 


### PR DESCRIPTION
Per https://github.com/temporalio/documentation/pull/1316 
However, versioned docs were removed, so fixing this in the docs src directory.

Other changes are from `yarn gen`