### PR TITLE
Removed "Edit Links"

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -212,7 +212,7 @@ module.exports = {
           sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
           exclude: [], // do not render context content
-          editUrl: "https://github.com/temporalio/documentation/blob/master",
+         // editUrl: "https://github.com/temporalio/documentation/blob/master",
           /**
            * Whether to display the author who last updated the doc.
            */


### PR DESCRIPTION
For now, "Edit Links" will be disabled across the docs. This is because the links redirect to the generated pages, and our users don't make much use of the feature anyway.
