### PR TITLE
Let web-ui decide which namespace to redirect to

### DIFF
--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -67,7 +67,7 @@ The following steps start and run a Temporal Cluster.
    ```
    Replace `default` with your [Namespace Name](/cloud/#temporal-cloud-namespace-name).
 
-**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8233`](http://127.0.0.1:8233/namespaces/default/workflows).
+**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8233`](http://127.0.0.1:8233/).
 
 <!-- For macOS users, if you receive the `error setting up schema: stat /Users/<user_name>/Library/Application Support/temporalite/db:` error, then create the folders `temporalite/db` in your `Application Support` library. -->
 
@@ -96,7 +96,7 @@ The following steps start and run a Temporal Cluster using the default configura
    docker-compose up
    ```
 
-**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8080`](http://127.0.0.1:8080/namespaces/default/workflows).
+**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8080`](http://127.0.0.1:8080/).
 
 To try other configurations (different dependencies and databases), or to try a custom Docker image, follow the [temporalio/docker-compose README](https://github.com/temporalio/docker-compose/blob/main/README.md).
 

--- a/docs/clusters/quick-install.md
+++ b/docs/clusters/quick-install.md
@@ -36,7 +36,7 @@ The following steps start and run a Temporal Cluster.
    ```
    Replace `default` with your [Namespace Name](/cloud/#temporal-cloud-namespace-name).
 
-**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8233`](http://127.0.0.1:8233/namespaces/default/workflows).
+**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8233`](http://127.0.0.1:8233/).
 
 <!-- For macOS users, if you receive the `error setting up schema: stat /Users/<user_name>/Library/Application Support/temporalite/db:` error, then create the folders `temporalite/db` in your `Application Support` library. -->
 
@@ -65,7 +65,7 @@ The following steps start and run a Temporal Cluster using the default configura
    docker-compose up
    ```
 
-**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8080`](http://127.0.0.1:8080/namespaces/default/workflows).
+**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8080`](http://127.0.0.1:8080/).
 
 To try other configurations (different dependencies and databases), or to try a custom Docker image, follow the [temporalio/docker-compose README](https://github.com/temporalio/docker-compose/blob/main/README.md).
 

--- a/kb/temporal-cluster-install-options.md
+++ b/kb/temporal-cluster-install-options.md
@@ -44,7 +44,7 @@ The following steps start and run a Temporal Cluster using the default configura
    docker-compose up
    ```
 
-**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8080`](http://127.0.0.1:8080/namespaces/default/workflows).
+**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8080`](http://127.0.0.1:8080/).
 
 To try other configurations (different dependencies and databases), or to try a custom Docker image, follow the [temporalio/docker-compose README](https://github.com/temporalio/docker-compose/blob/main/README.md).
 
@@ -93,6 +93,6 @@ The following steps start and run a Temporal Cluster.
    ```
    Replace `default` with your [Namespace Name](/cloud/#temporal-cloud-namespace-name).
 
-**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8233`](http://127.0.0.1:8233/namespaces/default/workflows).
+**Results**: You should have Temporal Cluster running at `http://127.0.0.1:7233` and the Temporal Web UI at [`http://127.0.0.1:8233`](http://127.0.0.1:8233/).
 
 <!-- For macOS users, if you receive the `error setting up schema: stat /Users/<user_name>/Library/Application Support/temporalite/db:` error, then create the folders `temporalite/db` in your `Application Support` library. -->


### PR DESCRIPTION
## What does this PR do?
currently the redirect assumes that the first namespace created will be the `default` namespace. this isn't always true given that the doc explicit recommends to replace `default` with user's own preferred namespace name. if the user follows the recommendation, then following the link from the docs brings them to an error page (where it says namespace was not found). this happened to me in fact. but i discovered that if i just navigate to http://127.0.0.1:8233/ the web ui is smart enough the redirect to my one and only namespace.

this happened with just `temporalite`, my preferred way to run temporal on my local machine, hence the change only affects that one line. it's possible that it applies to other ways to run temporal but i don't have the experience to recommend the change. regardless, letting web-ui decide where to redirect to sounds good to me.

## Notes to reviewers
all sorts of review welcome. it's my first contribution so i might be overlooking quite a lot of things here.