### PR TITLE
Guide context and narrative cleanup

### DIFF
--- a/docs/activities.md
+++ b/docs/activities.md
@@ -213,9 +213,9 @@ Heartbeat throttling may lead to Cancellation getting delivered later than expec
 #### Throttling
 
 Heartbeats may not always be sent to the Cluster—they may be throttled by the Worker.
-The throttle interval is the smaller of:
+The throttle interval is the smaller of the following:
 
-- `if heartbeatTimeout is provided, heartbeatTimeout * 0.8; else defaultHeartbeatThrottleInterval`
+- If `heartbeatTimeout` is provided, `heartbeatTimeout * 0.8`; otherwise, `defaultHeartbeatThrottleInterval`
 - `maxHeartbeatThrottleInterval`
 
 `defaultHeartbeatThrottleInterval` is 30 seconds by default, and `maxHeartbeatThrottleInterval` is 60 seconds by default.
@@ -229,9 +229,9 @@ Throttling is implemented as follows:
   - Sends the most recent Heartbeat.
   - Sets the timer again.
 
-#### Which Activities should Heartbeat
+#### Which Activities should Heartbeat?
 
-Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress"?
+Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress?"
 For short-term operations, progress updates are not a requirement.
 However, checking the progress and status of Activity Executions that run over long periods is almost always useful.
 

--- a/docs/app-dev-context/activity-heartbeats.md
+++ b/docs/app-dev-context/activity-heartbeats.md
@@ -1,24 +1,20 @@
-An Activity Heartbeat is a ping from the Worker that is executing the Activity to the Temporal Cluster.
-Each Heartbeat informs the Temporal Cluster that the Activity Execution is making progress and the Worker has not crashed.
+---
+id: activity-heartbeats
+title: Activity Heartbeats conceptual context
+sidebar_label: Activity Heartbeats
+description: An Activity Heartbeat is a ping from the Worker that is executing the Activity to the Temporal Cluster.
+tags:
+  - guide-context
+---
+
+An [Activity Heartbeat](/concepts/what-is-an-activity-heartbeat) is a ping from the [Worker Process](/concepts/what-is-a-worker-process) that is executing the Activity to the [Temporal Cluster](/concepts/what-is-a-temporal-cluster).
+Each Heartbeat informs the Temporal Cluster that the [Activity Execution](/concepts/what-is-an-activity-execution) is making progress and the Worker has not crashed.
 If the Cluster does not receive a Heartbeat within a [Heartbeat Timeout](/concepts/what-is-a-heartbeat-timeout) time period, the Activity will be considered failed and another [Activity Task Execution](/concepts/what-is-an-activity-task-execution) may be scheduled according to the Retry Policy.
 
