### PR TITLE
docs: correct the web-UI port

### DIFF
--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -96,7 +96,7 @@ The following steps start and run a Temporal Cluster using the default configura
    docker-compose up
    ```
 
-**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8080`](http://127.0.0.1:8080/namespaces/default/workflows).
+**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8088`](http://127.0.0.1:8080/namespaces/default/workflows).
 
 To try other configurations (different dependencies and databases), or to try a custom Docker image, follow the [temporalio/docker-compose README](https://github.com/temporalio/docker-compose/blob/main/README.md).
 


### PR DESCRIPTION
## What does this PR do?
Change the port of web UI from 8080 to 8888
## Notes to reviewers
In docker-compose files except the `docker-compose.yml`, there is no service that exposes to port 8080.

<!-- delete if n/a -->
