### PR TITLE
git install fails for go

### DIFF
--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -57,9 +57,11 @@ Temporalite requires Go 1.18 or later.
 
 The following steps start and run a Temporal Cluster.
 
-1. Build from source by using `go install`.
+1. Build from source.
    ```bash
-   go install github.com/temporalio/temporalite/cmd/temporalite@latest
+   git clone https://github.com/temporalio/temporalite.git
+   cd temporalite
+   go build ./cmd/temporalite
    ```
 2. Start Temporalite by using the `start` command.
    ```bash


### PR DESCRIPTION
go install fails due to replace directive in go.mod.

## What does this PR do?

Documented git install command fails. This PR updates the documentation with alternate way to build the temporalite.

## Notes to reviewers

The go install build command fails with the following error for `go version go1.19.1 darwin/arm64`
"The go.mod file for the module providing named packages contains one or more replace directives. It must not contain directives that would cause it to be interpreted differently than if it were the main module."

<!-- delete if n/a -->