-Heartbeats may not always be sent to the Cluster—they may be throttled by the Worker.
-The throttle interval is the smaller of:
+Heartbeats may not always be sent to the Cluster—they may be [throttled](/concepts/what-is-an-activity-heartbeat#throttling) by the Worker.
 
-- `if heartbeatTimeout is provided, heartbeatTimeout * 0.8; else defaultHeartbeatThrottleInterval`
-- `maxHeartbeatThrottleInterval`
+Activity Cancellations are delivered to Activities from the Cluster when they Heartbeat. Activities that don't Heartbeat can't receive a Cancellation.
+Heartbeat throttling may lead to Cancellation getting delivered later than expected.
 
-`defaultHeartbeatThrottleInterval` is 30 seconds by default, and `maxHeartbeatThrottleInterval` is 60 seconds by default.
-Each can be set in Worker options.
-
-Throttling is implemented as follows:
-
-- After sending a Heartbeat, the Worker sets a timer for the throttle interval.
-- The Worker stops sending Heartbeats, but continues receiving Heartbeats from the Activity and remembers the most recent one.
-- When the timer fires, the Worker:
-  - Sends the most recent Heartbeat.
-  - Sets the timer again.
-
-Activity Cancellations are delivered to Activities from the Cluster when they Heartbeat. Activities that don't Heartbeat can't receive a Cancellation. Heartbeat throttling may lead to Cancellation getting delivered later than expected.
-
-Heartbeats may contain a `details` field describing the Activity's current progress. If an Activity gets retried, the Activity can access the `details` from the last heartbeat that was sent to the Cluster.
+Heartbeats may contain a `details` field describing the Activity's current progress.
+If an Activity gets retried, the Activity can access the `details` from the last heartbeat that was sent to the Cluster.

--- a/docs/app-dev-context/activity-heartbeats.md
+++ b/docs/app-dev-context/activity-heartbeats.md
@@ -16,5 +16,5 @@ Heartbeats may not always be sent to the Cluster—they may be [throttled](/conc
 Activity Cancellations are delivered to Activities from the Cluster when they Heartbeat. Activities that don't Heartbeat can't receive a Cancellation.
 Heartbeat throttling may lead to Cancellation getting delivered later than expected.
 
-Heartbeats may contain a `details` field describing the Activity's current progress.
-If an Activity gets retried, the Activity can access the `details` from the last heartbeat that was sent to the Cluster.
+Heartbeats can contain a `details` field describing the Activity's current progress.
+If an Activity gets retried, the Activity can access the `details` from the last Heartbeat that was sent to the Cluster.

--- a/docs/app-dev-context/activity-parameters.md
+++ b/docs/app-dev-context/activity-parameters.md
@@ -1,4 +1,19 @@
-All Activity parameters must be serializable.
+---
+id: activity-parameters
+title: Activity Parameters - Appplication development context
+sidebar_label: Activity Parameters
+description: When it comes to your application data, that is – data that is serialized and encoded into a Payload, we recommend that you use a single object as an argument that wraps around the application data passed to Activities.
+tags:
+  - guide-context
+---
 
-There is no explicit limit to the amount of parameter data that can be passed to an Activity, but keep in mind that all parameters and return values are recorded in a [Workflow Execution Event History](/concepts/what-is-an-event-history).
-A large Workflow Execution Event History can adversely impact the performance of your Workflow Executions, because the entire Event History is transferred to Worker Processes with every [Workflow Task](/concepts/what-is-a-workflow-task).
+There is no explicit limit to the total number of parameters that an [Activity Definition](/concepts/what-is-an-activity-definition) may support.
+However, there is a limit of the total size of the data ends up encoded into a gRPC message Payload.
+Also, keep in mind that all Payload data is recorded in the [Workflow Execution Event History](/concepts/what-is-an-event-history) and large Event Histories can affect Worker performance.
+This is because the entire Event History could be transferred to a Worker Process with a [Workflow Task](/concepts/what-is-a-workflow-task).
+
+<!--TODO link to gRPC limit section when available -->
+
+Some SDKs require that you pass context objects, others do not.
+When it comes to your application data, that is – data that is serialized and encoded into a Payload, we recommend that you use a single object as an argument that wraps around the application data passed to Activities.
+This is so that you can change what data is passed to the Activity without breaking a function or method signature.

--- a/docs/app-dev-context/activity-parameters.md
+++ b/docs/app-dev-context/activity-parameters.md
@@ -9,6 +9,10 @@ tags:
 
 There is no explicit limit to the total number of parameters that an [Activity Definition](/concepts/what-is-an-activity-definition) may support.
 However, there is a limit of the total size of the data ends up encoded into a gRPC message Payload.
+
+A single argument is limited to a maximum size of 2 MB.
+And the total size of a gRPC message, which includes all the arguments, is limited to a maximum of 4 MB.
+
 Also, keep in mind that all Payload data is recorded in the [Workflow Execution Event History](/concepts/what-is-an-event-history) and large Event Histories can affect Worker performance.
 This is because the entire Event History could be transferred to a Worker Process with a [Workflow Task](/concepts/what-is-a-workflow-task).
 

--- a/docs/app-dev-context/activity-parameters.md
+++ b/docs/app-dev-context/activity-parameters.md
@@ -1,8 +1,8 @@
 ---
 id: activity-parameters
-title: Activity Parameters - Appplication development context
+title: Activity Parameters - Application development context
 sidebar_label: Activity Parameters
-description: When it comes to your application data, that is – data that is serialized and encoded into a Payload, we recommend that you use a single object as an argument that wraps around the application data passed to Activities.
+description: When it comes to your application data—that is, data that is serialized and encoded into a Payload—we recommend that you use a single object as an argument that wraps the application data passed to Activities.
 tags:
   - guide-context
 ---
@@ -15,5 +15,5 @@ This is because the entire Event History could be transferred to a Worker Proces
 <!--TODO link to gRPC limit section when available -->
 
 Some SDKs require that you pass context objects, others do not.
-When it comes to your application data, that is – data that is serialized and encoded into a Payload, we recommend that you use a single object as an argument that wraps around the application data passed to Activities.
+When it comes to your application data—that is, data that is serialized and encoded into a Payload—we recommend that you use a single object as an argument that wraps the application data passed to Activities.
 This is so that you can change what data is passed to the Activity without breaking a function or method signature.

--- a/docs/app-dev-context/activity-retry-policy.md
+++ b/docs/app-dev-context/activity-retry-policy.md
@@ -1,1 +1,10 @@
+---
+id: activity-retry-policy
+title: Activity Parameters - Appplication development context
+sidebar_label: Activity Parameters
+description: Activity Executions are automatically associated with a default Retry Policy if a custom one is not provided.
+tags:
+  - guide-context
+---
+
 Activity Executions are automatically associated with a default [Retry Policy](/concepts/what-is-a-retry-policy) if a custom one is not provided.

--- a/docs/app-dev-context/activity-retry-policy.md
+++ b/docs/app-dev-context/activity-retry-policy.md
@@ -1,6 +1,6 @@
 ---
 id: activity-retry-policy
-title: Activity Parameters - Appplication development context
+title: Activity Parameters - Application development context
 sidebar_label: Activity Parameters
 description: Activity Executions are automatically associated with a default Retry Policy if a custom one is not provided.
 tags:

--- a/docs/application-development/features.md
+++ b/docs/application-development/features.md
@@ -2078,8 +2078,8 @@ Heartbeats may not always be sent to the Cluster—they may be [throttled](/conc
 Activity Cancellations are delivered to Activities from the Cluster when they Heartbeat. Activities that don't Heartbeat can't receive a Cancellation.
 Heartbeat throttling may lead to Cancellation getting delivered later than expected.
 
-Heartbeats may contain a `details` field describing the Activity's current progress.
-If an Activity gets retried, the Activity can access the `details` from the last heartbeat that was sent to the Cluster.
+Heartbeats can contain a `details` field describing the Activity's current progress.
+If an Activity gets retried, the Activity can access the `details` from the last Heartbeat that was sent to the Cluster.
 
 <Tabs
 defaultValue="go"
@@ -2162,6 +2162,7 @@ public class YourActivityDefinitionImpl implements YourActivityDefinition {
 ```
 
 The method takes an optional argument, the `details` variable above that represents latest progress of the Activity Execution.
+This method can take a variety of types such as an exception object, custom object, or string.
 
 If the Activity Execution times out, the last Heartbeat `details` are included in the thrown `ActivityTimeoutException`, which can be caught by the calling Workflow.
 The Workflow can then use the `details` information to pass to the next Activity invocation if needed.
@@ -2260,7 +2261,7 @@ In this example, when the `heartbeatTimeout` is reached and the Activity is retr
 </TabItem>
 <TabItem value="python">
 
-To Heartbeat an Activity Execution in Python, us the [`heartbeat()`](https://python.temporal.io/temporalio.activity.html#heartbeat) API.
+To Heartbeat an Activity Execution in Python, use the [`heartbeat()`](https://python.temporal.io/temporalio.activity.html#heartbeat) API.
 
 ```python
     @activity.defn
@@ -2269,7 +2270,7 @@ To Heartbeat an Activity Execution in Python, us the [`heartbeat()`](https://pyt
 ```
 
 In addition to obtaining cancellation information, Heartbeats also support detail data that persists on the server for retrieval during Activity retry.
-If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` will return an iterable containing `123` and `456` on the next Run.
+If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` returns an iterable containing `123` and `456` on the next Run.
 
 </TabItem>
 </Tabs>

--- a/docs/application-development/features.md
+++ b/docs/application-development/features.md
@@ -19,7 +19,7 @@ This guide is a work in progress.
 Some sections may be incomplete or missing for some languages.
 Information may change at any time.
 
-If you can not find what you are looking for in the Application development guide, it could be in [older docs for SDKs](/sdks).
+If you can't find what you are looking for in the Application development guide, it could be in [older docs for SDKs](/sdks).
 
 :::
 
@@ -2069,30 +2069,17 @@ import RetrySimulator from '/docs/components/RetrySimulator/RetrySimulator';
 
 ## Activity Heartbeats
 
-An Activity Heartbeat is a ping from the Worker that is executing the Activity to the Temporal Cluster.
-Each Heartbeat informs the Temporal Cluster that the Activity Execution is making progress and the Worker has not crashed.
+An [Activity Heartbeat](/activities#activity-heartbeats) is a ping from the [Worker Process](/workers#worker-process) that is executing the Activity to the [Temporal Cluster](/clusters#).
+Each Heartbeat informs the Temporal Cluster that the [Activity Execution](/activities#activity-execution) is making progress and the Worker has not crashed.
 If the Cluster does not receive a Heartbeat within a [Heartbeat Timeout](/activities#heartbeat-timeout) time period, the Activity will be considered failed and another [Activity Task Execution](/tasks#activity-task-execution) may be scheduled according to the Retry Policy.
 
-Heartbeats may not always be sent to the Cluster—they may be throttled by the Worker.
-The throttle interval is the smaller of:
+Heartbeats may not always be sent to the Cluster—they may be [throttled](/concepts/what-is-an-activity-heartbeat#throttling) by the Worker.
 
-- `if heartbeatTimeout is provided, heartbeatTimeout * 0.8; else defaultHeartbeatThrottleInterval`
-- `maxHeartbeatThrottleInterval`
+Activity Cancellations are delivered to Activities from the Cluster when they Heartbeat. Activities that don't Heartbeat can't receive a Cancellation.
+Heartbeat throttling may lead to Cancellation getting delivered later than expected.
 
-`defaultHeartbeatThrottleInterval` is 30 seconds by default, and `maxHeartbeatThrottleInterval` is 60 seconds by default.
-Each can be set in Worker options.
-
-Throttling is implemented as follows:
-
-- After sending a Heartbeat, the Worker sets a timer for the throttle interval.
-- The Worker stops sending Heartbeats, but continues receiving Heartbeats from the Activity and remembers the most recent one.
-- When the timer fires, the Worker:
-  - Sends the most recent Heartbeat.
-  - Sets the timer again.
-
-Activity Cancellations are delivered to Activities from the Cluster when they Heartbeat. Activities that don't Heartbeat can't receive a Cancellation. Heartbeat throttling may lead to Cancellation getting delivered later than expected.
-
-Heartbeats may contain a `details` field describing the Activity's current progress. If an Activity gets retried, the Activity can access the `details` from the last heartbeat that was sent to the Cluster.
+Heartbeats may contain a `details` field describing the Activity's current progress.
+If an Activity gets retried, the Activity can access the `details` from the last heartbeat that was sent to the Cluster.
 
 <Tabs
 defaultValue="go"
@@ -2101,22 +2088,23 @@ values={[{label: 'Go', value: 'go'},{label: 'Java', value: 'java'},{label: 'PHP'
 
 <TabItem value="go">
 
-To [Heartbeat](/activities#activity-heartbeats) in an Activity, use the `RecordHeartbeat` API.
+To [Heartbeat](/activities#activity-heartbeats) in an Activity in Go, use the `RecordHeartbeat` API.
 
 ```go
-progress := 0
-for progress < 100 {
-    // Send heartbeat message to the server.
-    activity.RecordHeartbeat(ctx, progress)
-    // Do some work.
-    ...
-    progress++
+import (
+    // ...
+    "go.temporal.io/sdk/workflow"
+    // ...
+)
+
+func YourActivityDefinition(ctx, YourActivityDefinitionParam) (YourActivityDefinitionResult, error) {
+    // ...
+    activity.RecordHeartbeat(ctx, details)
+    // ...
 }
 ```
 
-When an Activity Task Execution times out due to a missed Heartbeat, the last value of the details (`progress` in the
-above sample) is returned from the `workflow.ExecuteActivity` function as the details field of `TimeoutError`
-with `TimeoutType` set to `Heartbeat`.
+When an Activity Task Execution times out due to a missed Heartbeat, the last value of the `details` variable above is returned to the calling Workflow in the `details` field of `TimeoutError` with `TimeoutType` set to `Heartbeat`.
 
 You can also Heartbeat an Activity from an external source:
 
@@ -2158,37 +2146,27 @@ func SampleActivity(ctx context.Context, inputArg InputParams) error {
 </TabItem>
 <TabItem value="java">
 
-To inform the Temporal service that the Activity is still alive, use `Activity.getExecutionContext().heartbeat()` in the Activity implementation code.
+To Heartbeat an Activity Execution in Java, use the `Activity.getExecutionContext().heartbeat()` Class method.
 
-The `Activity.getExecutionContext().heartbeat()` can take an argument that represents Heartbeat `details`.
-If an Activity times out, the last Heartbeat `details` are included in the thrown `ActivityTimeoutException`, which can be caught by the calling Workflow.
+```java
+public class YourActivityDefinitionImpl implements YourActivityDefinition {
+
+  @Override
+  public String yourActivityMethod(YourActivityMethodParam param) {
+    // ...
+    Activity.getExecutionContext().heartbeat(details);
+    // ...
+  }
+  // ...
+}
+```
+
+The method takes an optional argument, the `details` variable above that represents latest progress of the Activity Execution.
+
+If the Activity Execution times out, the last Heartbeat `details` are included in the thrown `ActivityTimeoutException`, which can be caught by the calling Workflow.
 The Workflow can then use the `details` information to pass to the next Activity invocation if needed.
 
 In the case of Activity retries, the last Heartbeat's `details` are available and can be extracted from the last failed attempt by using `Activity.getExecutionContext().getHeartbeatDetails(Class<V> detailsClass)`
-
-The following example uses Activity Heartbeat to report the progress of the `download` Activity method.
-
-```java
-public class FileProcessingActivitiesImpl implements FileProcessingActivities {
-
-  @Override
-  public String download(String bucketName, String remoteName, String localName) {
-    InputStream inputStream = openInputStream(file);
-    try {
-      byte[] bytes = new byte[MAX_BUFFER_SIZE];
-      while ((read = inputStream.read(bytes)) != -1) {
-        totalRead += read;
-        f.write(bytes, 0, read);
-        // Let the Temporal Server know about the download progress.
-        Activity.getExecutionContext().heartbeat(totalRead);
-      }
-    } finally {
-      inputStream.close();
-    }
-  }
-  ...
-}
-```
 
 </TabItem>
 <TabItem value="php">
@@ -2282,15 +2260,16 @@ In this example, when the `heartbeatTimeout` is reached and the Activity is retr
 </TabItem>
 <TabItem value="python">
 
-In order for an Activity to be notified of cancellation requests, you must invoke [`heartbeat()`](https://python.temporal.io/temporalio.activity.html#heartbeat).
+To Heartbeat an Activity Execution in Python, us the [`heartbeat()`](https://python.temporal.io/temporalio.activity.html#heartbeat) API.
 
 ```python
     @activity.defn
-    async def some_activity() -> str:
+    async def your_activity_definition() -> str:
         activity.heartbeat("heartbeat details!")
 ```
 
-In addition to obtaining cancellation information, Heartbeats also support detail data that persists on the server for retrieval during Activity Retry. If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` will return an iterable containing `123` and `456` on the next run.
+In addition to obtaining cancellation information, Heartbeats also support detail data that persists on the server for retrieval during Activity retry.
+If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` will return an iterable containing `123` and `456` on the next Run.
 
 </TabItem>
 </Tabs>

--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -19,7 +19,7 @@ This guide is a work in progress.
 Some sections may be incomplete or missing for some languages.
 Information may change at any time.
 
-If you can not find what you are looking for in the Application development guide, it could be in [older docs for SDKs](/sdks).
+If you can't find what you are looking for in the Application development guide, it could be in [older docs for SDKs](/sdks).
 
 :::
 
@@ -1495,10 +1495,16 @@ These require special primitives for heartbeating and cancellation. The `shared_
 
 ### Activity parameters
 
-All Activity parameters must be serializable.
+There is no explicit limit to the total number of parameters that an [Activity Definition](/activities#activity-definition) may support.
+However, there is a limit of the total size of the data ends up encoded into a gRPC message Payload.
+Also, keep in mind that all Payload data is recorded in the [Workflow Execution Event History](/workflows#event-history) and large Event Histories can affect Worker performance.
+This is because the entire Event History could be transferred to a Worker Process with a [Workflow Task](/tasks#workflow-task).
 
-There is no explicit limit to the amount of parameter data that can be passed to an Activity, but keep in mind that all parameters and return values are recorded in a [Workflow Execution Event History](/workflows#event-history).
-A large Workflow Execution Event History can adversely impact the performance of your Workflow Executions, because the entire Event History is transferred to Worker Processes with every [Workflow Task](/tasks#workflow-task).
+<!--TODO link to gRPC limit section when available -->
+
+Some SDKs require that you pass context objects, others do not.
+When it comes to your application data, that is – data that is serialized and encoded into a Payload, we recommend that you use a single object as an argument that wraps around the application data passed to Activities.
+This is so that you can change what data is passed to the Activity without breaking a function or method signature.
 
 <Tabs
 defaultValue="go"

--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -1497,13 +1497,17 @@ These require special primitives for heartbeating and cancellation. The `shared_
 
 There is no explicit limit to the total number of parameters that an [Activity Definition](/activities#activity-definition) may support.
 However, there is a limit of the total size of the data ends up encoded into a gRPC message Payload.
+
+A single argument is limited to a maximum size of 2 MB.
+And the total size of a gRPC message, which includes all the arguments, is limited to a maximum of 4 MB.
+
 Also, keep in mind that all Payload data is recorded in the [Workflow Execution Event History](/workflows#event-history) and large Event Histories can affect Worker performance.
 This is because the entire Event History could be transferred to a Worker Process with a [Workflow Task](/tasks#workflow-task).
 
 <!--TODO link to gRPC limit section when available -->
 
 Some SDKs require that you pass context objects, others do not.
-When it comes to your application data, that is – data that is serialized and encoded into a Payload, we recommend that you use a single object as an argument that wraps around the application data passed to Activities.
+When it comes to your application data—that is, data that is serialized and encoded into a Payload—we recommend that you use a single object as an argument that wraps the application data passed to Activities.
 This is so that you can change what data is passed to the Activity without breaking a function or method signature.
 
 <Tabs

--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -16,7 +16,7 @@ This guide is a work in progress.
 Some sections may be incomplete or missing for some languages.
 Information may change at any time.
 
-If you can not find what you are looking for in the Application development guide, it could be in [older docs for SDKs](/sdks).
+If you can't find what you are looking for in the Application development guide, it could be in [older docs for SDKs](/sdks).
 
 :::
 

--- a/docs/concepts/what-is-an-activity-heartbeat.md
+++ b/docs/concepts/what-is-an-activity-heartbeat.md
@@ -29,7 +29,29 @@ That way if a Worker fails it can be handled in a timely manner.
 A Heartbeat can include an application layer payload that can be used to _save_ Activity Execution progress.
 If an [Activity Task Execution](/concepts/what-is-an-activity-task-execution) times out due to a missed Heartbeat, the next Activity Task can access and continue with that payload.
 
-**What Activities should Heartbeat?**
+Activity Cancellations are delivered to Activities from the Cluster when they Heartbeat. Activities that don't Heartbeat can't receive a Cancellation.
+Heartbeat throttling may lead to Cancellation getting delivered later than expected.
+
+#### Throttling
+
+Heartbeats may not always be sent to the Cluster—they may be throttled by the Worker.
+The throttle interval is the smaller of:
+
+- `if heartbeatTimeout is provided, heartbeatTimeout * 0.8; else defaultHeartbeatThrottleInterval`
+- `maxHeartbeatThrottleInterval`
+
+`defaultHeartbeatThrottleInterval` is 30 seconds by default, and `maxHeartbeatThrottleInterval` is 60 seconds by default.
+Each can be set in Worker options.
+
+Throttling is implemented as follows:
+
+- After sending a Heartbeat, the Worker sets a timer for the throttle interval.
+- The Worker stops sending Heartbeats, but continues receiving Heartbeats from the Activity and remembers the most recent one.
+- When the timer fires, the Worker:
+  - Sends the most recent Heartbeat.
+  - Sets the timer again.
+
+#### Which Activities should Heartbeat
 
 Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress"?
 For short-term operations, progress updates are not a requirement.

--- a/docs/concepts/what-is-an-activity-heartbeat.md
+++ b/docs/concepts/what-is-an-activity-heartbeat.md
@@ -35,9 +35,9 @@ Heartbeat throttling may lead to Cancellation getting delivered later than expec
 #### Throttling
 
 Heartbeats may not always be sent to the Cluster—they may be throttled by the Worker.
-The throttle interval is the smaller of:
+The throttle interval is the smaller of the following:
 
-- `if heartbeatTimeout is provided, heartbeatTimeout * 0.8; else defaultHeartbeatThrottleInterval`
+- If `heartbeatTimeout` is provided, `heartbeatTimeout * 0.8`; otherwise, `defaultHeartbeatThrottleInterval`
 - `maxHeartbeatThrottleInterval`
 
 `defaultHeartbeatThrottleInterval` is 30 seconds by default, and `maxHeartbeatThrottleInterval` is 60 seconds by default.
@@ -51,9 +51,9 @@ Throttling is implemented as follows:
   - Sends the most recent Heartbeat.
   - Sets the timer again.
 
-#### Which Activities should Heartbeat
+#### Which Activities should Heartbeat?
 
-Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress"?
+Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress?"
 For short-term operations, progress updates are not a requirement.
 However, checking the progress and status of Activity Executions that run over long periods is almost always useful.
 

--- a/docs/go/how-to-heartbeat-an-activity-in-go.md
+++ b/docs/go/how-to-heartbeat-an-activity-in-go.md
@@ -8,22 +8,23 @@ tags:
   - developer-guide
 ---
 
-To [Heartbeat](/concepts/what-is-an-activity-heartbeat) in an Activity, use the `RecordHeartbeat` API.
+To [Heartbeat](/concepts/what-is-an-activity-heartbeat) in an Activity in Go, use the `RecordHeartbeat` API.
 
 ```go
-progress := 0
-for progress < 100 {
-    // Send heartbeat message to the server.
-    activity.RecordHeartbeat(ctx, progress)
-    // Do some work.
-    ...
-    progress++
+import (
+    // ...
+    "go.temporal.io/sdk/workflow"
+    // ...
+)
+
+func YourActivityDefinition(ctx, YourActivityDefinitionParam) (YourActivityDefinitionResult, error) {
+    // ...
+    activity.RecordHeartbeat(ctx, details)
+    // ...
 }
 ```
 
-When an Activity Task Execution times out due to a missed Heartbeat, the last value of the details (`progress` in the
-above sample) is returned from the `workflow.ExecuteActivity` function as the details field of `TimeoutError`
-with `TimeoutType` set to `Heartbeat`.
+When an Activity Task Execution times out due to a missed Heartbeat, the last value of the `details` variable above is returned to the calling Workflow in the `details` field of `TimeoutError` with `TimeoutType` set to `Heartbeat`.
 
 You can also Heartbeat an Activity from an external source:
 

--- a/docs/java/how-to-heartbeat-an-activity-in-java.md
+++ b/docs/java/how-to-heartbeat-an-activity-in-java.md
@@ -8,34 +8,24 @@ tags:
   - developer-guide
 ---
 
-To inform the Temporal service that the Activity is still alive, use `Activity.getExecutionContext().heartbeat()` in the Activity implementation code.
+To Heartbeat an Activity Execution in Java, use the `Activity.getExecutionContext().heartbeat()` Class method.
 
-The `Activity.getExecutionContext().heartbeat()` can take an argument that represents Heartbeat `details`.
-If an Activity times out, the last Heartbeat `details` are included in the thrown `ActivityTimeoutException`, which can be caught by the calling Workflow.
+```java
+public class YourActivityDefinitionImpl implements YourActivityDefinition {
+
+  @Override
+  public String yourActivityMethod(YourActivityMethodParam param) {
+    // ...
+    Activity.getExecutionContext().heartbeat(details);
+    // ...
+  }
+  // ...
+}
+```
+
+The method takes an optional argument, the `details` variable above that represents latest progress of the Activity Execution.
+
+If the Activity Execution times out, the last Heartbeat `details` are included in the thrown `ActivityTimeoutException`, which can be caught by the calling Workflow.
 The Workflow can then use the `details` information to pass to the next Activity invocation if needed.
 
 In the case of Activity retries, the last Heartbeat's `details` are available and can be extracted from the last failed attempt by using `Activity.getExecutionContext().getHeartbeatDetails(Class<V> detailsClass)`
-
-The following example uses Activity Heartbeat to report the progress of the `download` Activity method.
-
-```java
-public class FileProcessingActivitiesImpl implements FileProcessingActivities {
-
-  @Override
-  public String download(String bucketName, String remoteName, String localName) {
-    InputStream inputStream = openInputStream(file);
-    try {
-      byte[] bytes = new byte[MAX_BUFFER_SIZE];
-      while ((read = inputStream.read(bytes)) != -1) {
-        totalRead += read;
-        f.write(bytes, 0, read);
-        // Let the Temporal Server know about the download progress.
-        Activity.getExecutionContext().heartbeat(totalRead);
-      }
-    } finally {
-      inputStream.close();
-    }
-  }
-  ...
-}
-```

--- a/docs/java/how-to-heartbeat-an-activity-in-java.md
+++ b/docs/java/how-to-heartbeat-an-activity-in-java.md
@@ -24,6 +24,7 @@ public class YourActivityDefinitionImpl implements YourActivityDefinition {
 ```
 
 The method takes an optional argument, the `details` variable above that represents latest progress of the Activity Execution.
+This method can take a variety of types such as an exception object, custom object, or string.
 
 If the Activity Execution times out, the last Heartbeat `details` are included in the thrown `ActivityTimeoutException`, which can be caught by the calling Workflow.
 The Workflow can then use the `details` information to pass to the next Activity invocation if needed.

--- a/docs/python/how-to-heartbeat-an-activity-in-python.md
+++ b/docs/python/how-to-heartbeat-an-activity-in-python.md
@@ -9,7 +9,7 @@ tags:
   - python
 ---
 
-To Heartbeat an Activity Execution in Python, us the [`heartbeat()`](https://python.temporal.io/temporalio.activity.html#heartbeat) API.
+To Heartbeat an Activity Execution in Python, use the [`heartbeat()`](https://python.temporal.io/temporalio.activity.html#heartbeat) API.
 
 ```python
     @activity.defn
@@ -18,4 +18,4 @@ To Heartbeat an Activity Execution in Python, us the [`heartbeat()`](https://pyt
 ```
 
 In addition to obtaining cancellation information, Heartbeats also support detail data that persists on the server for retrieval during Activity retry.
-If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` will return an iterable containing `123` and `456` on the next Run.
+If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` returns an iterable containing `123` and `456` on the next Run.

--- a/docs/python/how-to-heartbeat-an-activity-in-python.md
+++ b/docs/python/how-to-heartbeat-an-activity-in-python.md
@@ -9,12 +9,13 @@ tags:
   - python
 ---
 
-In order for an Activity to be notified of cancellation requests, you must invoke [`heartbeat()`](https://python.temporal.io/temporalio.activity.html#heartbeat).
+To Heartbeat an Activity Execution in Python, us the [`heartbeat()`](https://python.temporal.io/temporalio.activity.html#heartbeat) API.
 
 ```python
     @activity.defn
-    async def some_activity() -> str:
+    async def your_activity_definition() -> str:
         activity.heartbeat("heartbeat details!")
 ```
 
-In addition to obtaining cancellation information, Heartbeats also support detail data that persists on the server for retrieval during Activity Retry. If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` will return an iterable containing `123` and `456` on the next run.
+In addition to obtaining cancellation information, Heartbeats also support detail data that persists on the server for retrieval during Activity retry.
+If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` will return an iterable containing `123` and `456` on the next Run.


### PR DESCRIPTION
1.  Adds frontmatter to context files
2. Aligns code samples and narrative across a few of the language files related to the context files that were updated.
