### PR TITLE
Adds reference to logger

### DIFF
--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -337,7 +337,7 @@ values={[{label: 'Go', value: 'go'},{label: 'Java', value: 'java'},{label: 'PHP'
 
 <TabItem value="go">
 
-In Workflow Definitions you can use `workflow.GetLogger(ctx)` to write logs.
+In Workflow Definitions you can use [`workflow.GetLogger(ctx)`](https://pkg.go.dev/go.temporal.io/sdk/workflow#GetLogger) to write logs.
 
 ```go
 import (

--- a/docs/go/how-to-log-from-a-workflow-in-go.md
+++ b/docs/go/how-to-log-from-a-workflow-in-go.md
@@ -10,7 +10,7 @@ tags:
   - log
 ---
 
-In Workflow Definitions you can use `workflow.GetLogger(ctx)` to write logs.
+In Workflow Definitions you can use [`workflow.GetLogger(ctx)`](https://pkg.go.dev/go.temporal.io/sdk/workflow#GetLogger) to write logs.
 
 ```go
 import (

--- a/docs/go/how-to-set-workeroptions-in-go.md
+++ b/docs/go/how-to-set-workeroptions-in-go.md
@@ -211,7 +211,7 @@ Set to enable logging in Workflow Execution replays.
 - type: `bool`
 - Default: `false`
 
-In Workflow Definitions you can use `workflow.GetLogger(ctx)` to write logs.
+In Workflow Definitions you can use [`workflow.GetLogger(ctx)`](https://pkg.go.dev/go.temporal.io/sdk/workflow#GetLogger) to write logs.
 By default, the logger will skip logging during replays, so you do not see duplicate logs.
 
 This is only really useful for debugging purpose.


### PR DESCRIPTION
## What does this PR do?
Adds URL reference to `GetLogger(ctx)`.

(API reference [here](https://github.com/temporalio/sdk-go/blob/v1.16.0/workflow/workflow.go#L190)) 
## Notes to reviewers

<!-- delete if n/a -->