### PR TITLE
Update references to tctl cluster get-search-attributes

### DIFF
--- a/docs/tctl/cluster/get-search-attributes.md
+++ b/docs/tctl/cluster/get-search-attributes.md
@@ -8,7 +8,7 @@ tags:
   - tctl
 ---
 
-The `tctl cluster get-search-attributes` command lists all [Search Attributes](/concepts/what-is-a-search-attribute) that can be used in the `--query` modifier of the [`tctl workflow list`](/tctl/workflow/list) command and the `--search_attr_key` and `--search-attr_value` modifiers of the [`tctl workflow run`](/tctl/workflow/run) and [`tctl workflow start`](/tctl/workflow/start) commands.
+The `tctl cluster get-search-attributes` command lists all [Search Attributes](/concepts/what-is-a-search-attribute) that can be used in the `--query` modifier of the [`tctl workflow list`](/tctl/workflow/list) command and the `--search_attr_key` and `--search_attr_value` modifiers of the [`tctl workflow run`](/tctl/workflow/run) and [`tctl workflow start`](/tctl/workflow/start) commands.
 
 **Example:**
 

--- a/docs/tctl/cluster/get-search-attributes.md
+++ b/docs/tctl/cluster/get-search-attributes.md
@@ -8,7 +8,7 @@ tags:
   - tctl
 ---
 
-The `tctl cluster get-search-attributes` command lists all [Search Attributes](/concepts/what-is-a-search-attribute) that can be used in the `--query` modifier of the [`tctl workflow list`](/tctl/workflow/list) command.
+The `tctl cluster get-search-attributes` command lists all [Search Attributes](/concepts/what-is-a-search-attribute) that can be used in the `--query` modifier of the [`tctl workflow list`](/tctl/workflow/list) command and the `--search_attr_key` and `--search-attr_value` modifiers of the [`tctl workflow run`](/tctl/workflow/run) and [`tctl workflow start`](/tctl/workflow/start) commands.
 
 **Example:**
 

--- a/docs/tctl/cluster/index.md
+++ b/docs/tctl/cluster/index.md
@@ -10,4 +10,4 @@ tags:
 The `tctl cluster` command enables [Temporal Cluster](/concepts/what-is-a-temporal-cluster) operations.
 
 - [`tctl cluster health`](/tctl/cluster/health)
-- [`tctl cluster list-search-attributes`](/tctl/cluster/get-search-attributes)
+- [`tctl cluster get-search-attributes`](/tctl/cluster/get-search-attributes)

--- a/docs/tctl/workflow/run.md
+++ b/docs/tctl/workflow/run.md
@@ -187,7 +187,7 @@ tctl workflow run --memo_file <filename>
 Specify a [Search Attribute](/concepts/what-is-a-search-attribute) key.
 For multiple keys, concatenate them and use pipes (`|`) as separators.
 
-To list valid keys, use the `tctl cluster get-search-attr` command.
+To list valid keys, use the `tctl cluster get-search-attributes` command.
 
 **Example**
 
@@ -201,7 +201,7 @@ Specify a [Search Attribute](/concepts/what-is-a-search-attribute) value.
 For multiple values, concatenate them and use pipes (`|`) as separators.
 If a value is an array, use JSON format, such as `["a","b"]`, `[1,2]`, `["true","false"]`, or `["2022-06-07T17:16:34-08:00","2022-06-07T18:16:34-08:00"]`.
 
-To list valid keys and value types, use the `tctl cluster get-search-attr` command.
+To list valid keys and value types, use the `tctl cluster get-search-attributes` command.
 
 **Example**
 

--- a/docs/tctl/workflow/start.md
+++ b/docs/tctl/workflow/start.md
@@ -203,7 +203,7 @@ tctl workflow start --memo_file <filename>
 Specify a [Search Attribute](/concepts/what-is-a-search-attribute) name.
 For multiple names, concatenate them and use pipes (`|`) as separators.
 
-To list valid Search Attributes, use the `tctl cluster get-search-attr` command.
+To list valid Search Attributes, use the `tctl cluster get-search-attributes` command.
 
 **Example**
 
@@ -217,7 +217,7 @@ Specify a [Search Attribute](/concepts/what-is-a-search-attribute) value.
 For multiple values, concatenate them and use pipes (`|`) as separators.
 If a value is an array, use JSON format, such as `["a","b"]`, `[1,2]`, `["true","false"]`, or `["2022-06-07T17:16:34-08:00","2022-06-07T18:16:34-08:00"]`.
 
-To list valid Search Attributes and value types, use the `tctl cluster get-search-attr` command.
+To list valid Search Attributes and value types, use the `tctl cluster get-search-attributes` command.
 
 **Example**
 


### PR DESCRIPTION
## Preview

https://deploy-preview-1637--mystifying-fermi-1bc096.netlify.app/

## What does this PR do?

Per #1636 from @bmorton, corrected references to `tctl cluster get-search-attributes` and resolved a couple of related issues.
