### PR TITLE
tctl version corrections: 1.17 and next

### DIFF
--- a/docs-src/concepts/what-is-tctl-next.md
+++ b/docs-src/concepts/what-is-tctl-next.md
@@ -9,11 +9,11 @@ tags:
 ---
 
 This documentation reflects the "next" version of Temporal's tctl command line tool.
-Currently it is known as [tctl v2.0.0-beta](https://github.com/temporalio/tctl#trying-out-new-tctl-v200-beta-with-updated-ux), but the name may change in the future.
+`tctl next` was formerly known as [tctl v2.0.0-beta](https://github.com/temporalio/tctl#trying-out-new-tctl-v200-beta-with-updated-ux).
 
 :::note
 
-If you are using `tctl` version 1.16.12 or older, you must update to at least version 1.16.3 before you can switch to `tctl` v2.0.0-beta.1.
+Update to version 1.17 or later before switching to `tctl next`.
 
 :::
 

--- a/docs-src/tctl-v1/schedule/index.md
+++ b/docs-src/tctl-v1/schedule/index.md
@@ -7,9 +7,7 @@ tags:
   - tctl
 ---
 
-A [Schedule](/concepts/what-is-a-schedule) is an experimental feature and the `schedule` command is available in versions 1.17.0-alpha.2 and later.
-Version 1.17.0-alpha.2 is currently available in version 1.16.2.
-Use `tctl config set version next` command while on version 1.16.2.
+A [Schedule](/concepts/what-is-a-schedule) is an experimental feature available in `tctl 1.17` and `tctl next`.
 
 - [Backfill a Schedule using tctl](/tctl-v1/schedule/backfill)
 - [Create a Schedule using tctl](/tctl-v1/schedule/create)


### PR DESCRIPTION
Ran through tctl to correct 1.16 to 1.17, and beta/2.0 to next.