### PR TITLE
Update limits for Cloud Namespace Names

### DIFF
--- a/docs/concepts/what-is-a-cloud-namespace-name.md
+++ b/docs/concepts/what-is-a-cloud-namespace-name.md
@@ -13,7 +13,7 @@ It cannot be changed after the Namespace is provisioned.
 
 Each Namespace Name must conform to the DNS naming rules:
 
+- A Namespace Name must contain at least 1 character and no more than 34 characters.
 - A Namespace Name must begin or end with a letter or number and can contain only letters, numbers, and the hyphen (-) character.
-- Each hyphen (-) character must be immediately preceded and followed by a letter or number; consecutive hyphens are not permitted.
+- Each hyphen (-) character must be immediately preceded _and_ followed by a letter or number; consecutive hyphens are not permitted.
 - All letters in a Namespace Name must be lowercase.
-- Namespace Names must contain at least 3 characters and no more than 23 characters.


### PR DESCRIPTION
## What does this PR do?

Update the length limits for a Cloud Namespace Name (was 3–23, is 1–34), per experiments run by @mastermanu.

## Preview

**https://deploy-preview-1351--mystifying-fermi-1bc096.netlify.app/concepts/what-is-a-cloud-namespace-name**
