### PR TITLE
TW-102 updates Alias

### DIFF
--- a/docs-src/tctl-next/task-queue/describe.md
+++ b/docs-src/tctl-next/task-queue/describe.md
@@ -7,7 +7,7 @@ tags:
   - tctl
 ---
 
-Alias: `desc`
+Alias: `d`
 
 The `tctl task-queue describe` command describes the poller information of a [Task Queue](/concepts/what-is-a-task-queue).
 

--- a/docs-src/tctl-next/task-queue/list-partition.md
+++ b/docs-src/tctl-next/task-queue/list-partition.md
@@ -7,6 +7,8 @@ tags:
   - tctl
 ---
 
+Alias: `lp`
+
 The `tctl task-queue list-partition` command lists the partitions of a [Task Queue](/concepts/what-is-a-task-queue) and the hostname for the partitions.
 
 `tctl task-queue list-partition --task-queue <value>`

--- a/docs/tctl-next/task-queue.md
+++ b/docs/tctl-next/task-queue.md
@@ -20,7 +20,7 @@ Alias: `tq`
 
 ## describe
 
-Alias: `desc`
+Alias: `d`
 
 The `tctl task-queue describe` command describes the poller information of a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a href="/tasks#task-queue">Learn more</a></p></div></a>.
 
@@ -42,6 +42,8 @@ The following modifiers are supported and control the behavior of the command.
 - [--time-format](/tctl-next/modifiers#--time-format)
 
 ## list-partition
+
+Alias: `lp`
 
 The `tctl task-queue list-partition` command lists the partitions of a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a href="/tasks#task-queue">Learn more</a></p></div></a> and the hostname for the partitions.
 


### PR DESCRIPTION
## What does this PR do?
Updates Alias for tctl next commands.

Ran the help command to verify.

```
   tctl task-queue - Operations on task queues

USAGE:
   tctl task-queue command [command options] [arguments...]

COMMANDS:
   describe, d         Describe pollers info of task queue
   list-partition, lp  List all the taskqueue partitions and the hostname for partitions
   help, h             Shows a list of commands or help for one command

OPTIONS:

   --help, -h  show help (default: false)
```
## Notes to reviewers

<!-- delete if n/a -->