### PR TITLE
avoid triming TypeScript code samples, use dedent instead

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -241,7 +241,7 @@ module.exports = {
                     if (!/^ts$/.test(node.lang)) {
                       return;
                     }
-                    node.value = "// @ts-nocheck\n" + node.value.trim();
+                    node.value = "// @ts-nocheck\n" + node.value;
                   }
 
                   visit(tree, "code", visitor);
@@ -276,6 +276,9 @@ module.exports = {
                     }
                     if (node.value.startsWith("// @ts-nocheck\n")) {
                       node.value = node.value.slice("// @ts-nocheck\n".length);
+                      if (node.lang === "ts") {
+                        node.value = dedent(node.value);
+                      }
                     }
                     // If TS compiled output is empty, replace it with a more helpful comment
                     if (
@@ -426,4 +429,41 @@ function convertIndent4ToIndent2(code) {
   return code.replace(/^( {4})+/gm, (match) => {
     return "  ".repeat(match.length / 4);
   });
+}
+
+// Remove the minimum leading whitespace on each line, excluding whitespace-only
+// lines. Helpful for cleaning up TypeScript examples that are pulled from
+// the body of a function.
+function dedent(code) {
+  const lines = code.split("\n");
+
+  if (!lines.length) {
+    return code;
+  }
+
+  // First, find the minimum number of leading space characters, excluding
+  // lines that are whitespace-only.
+  let minIndent = Number.POSITIVE_INFINITY;
+  for (const line of lines) {
+    if (line.trim().length === 0) {
+      continue;
+    }
+
+    const match = line.match(/^( +)/);
+    if (match && match[0].length < minIndent) {
+      minIndent = match[0].length;
+    } else if (!match) {
+      minIndent = 0;
+    }
+  }
+
+  // If there's no leading whitespace, just return the code
+  if (minIndent === 0 || minIndent === Number.POSITIVE_INFINITY) {
+    return code;
+  }
+
+  // Otherwise, remove leading spaces from each line
+  return lines
+    .map((line) => line.replace(new RegExp(`^ {${minIndent}}`), ""))
+    .join("\n");
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #1503. The problem is that the current `docusaurus.config.js` runs `trim()` on TypeScript code, which messes up indentation on snippets where every line is indented because the snippet is pulled from a function body. For example, the following screenshot shows the first line of code is flush against the left because of `trim()`.

![image](https://user-images.githubusercontent.com/1620265/190835370-f2f8e588-7d97-448d-b4eb-ac91cc992197.png)

With this PR, the previous snippet is rendered correctly, including trimming leading whitespace:

![image](https://user-images.githubusercontent.com/1620265/190835388-19e1f0d4-a5c1-44b0-af6b-ac377444f7a8.png)

Note that I tried using the [dedent npm package](https://www.npmjs.com/package/dedent), but that package does not handle empty lines.

## Notes to reviewers

<!-- delete if n/a -->
