### PR TITLE
Remove num partitions dynamic config for schedules

### DIFF
--- a/docs/concepts/what-is-a-schedule.md
+++ b/docs/concepts/what-is-a-schedule.md
@@ -192,17 +192,6 @@ frontend.enableSchedules:
   - value: true
 worker.enableScheduler:
   - value: true
-matching.numTaskqueueReadPartitions:
-  - value: 1
-    constraints:
-      taskQueueName: temporal-sys-scheduler-tq
-matching.numTaskqueueWritePartitions:
-  - value: 1
-    constraints:
-      taskQueueName: temporal-sys-scheduler-tq
 ```
-
-Only the first two values are required; the second two are suggested because, by default, only one Worker runs per Task Queue, so more than one partition is not useful.
-Setting the Task Queue to use one partition reduces latency.
 
 If you're familiar with Dynamic Config, you can also constrain these settings per Namespace as needed for your installation.

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -823,17 +823,6 @@ frontend.enableSchedules:
   - value: true
 worker.enableScheduler:
   - value: true
-matching.numTaskqueueReadPartitions:
-  - value: 1
-    constraints:
-      taskQueueName: temporal-sys-scheduler-tq
-matching.numTaskqueueWritePartitions:
-  - value: 1
-    constraints:
-      taskQueueName: temporal-sys-scheduler-tq
 ```
-
-Only the first two values are required; the second two are suggested because, by default, only one Worker runs per Task Queue, so more than one partition is not useful.
-Setting the Task Queue to use one partition reduces latency.
 
 If you're familiar with Dynamic Config, you can also constrain these settings per Namespace as needed for your installation.


### PR DESCRIPTION
## What does this PR do?

These values aren't effective anymore after server release 1.17.4, so we can just drop them. This will be enabled by default in 1.18 and we can drop the rest.
