### PR TITLE
Revise 7/8/2022 Temporal Cloud release note

### DIFF
--- a/cloud/release-notes/release-note-2022-07-08.md
+++ b/cloud/release-notes/release-note-2022-07-08.md
@@ -1,13 +1,13 @@
 ---
 slug: release-note-2022-07-08
-title: cloud.temporal.io in private GA
+title: Temporal Cloud UI in private beta
 tags:
   - feature
 date: 2022-07-08T00:00:00Z
 ---
 
-[cloud.temporal.io](https://cloud.temporal.io) is in private general availability (GA).
-You can access the Temporal Cloud UI to manage your Temporal Cloud Account and your Workflows.
+Temporal Cloud UI is in private beta.
+You can access the Temporal Cloud UI to manage your Temporal Cloud account, Namespaces, and Workflows.
 With Temporal Cloud UI, you can also configure the following:
 
 - Certificates to connect to your Namespace


### PR DESCRIPTION
## What does this PR do?

Updates [July 8, 2022, release note](https://docs.temporal.io/cloud/release-notes/release-note-2022-07-08/) for Temporal Cloud.
