### PR TITLE
Fix link to `Register Types`

### DIFF
--- a/docs/typescript/production-deploy.md
+++ b/docs/typescript/production-deploy.md
@@ -50,7 +50,7 @@ For more information, see [Connecting to Temporal Cloud (with mTLS)](/typescript
 
 ## Pre-build code
 
-This information has been moved to [Register Types](../../application-development/foundations/#register-types) section in the application developers guide.
+This information has been moved to [Register Types](/application-development/foundations/#register-types) section in the application developer guide.
 
 ## Logging
 

--- a/docs/typescript/production-deploy.md
+++ b/docs/typescript/production-deploy.md
@@ -50,7 +50,7 @@ For more information, see [Connecting to Temporal Cloud (with mTLS)](/typescript
 
 ## Pre-build code
 
-This information has been moved to [Register Types](../application-development/foundations#register-types) section in the application developers guide.
+This information has been moved to [Register Types](../../application-development/foundations/#register-types) section in the application developers guide.
 
 ## Logging
 


### PR DESCRIPTION
## What does this PR do?

Fixes a link to `Register Types`

