### PR TITLE
Fix typo in tctl workflow cancel documentation

### DIFF
--- a/docs/tctl/workflow/cancel.md
+++ b/docs/tctl/workflow/cancel.md
@@ -41,5 +41,5 @@ Aliases: `--rid`, `-r`
 **Example**
 
 ```bash
-tctl workflow show --run_id <id>
+tctl workflow cancel --run_id <id>
 ```


### PR DESCRIPTION
## What does this PR do?
The documentation for `tctl workflow cancel` provides an example for `--run_id` in which `show` is used instead of `cancel`. Fixes that typo.
