### PR TITLE
adding the Temp CLI Auth env

### DIFF
--- a/docs/tctl/environment-variables.md
+++ b/docs/tctl/environment-variables.md
@@ -15,6 +15,10 @@ Setting environment variables for repeated parameters can shorten tctl commands.
 Specify a host and port for the Frontend Service.
 The default is `127.0.0.1:7233`.
 
+### TEMPORAL_CLI_AUTH
+
+Specify the authorization header to be set for a gRPC request.
+
 ### TEMPORAL_CLI_AUTHORIZATION_TOKEN
 
 Specify a token to be used by the HTTP Basic Authorization plugin.


### PR DESCRIPTION
## What does this PR do?
Missing this Env var [`TEMPORAL_CLI_AUTH`](https://cs.github.com/temporalio/tctl/blob/a29715cd2f2b5d17b7886210c45e0631d3ce4d26/cli/app.go#L71)
## Notes to reviewers

Customer reported this issue and was [having trouble connect:](https://temporalio.slack.com/archives/CTRCR8RBP/p1665606479737479)

<!-- delete if n/a -->