### PR TITLE
Update command for getting search attributes

### DIFF
--- a/docs/tctl/workflow/run.md
+++ b/docs/tctl/workflow/run.md
@@ -187,7 +187,7 @@ tctl workflow run --memo_file <filename>
 Specify a [Search Attribute](/concepts/what-is-a-search-attribute) key.
 For multiple keys, concatenate them and use pipes (`|`) as separators.
 
-To list valid keys, use the `tctl cluster get-search-attr` command.
+To list valid keys, use the `tctl cluster get-search-attributes` command.
 
 **Example**
 
@@ -201,7 +201,7 @@ Specify a [Search Attribute](/concepts/what-is-a-search-attribute) value.
 For multiple values, concatenate them and use pipes (`|`) as separators.
 If a value is an array, use JSON format, such as `["a","b"]`, `[1,2]`, `["true","false"]`, or `["2022-06-07T17:16:34-08:00","2022-06-07T18:16:34-08:00"]`.
 
-To list valid keys and value types, use the `tctl cluster get-search-attr` command.
+To list valid keys and value types, use the `tctl cluster get-search-attributes` command.
 
 **Example**
 

--- a/docs/tctl/workflow/start.md
+++ b/docs/tctl/workflow/start.md
@@ -203,7 +203,7 @@ tctl workflow start --memo_file <filename>
 Specify a [Search Attribute](/concepts/what-is-a-search-attribute) name.
 For multiple names, concatenate them and use pipes (`|`) as separators.
 
-To list valid Search Attributes, use the `tctl cluster get-search-attr` command.
+To list valid Search Attributes, use the `tctl cluster get-search-attributes` command.
 
 **Example**
 
@@ -217,7 +217,7 @@ Specify a [Search Attribute](/concepts/what-is-a-search-attribute) value.
 For multiple values, concatenate them and use pipes (`|`) as separators.
 If a value is an array, use JSON format, such as `["a","b"]`, `[1,2]`, `["true","false"]`, or `["2022-06-07T17:16:34-08:00","2022-06-07T18:16:34-08:00"]`.
 
-To list valid Search Attributes and value types, use the `tctl cluster get-search-attr` command.
+To list valid Search Attributes and value types, use the `tctl cluster get-search-attributes` command.
 
 **Example**
 


### PR DESCRIPTION
## What does this PR do?

I came across `tctl cluster get-search-attr` in documentation, which did not work.  I checked the docs and noticed it should be `tctl cluster get-search-attributes`, so I've updated to reflect that here!