### PR TITLE
Set `public: true` in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,5 @@
 {
+  "public": true,
   "trailingSlash": false,
   "github": {
     "silent": true
@@ -546,7 +547,7 @@
       "source": "/server/quick-install",
       "destination": "/clusters/quick-install"
     },
-    { 
+    {
       "source": "/server/security",
       "destination": "/security"
     },


### PR DESCRIPTION
## What does this PR do?

Makes build logs visible to people outside the temporal vercel team, so that all contributors can see whether/how their PR is breaking the build and fix it.

https://vercel.com/docs/project-configuration#project-configuration/public
