### PR TITLE
fix broken/unhelpful sdk-typescript badges

### DIFF
--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -209,8 +209,7 @@ pip install temporalio
 </TabItem>
 <TabItem value="typescript">
 
-[![CI Status](https://img.shields.io/github/workflow/status/temporalio/sdk-typescript/Continuous%20Integration?style=for-the-badge)](https://www.npmjs.com/package/temporalio)
-[![NPM](https://img.shields.io/npm/v/temporalio.svg?style=for-the-badge)](https://www.npmjs.com/package/temporalio)
+[![NPM](https://img.shields.io/npm/v/temporalio.svg?style=for-the-badge)](https://www.npmjs.com/search?q=author%3Atemporal-sdk-team)
 
 To download the latest version of the Temporal TypeScript Command, run the following command:
 


### PR DESCRIPTION
## What does this PR do?

At this very moment, the TypeScript SDK build badge indicates that the git repo is currently failing tests. This is unhelpful in user documentation, as users are expected to use NPM releases, which are expected to be stable. More over, the NPM badge directs users to the `temporalio` NPM package, which has been deprecated.

This PR removes the build badge and replace the target of the NPM badge to an NPM search of [all packages published by the SDK team](https://www.npmjs.com/search?q=author%3Atemporal-sdk-team).
