### PR TITLE
Added warnings around mentions of `npx @temporalio/create@latest/`

### DIFF
--- a/docs-src/typescript/index.md
+++ b/docs-src/typescript/index.md
@@ -15,6 +15,8 @@ This project requires Node.js 14 or later.
 
 **Create a new project**
 
+_NOTE: There is an issue with Node.js 18 where this step might fail. Please follow this [slack thread](https://temporalio.slack.com/archives/CTRCR8RBP/p1664991819126059) for the most recent updates. In the meantime please directly clone your template from [samples-typescript](https://github.com/temporalio/samples-typescript)_
+
 ```bash
 npx @temporalio/create@latest ./your-app
 ```

--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -214,6 +214,8 @@ pip install temporalio
 
 This project requires Node.js 14 or later.
 
+_NOTE: There is an issue with Node.js 18 where this step might fail. Please follow this [slack thread](https://temporalio.slack.com/archives/CTRCR8RBP/p1664991819126059) for the most recent updates. In the meantime please directly clone your template from [samples-typescript](https://github.com/temporalio/samples-typescript)_
+
 **Create a new project**
 
 ```bash

--- a/docs/typescript/introduction.md
+++ b/docs/typescript/introduction.md
@@ -74,6 +74,9 @@ If you want to run Temporal without Docker, [Temporalite](https://github.com/tem
 
 Use the [package initializer](/typescript/package-initializer) to create a new project:
 
+_NOTE: There is an issue with Node.js 18 where this step might fail. Please follow this [slack thread](https://temporalio.slack.com/archives/CTRCR8RBP/p1664991819126059) for the most recent updates. In the meantime please directly clone your template from [samples-typescript](https://github.com/temporalio/samples-typescript)_
+
+
 ```bash
 npx @temporalio/create@latest ./example
 cd example

--- a/docs/typescript/nextjs.md
+++ b/docs/typescript/nextjs.md
@@ -16,6 +16,9 @@ If you run into trouble, you are welcome to reach out on the [Temporal Slack](ht
 
 **To skip straight to a fully working example, you can check our [samples-typescript repo](https://github.com/temporalio/samples-typescript/tree/main/nextjs-ecommerce-oneclick)**, which you can also clone from scratch with [package initializer](/typescript/package-initializer) skeleton:
 
+_NOTE: There is an issue with Node.js 18 where this step might fail. Please follow this [slack thread](https://temporalio.slack.com/archives/CTRCR8RBP/p1664991819126059) for the most recent updates. In the meantime please directly clone your template from [samples-typescript](https://github.com/temporalio/samples-typescript)_
+
+
 ```bash
 npx @temporalio/create@latest nextjs-temporal-app --sample nextjs-ecommerce-oneclick
 ```

--- a/docs/typescript/package-initializer.md
+++ b/docs/typescript/package-initializer.md
@@ -13,6 +13,8 @@ description: temporalio/create is an optional tool to set up a new Temporal proj
 
 > See the [Getting started](/typescript/introduction/#getting-started) guide for basic usage and environment set up before running this tool.
 
+_NOTE: There is an issue with Node.js 18 where this step might fail. Please follow this [slack thread](https://temporalio.slack.com/archives/CTRCR8RBP/p1664991819126059) for the most recent updates. In the meantime please directly clone your template from [samples-typescript](https://github.com/temporalio/samples-typescript)_
+
 ```bash
 npx @temporalio/create@latest ./example
 ```

--- a/docs/typescript/security.md
+++ b/docs/typescript/security.md
@@ -194,6 +194,7 @@ Follow this tutorial for setting up mTLS (Mutual TLS authentication) with Tempor
    - Follow [these instructions](https://github.com/temporalio/samples-server/tree/master/tls/tls-simple#readme) to set up a local server with mTLS
    - The sample does not register the default Namespace on startup, register it with: `docker exec -it tls-simple_temporal-admin-tools_1 tctl n re --retention 1 default`
 1. Configure your Temporal Client and Worker to connect with mTLS
+   - _NOTE: There is an issue with Node.js 18 where this step might fail. Please follow this [slack thread](https://temporalio.slack.com/archives/CTRCR8RBP/p1664991819126059) for the most recent updates. In the meantime please directly clone your template from [samples-typescript](https://github.com/temporalio/samples-typescript)_
    - Scaffold a new Temporal project with `npx @temporalio/create@latest` using the `hello-world-mtls` template, or copy the relevant configuration from the snippets below into an existing project.
    - Export the required environment variables:
      ```bash


### PR DESCRIPTION
## What does this PR do?

Alerting users about a Node 18 regression and showing alternative solutions.

## Notes to reviewers

There seems to be a regression in node 18 and running `npx @temporalio/create@latest/` does not seem to work.
