### PR TITLE
docs: testEnv.workflowClient deprecation

### DIFF
--- a/docs/typescript/testing.md
+++ b/docs/typescript/testing.md
@@ -75,7 +75,7 @@ Workflows can be tested with [`TestWorkflowEnvironment`](https://typescript.temp
 
 A typical test suite would set up a single instance of the test environment to be reused in all tests (e.g. in a [Mocha](https://mochajs.org/) `before()` hook or a [Jest](https://jestjs.io/) `beforeAll` hook).
 
-When creating an environment, [`TestWorkflowEnvironment.create`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#create) will automatically start a test server that you can access with [`workflowClient`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#workflowclient) and [`nativeConnection`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#nativeconnection).
+When creating an environment, [`TestWorkflowEnvironment.create`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#create) will automatically start a test server that you can access with [`client`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#client) and [`nativeConnection`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#nativeconnection).
 
 ### Example setup
 
@@ -109,7 +109,7 @@ Since the `TestWorkflowEnvironment` is meant for testing Workflows, you'd typica
 
 ```ts
 test('httpWorkflow with mock activity', async () => {
-  const { workflowClient, nativeConnection } = testEnv;
+  const { client, nativeConnection } = testEnv;
 
   // Implement only the relevant activities for this workflow
   const mockActivities: Partial<typeof Activities> = {
@@ -122,7 +122,7 @@ test('httpWorkflow with mock activity', async () => {
     activities: mockActivities,
   });
   const result = await worker.runUntil(
-    await workflowClient.execute(httpWorkflow, {
+    await client.workflow.execute(httpWorkflow, {
       workflowId: uuid4(),
       taskQueue: 'test',
     })
@@ -134,7 +134,7 @@ test('httpWorkflow with mock activity', async () => {
 ### Time skipping in Workflows
 
 The built-in test server automatically "skips" (fast forwards) time when no Activities are executing.
-The test server starts in "normal" time, using the `TestWorkflowEnvironment.workflowClient` `execute` or `result`
+The test server starts in "normal" time, using the `TestWorkflowEnvironment.client.workflow` `execute` or `result`
 methods switch the test server to "skipped" time mode until the Workflow completes.
 If a Workflow sleeps for days, running it in the test environment will cause it to complete almost immediately.
 
@@ -159,7 +159,7 @@ test('sleep completes almost immediately', async () => {
   });
   // Does not wait an entire day
   await worker.runUntil(
-    testEnv.workflowClient.execute(sleeperWorkflow, {
+    testEnv.client.workflow.execute(sleeperWorkflow, {
       workflowId: uuid(),
       taskQueue: 'test',
     })
@@ -197,12 +197,10 @@ export async function sleeperWorkflow() {
 
 ```ts
 test('advancing time using `testEnv.sleep()`', async () => {
-  const client = testEnv.workflowClient;
-
   // Important: `start()` starts the test server in "normal" mode,
   // not skipped time mode. If you don't advance time using `testEnv.sleep()`,
   // then `sleeperWorkflow()` will run for days.
-  handle = await client.start(sleeperWorkflow, {
+  handle = await testEnv.client.workflow.start(sleeperWorkflow, {
     taskQueue,
     workflowId: uuidv4(),
   });
@@ -263,7 +261,7 @@ test('countdownWorkflow sends reminder email if processing does not complete in 
     activities,
   });
   await worker.runUntil(
-    testEnv.workflowClient.execute(processOrderWorkflow, {
+    testEnv.client.workflow.execute(processOrderWorkflow, {
       workflowId: uuid(),
       taskQueue: 'test',
       args: [
@@ -308,7 +306,7 @@ const worker = await Worker.create({
 });
 
 await worker.runUntil(
-  testEnv.workflowClient.execute(functionToTest, workflowOptions)
+  testEnv.client.workflow.execute(functionToTest, workflowOptions)
 );
 ```
 
@@ -351,7 +349,7 @@ const worker = await Worker.create({
 });
 
 await worker.runUntil(
-  testEnv.workflowClient.execute(functionToTest, workflowOptions) // Throws WorkflowFailedError
+  testEnv.client.workflow.execute(functionToTest, workflowOptions) // Throws WorkflowFailedError
 );
 ```
 


### PR DESCRIPTION
## What does this PR do?

Replace deprecated `TestWorkflowEnvironment.workflowClient` with `client.workflow`
