### PR TITLE
tctl: remove aliases for commands and modifiers

### DIFF
--- a/docs-src/tctl-next/activity/index.md
+++ b/docs-src/tctl-next/activity/index.md
@@ -9,7 +9,5 @@ tags:
 
 The `tctl activity` commands enable [Activity Execution](/concepts/what-is-an-activity-execution) operations.
 
-Alias: `a`
-
 - [tctl activity complete](/tctl-next/activity#complete)
 - [tctl activity fail](/tctl-next/activity#fail)

--- a/docs-src/tctl-next/batch/describe.md
+++ b/docs-src/tctl-next/batch/describe.md
@@ -7,8 +7,6 @@ tags:
   - tctl
 ---
 
-Alias: `desc`
-
 The `tctl batch describe` command describes the progress of a batch job.
 
 `tctl batch describe --job-id <value>`

--- a/docs-src/tctl-next/batch/list.md
+++ b/docs-src/tctl-next/batch/list.md
@@ -7,8 +7,6 @@ tags:
   - tctl
 ---
 
-Alias: `l`
-
 The `tctl batch list` command lists all batch jobs.
 
 `tctl batch list <modifiers>`

--- a/docs-src/tctl-next/data-converter/index.md
+++ b/docs-src/tctl-next/data-converter/index.md
@@ -9,6 +9,4 @@ tags:
 
 The `tctl data-converter` command enables custom [Data Converter](/concepts/what-is-a-data-converter) operations.
 
-Alias: `dc`
-
 - [tctl data-converter web](/tctl-next/data-converter#web)

--- a/docs-src/tctl-next/modifiers/pagesize.md
+++ b/docs-src/tctl-next/modifiers/pagesize.md
@@ -8,5 +8,3 @@ tags:
 ---
 
 Specify the maximum number of batch jobs to list on a page. The default value is 30.
-
-Alias: `--ps`

--- a/docs-src/tctl-next/modifiers/query.md
+++ b/docs-src/tctl-next/modifiers/query.md
@@ -14,3 +14,5 @@ The `--query` flag is supported only when [Advanced Visibility](/concepts/what-i
 Specify an SQL-like query of [Search Attributes](/concepts/what-is-a-search-attribute).
 
 Using the `--query` option causes tctl to ignore all other filter options, including `open`, `earliest-time`, `latest-time`, `workflow-id`, and `workflow-type`.
+
+Alias: `--q`

--- a/docs-src/tctl-next/modifiers/reason.md
+++ b/docs-src/tctl-next/modifiers/reason.md
@@ -8,5 +8,3 @@ tags:
 ---
 
 Specify a reason for terminating the [Workflow Execution](/concepts/what-is-a-workflow-execution).
-
-Alias: `-r`

--- a/docs-src/tctl-next/modifiers/retention.md
+++ b/docs-src/tctl-next/modifiers/retention.md
@@ -10,5 +10,3 @@ tags:
 Set the [Retention Period](/clusters#retention-period) for the [Namespace](/concepts/what-is-a-namespace).
 
 The Retention Period applies to Closed [Workflow Executions](/concepts/what-is-a-workflow-execution).
-
-Alias `--rd`

--- a/docs-src/tctl-next/modifiers/run-id.md
+++ b/docs-src/tctl-next/modifiers/run-id.md
@@ -9,4 +9,4 @@ tags:
 
 Show the History of a [Workflow Execution](/concepts/what-is-a-workflow-execution) by specifying a [Run Id](/concepts/what-is-a-run-id).
 
-Alias: `--rid`
+Alias: `--r`

--- a/docs-src/tctl-next/modifiers/run-timeout.md
+++ b/docs-src/tctl-next/modifiers/run-timeout.md
@@ -8,5 +8,3 @@ tags:
 ---
 
 Single Workflow Run timeout, in seconds.
-
-Alias: `--rt`

--- a/docs-src/tctl-next/modifiers/task-queue.md
+++ b/docs-src/tctl-next/modifiers/task-queue.md
@@ -8,3 +8,5 @@ tags:
 ---
 
 Specify a [Task Queue](/concepts/what-is-a-task-queue).
+
+Alias: `--t`

--- a/docs-src/tctl-next/modifiers/yes.md
+++ b/docs-src/tctl-next/modifiers/yes.md
@@ -8,3 +8,5 @@ tags:
 ---
 
 Use the --yes modifier to automatically confirm all prompts.
+
+Alias: `--y`

--- a/docs-src/tctl-next/namespace/describe.md
+++ b/docs-src/tctl-next/namespace/describe.md
@@ -11,8 +11,6 @@ The `tctl namespace describe` command describes a [Namespace](/namespaces).
 
 `tctl namespace describe`
 
-Alias: `d`
-
 The following modifiers are supported and control the behavior of the command.
 Always include required modifiers when executing this command.
 

--- a/docs-src/tctl-next/namespace/list.md
+++ b/docs-src/tctl-next/namespace/list.md
@@ -7,8 +7,6 @@ tags:
   - tctl
 ---
 
-Alias: `l`
-
 The `tctl namespace list` command lists all [Namespaces](/concepts/what-is-a-namespace).
 
 `tctl namespace list`

--- a/docs-src/tctl-next/task-queue/describe.md
+++ b/docs-src/tctl-next/task-queue/describe.md
@@ -7,8 +7,6 @@ tags:
   - tctl
 ---
 
-Alias: `desc`
-
 The `tctl task-queue describe` command describes the poller information of a [Task Queue](/concepts/what-is-a-task-queue).
 
 `tctl task-queue describe <modifiers>`

--- a/docs-src/tctl-next/workflow/describe.md
+++ b/docs-src/tctl-next/workflow/describe.md
@@ -12,8 +12,6 @@ This information can be used to locate a failed Workflow Execution, for example.
 
 `tctl workflow describe <modifiers>`
 
-Alias: `d`
-
 The following modifiers control the behavior of the command.
 Always include required modifiers when executing this command.
 

--- a/docs-src/tctl-next/workflow/index.md
+++ b/docs-src/tctl-next/workflow/index.md
@@ -9,8 +9,6 @@ tags:
 
 The `tctl workflow` commands enable [Workflow Execution](/concepts/what-is-a-workflow-execution) operations.
 
-Alias: `w`
-
 - [tctl workflow cancel](/tctl-next/workflow#cancel)
 - [tctl workflow count](/tctl-next/workflow#count)
 - [tctl workflow describe](/tctl-next/workflow#describe)

--- a/docs-src/tctl-v1/activity/complete.md
+++ b/docs-src/tctl-v1/activity/complete.md
@@ -9,7 +9,7 @@ tags:
 
 The `tctl activity complete` command completes an [Activity Execution](/concepts/what-is-an-activity-execution).
 
-`tctl activity complete [<modifiers>]`
+`tctl activity complete <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -17,7 +17,7 @@ The following modifiers control the behavior of the command.
 
 Specify the [Workflow Id](/concepts/what-is-a-workflow-id) of an [Activity Execution](/concepts/what-is-an-activity-execution) to complete.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -29,7 +29,7 @@ tctl activity complete --workflow_id <id>
 
 Specify the [Run Id](/concepts/what-is-a-run-id) of an [Activity Execution](/concepts/what-is-an-activity-execution) to complete.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -40,8 +40,6 @@ tctl activity complete --run_id <id>
 ### --activity_id
 
 Specify the [Activity Id](/concepts/what-is-an-activity-id) of an [Activity Execution](/concepts/what-is-an-activity-execution) to complete.
-
-Alias: `--aid`
 
 **Example**
 

--- a/docs-src/tctl-v1/activity/fail.md
+++ b/docs-src/tctl-v1/activity/fail.md
@@ -17,7 +17,7 @@ The following modifiers control the behavior of the command.
 
 Specify the [Workflow Id](/concepts/what-is-a-workflow-id) of an [Activity Execution](/concepts/what-is-an-activity-execution) to fail.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -29,7 +29,7 @@ tctl activity fail --workflow_id <id>
 
 Specify the [Run Id](/concepts/what-is-a-run-id) of an [Activity Execution](/concepts/what-is-an-activity-execution) to fail.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -40,8 +40,6 @@ tctl activity fail --run_id <id>
 ### --activity_id
 
 Specify the [Activity Id](/concepts/what-is-an-activity-id) of an [Activity Execution](/concepts/what-is-an-activity-execution) to fail.
-
-Alias: `--aid`
 
 **Example**
 

--- a/docs-src/tctl-v1/activity/index.md
+++ b/docs-src/tctl-v1/activity/index.md
@@ -9,7 +9,5 @@ tags:
 
 The `tctl activity` commands enable [Activity Execution](/concepts/what-is-an-activity-execution) operations.
 
-Alias: `a`
-
 - [tctl activity complete](/tctl-v1/activity/complete)
 - [tctl activity fail](/tctl-v1/activity/fail)

--- a/docs-src/tctl-v1/admin/cluster/add-search-attributes.md
+++ b/docs-src/tctl-v1/admin/cluster/add-search-attributes.md
@@ -8,8 +8,6 @@ tags:
   - admin
 ---
 
-Alias: `asa`
-
 The `tctl admin cluster add-search-attributes` command allows Search Attributes to be added to a Cluster.
 Custom Search Attributes can be used to make a Cluster more identifiable.
 
@@ -37,15 +35,11 @@ This will only register in metadata.
 
 #### --name
 
-Alias: `-n value`
-
 The name of the Search Attribute to add. Names can have multiple values.
 
 Search Attribute names are case sensitive.
 
 #### --type
-
-Alias: `-t value`
 
 The type of Search Attribute to add.
 Multiple values can be added at once.

--- a/docs-src/tctl-v1/admin/cluster/describe.md
+++ b/docs-src/tctl-v1/admin/cluster/describe.md
@@ -10,8 +10,6 @@ tags:
 
 The `tctl admin cluster describe` command provides information for the current Cluster.
 
-Alias: `d`
-
 The following modifier changes the behavior of the command:
 
 #### --cluster_value

--- a/docs-src/tctl-v1/admin/cluster/get-search-attributes.md
+++ b/docs-src/tctl-v1/admin/cluster/get-search-attributes.md
@@ -10,12 +10,8 @@ tags:
 
 The `tctl admin cluster get_search_attributes` command retrieves existing Search Attributes for a given Cluster.
 
-Alias: `gsa`
-
 The following modifier will change the behavior of the command:
 
 #### --print_json
-
-Alias: `--pjson value`
 
 Prints the existing search attributes in JSON format.

--- a/docs-src/tctl-v1/admin/cluster/index.md
+++ b/docs-src/tctl-v1/admin/cluster/index.md
@@ -10,8 +10,6 @@ tags:
 
 The `tctl admin cluster` command runs the administrator-level operations on a given Cluster.
 
-Alias: `cl`
-
 `tctl admin cluster command [command modifiers] [arguments...]`
 
 - [`add_search_attributes`](/tctl-v1/admin/cluster/add-search-attributes)

--- a/docs-src/tctl-v1/admin/cluster/list.md
+++ b/docs-src/tctl-v1/admin/cluster/list.md
@@ -10,8 +10,6 @@ tags:
 
 The `tctl admin cluster list` command lists Cluster information on the given Cluster.
 
-Alias: `ls`
-
 Default: 100
 
 The modifier below changes the behavior of the command:

--- a/docs-src/tctl-v1/admin/cluster/remove-remote-cluster.md
+++ b/docs-src/tctl-v1/admin/cluster/remove-remote-cluster.md
@@ -10,8 +10,6 @@ tags:
 
 The `tctl admin cluster remove_remote_cluster` command removes remote Cluster information on the given Cluster.
 
-Alias: `rrc`
-
 The modifier below changes the behavior of the operation:
 
 #### --cluster

--- a/docs-src/tctl-v1/admin/cluster/upsert-remote-cluster.md
+++ b/docs-src/tctl-v1/admin/cluster/upsert-remote-cluster.md
@@ -10,16 +10,10 @@ tags:
 
 The `tctl admin cluster upsert_remote_cluster` command adds or updates remote Cluster information in the current Cluster.
 
-Alias: `urc`
-
 #### --frontend_address
-
-Alias: `--fad value`
 
 The remote Cluster frontend address.
 
 #### --enable_connection
-
-Alias: `--ec`
 
 Enables remote Cluster connection.

--- a/docs-src/tctl-v1/admin/decode/index.md
+++ b/docs-src/tctl-v1/admin/decode/index.md
@@ -14,9 +14,3 @@ The `tctl admin decode` command allows the user to decode payloads sent and rece
 
 - [`proto`](/tctl-v1/admin/decode/proto)
 - [`base64`](/tctl-v1/admin/decode/base64)
-
-`--help`
-
-Alias: `-h`
-
-Shows helpful information for the given command.

--- a/docs-src/tctl-v1/admin/dlq/index.md
+++ b/docs-src/tctl-v1/admin/dlq/index.md
@@ -15,9 +15,3 @@ The `tctl admin dlq` commands run admin operations on a given dead-letter queue 
 - [tctl admin dlq read](/tctl-v1/admin/dlq/read)
 - [tctl admin dlq purge](/tctl-v1/admin/dlq/purge)
 - [tctl admin dlq merge](/tctl-v1/admin/dlq/merge)
-
-`--help`
-
-Alias: `-h`
-
-Shows helpful information for the command.

--- a/docs-src/tctl-v1/admin/dlq/merge.md
+++ b/docs-src/tctl-v1/admin/dlq/merge.md
@@ -12,11 +12,7 @@ The `tctl admib dlq merge` command allows dead-letter queue (DLQ) messages to be
 
 The messages must have TaskIds with an equal or lesser value than the given TaskId.
 
-Alias: `m`
-
 #### --dlq_type
-
-Alias: `--dt value`
 
 The type of DLQ to manage.
 

--- a/docs-src/tctl-v1/admin/dlq/purge.md
+++ b/docs-src/tctl-v1/admin/dlq/purge.md
@@ -10,11 +10,7 @@ tags:
 
 The `tctl admin dlq purge` command deletes DLQ messages that have a Task Id equal to or less than the provided Task Id.
 
-Alias: `p`
-
 #### --dlq_type
-
-Alias: `--dt value`
 
 The type of DLQ to manage.
 

--- a/docs-src/tctl-v1/admin/dlq/read.md
+++ b/docs-src/tctl-v1/admin/dlq/read.md
@@ -10,13 +10,9 @@ tags:
 
 The `tctl admin dlq read` command reads out messages from the dead-letter queue (DLQ).
 
-Alias: `r`
-
 ---
 
 #### --dlq_type
-
-Alias: `--dt value`
 
 The type of DLQ to manage.
 

--- a/docs-src/tctl-v1/admin/history_host/describe.md
+++ b/docs-src/tctl-v1/admin/history_host/describe.md
@@ -9,30 +9,22 @@ tags:
 
 The `tctl admin history_host describe` command describes the internal information of history host.
 
-Alias: `-desc`
-
 The following modifiers change the behavior of the command.
 
 #### --workflow_id
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The WorkflowId of the Workflow whose history host is to be described.
 
 #### --history_address
 
-Alias: `--had value`
-
 The history address of the history host.
 
 #### --shard_id
 
-Alias: `--sid value`
-
 The Id of the shard that belongs to the history host.
 
 #### --print_full
-
-Alias: `--pf`
 
 Print a full and detailed summary of the history host.

--- a/docs-src/tctl-v1/admin/history_host/get_shardid.md
+++ b/docs-src/tctl-v1/admin/history_host/get_shardid.md
@@ -9,8 +9,6 @@ tags:
 
 The `tctl admin history_host get_shardid` command gets the `shardId` for a given `namespaceId` and `workflowId`.
 
-Alias: `gsh`
-
 The following modifiers change the behavior of this command.
 
 #### --namespace_id
@@ -19,7 +17,7 @@ The `namespaceId` of the history host where we're getting the `shardId`.
 
 #### --workflow_id
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The WorkflowId of the history host where we're getting the shardId.
 

--- a/docs-src/tctl-v1/admin/history_host/index.md
+++ b/docs-src/tctl-v1/admin/history_host/index.md
@@ -9,8 +9,6 @@ tags:
 
 The `tctl admin history_host` command runs an admin-level operation on the history host.
 
-Alias: `hist`
-
 ## Usage
 
 `tctl admin history_host command [command options] [arguments...]`

--- a/docs-src/tctl-v1/admin/index.md
+++ b/docs-src/tctl-v1/admin/index.md
@@ -10,8 +10,6 @@ tags:
 
 A `tctl admin` command allows the user to run admin operations.
 
-Alias : `adm`
-
 Modifiers:
 
 - Help: `tctl admin [--help | -h]`

--- a/docs-src/tctl-v1/admin/membership/index.md
+++ b/docs-src/tctl-v1/admin/membership/index.md
@@ -15,5 +15,5 @@ The `tctl admin membership` command allows admin operations to be run on members
 
 ### Commands
 
-- list_gossip
-- list_db
+- [list_gossip](/tctl-v1/admin/membership/list_gossip)
+- [list_db](/tctl-v1/admin/membership/list_db)

--- a/docs-src/tctl-v1/admin/membership/list_gossip.md
+++ b/docs-src/tctl-v1/admin/membership/list_gossip.md
@@ -12,7 +12,9 @@ The `tctl admin membership list_gossip` command lists the ringpop membership ite
 
 The following modifier changes the behavior of the command:
 
-`--role value` — filters the results by membership role
+#### `--role value`
+
+Filters the results by membership role
 
 Default: all
 Values: all, frontend, history, matching, worker

--- a/docs-src/tctl-v1/admin/shard/close_shard.md
+++ b/docs-src/tctl-v1/admin/shard/close_shard.md
@@ -11,12 +11,10 @@ tags:
 
 The `tctl admin shard close_shard` command closes a shard with an Id that corresponds to the value given in the command.
 
-Alias: `clsh`
-
 `tctl admin shard close_shard [command options] [arguments...]`
 
 The modifier below will change the behavior and output of the command.
 
-`--share_id value`
+#### `--share_id value`
 
 ShareId managed by the Temporal Cluster.

--- a/docs-src/tctl-v1/admin/shard/describe.md
+++ b/docs-src/tctl-v1/admin/shard/describe.md
@@ -11,11 +11,10 @@ tags:
 
 The `tctl admin shard describe` command shows the Id for the specified shard.
 
-Alias: `d`
-
 The modifier below controls the behavior of the command.
 
-`--share_id value`
+#### `--share_id value`
+
 The Id of the shard to describe
 
 Default: 0

--- a/docs-src/tctl-v1/admin/shard/describe_task.md
+++ b/docs-src/tctl-v1/admin/shard/describe_task.md
@@ -11,11 +11,9 @@ tags:
 
 The `tctl admin shard describe_task` command describes a specified Task's Task Id, Task type, shard Id, and task visibility timestamp.
 
-Alias: `-dt`
-
 The modifiers below control the output and behavior of the command. Enter all modifiers after the command as such:
 
-`tctl admin shard describe_task [<modifiers>]`
+`tctl admin shard describe_task <modifiers>`
 
 #### --db_engine
 

--- a/docs-src/tctl-v1/admin/shard/index.md
+++ b/docs-src/tctl-v1/admin/shard/index.md
@@ -11,8 +11,6 @@ tags:
 
 The `tctl admin shard` commands enable admin-level operations on a specified shard.
 
-Alias: `shar`
-
 #### tctl admin shard commands
 
 - [`describe`](/tctl-v1/admin/shard/describe)

--- a/docs-src/tctl-v1/admin/shard/list_tasks.md
+++ b/docs-src/tctl-v1/admin/shard/list_tasks.md
@@ -15,14 +15,10 @@ The modifiers below affect the output and behavior of the command.
 
 #### `--more`
 
-Alias: `-m`
-
 Lists more pages of list tasks.
 The default setting is to list one page of 10 list tasks.
 
 #### `--pagesize value`
-
-Alias: `--ps value`
 
 The size of the result page.
 Default: 10

--- a/docs-src/tctl-v1/admin/shard/remove_task.md
+++ b/docs-src/tctl-v1/admin/shard/remove_task.md
@@ -15,8 +15,6 @@ The `tctl admin shard remove_task` command removes a Task from the shard.
 
 The Task removed must have values that matches what is given in the command line.
 
-Alias: `rmtk`
-
 The modifiers below change the behavior of the command.
 
 #### `--shard_id value`

--- a/docs-src/tctl-v1/admin/workflow/delete.md
+++ b/docs-src/tctl-v1/admin/workflow/delete.md
@@ -9,8 +9,6 @@ tags:
   - workflow
 ---
 
-Alias: `del`
-
 The `tctl admin workflow delete` command deletes the current [Workflow Execution](/workflows/#workflow-execution) and the mutableState record.
 
 #### `--db_engine value`
@@ -74,19 +72,17 @@ Elasticsearch index name.
 
 #### `--workflow_id value`
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The Id of the current Workflow.
 
 #### `--run_id value`
 
-Aliases: `--rid value`, `-r value`
+Alias: `-r`
 
 The Id of the current run.
 
 #### `--skip_errors`
-
-Alias: `--serr`
 
 Skip any errors that occur in the Workflow Execution.
 

--- a/docs-src/tctl-v1/admin/workflow/describe.md
+++ b/docs-src/tctl-v1/admin/workflow/describe.md
@@ -9,18 +9,16 @@ tags:
   - workflow
 ---
 
-Alias: `desc`
-
 The `tctl admin workflow describe` command describes internal information of the current [Workflow Execution](/workflows/#workflow-execution).
 
 #### `--workflow_id value`
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The Id of the current Workflow.
 
 #### `--run_id value`
 
-Aliases: `--rid value`, `-r value`
+Alias: `-r`
 
 The Id of the current run.

--- a/docs-src/tctl-v1/admin/workflow/index.md
+++ b/docs-src/tctl-v1/admin/workflow/index.md
@@ -9,8 +9,6 @@ tags:
   - workflow
 ---
 
-Alias: `-wf`
-
 The `tctl admin workflow` commands enable administrator-level operations on Workflow Executions.
 
 `tctl admin workflow command [modifiers] [arguments...]`

--- a/docs-src/tctl-v1/admin/workflow/refresh_tasks.md
+++ b/docs-src/tctl-v1/admin/workflow/refresh_tasks.md
@@ -9,18 +9,16 @@ tags:
   - workflow
 ---
 
-Alias: `rt`
-
 The `tctl admin workflow refresh_tasks` command updates all [Tasks](/tasks) in a [Workflow](/workflows), provided that the command can fetch new information for Tasks.
 
 #### `--workflow_id value`
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The Id of the current Workflow.
 
 #### `--run_id value`
 
-Aliases: `--rid value`, `-r value`
+Alias: `-r`
 
 The Id of the current run.

--- a/docs-src/tctl-v1/admin/workflow/show.md
+++ b/docs-src/tctl-v1/admin/workflow/show.md
@@ -13,13 +13,13 @@ The `tctl admin workflow show` command displays Workflow history from the databa
 
 #### `--workflow_id value`
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The current Workflow.
 
 #### `--run_id value`
 
-Aliases: `--rid value`, `-r value`
+Alias: `-r`
 
 The current RunId.
 

--- a/docs-src/tctl-v1/batch/describe.md
+++ b/docs-src/tctl-v1/batch/describe.md
@@ -7,8 +7,6 @@ tags:
   - tctl
 ---
 
-Alias: `desc`
-
 The `tctl batch describe` command describes the progress of a batch job.
 
 `tctl batch describe --job_id <id>`
@@ -20,8 +18,6 @@ The following modifier controls the behavior of the command.
 _Required modifier_
 
 Specify the job ID of a batch job.
-
-Alias: `--jid`
 
 **Example**
 

--- a/docs-src/tctl-v1/batch/list.md
+++ b/docs-src/tctl-v1/batch/list.md
@@ -7,19 +7,15 @@ tags:
   - tctl
 ---
 
-Alias: `l`
-
 The `tctl batch list` command lists all batch jobs.
 
-`tctl batch list [<modifiers>]`
+`tctl batch list <modifiers>`
 
 The following modifier controls the behavior of the command.
 
 ### `--pagesize`
 
 Specify the maximum number of batch jobs to list on a page. The default value is 30.
-
-Alias: `--ps`
 
 **Example**
 

--- a/docs-src/tctl-v1/batch/start.md
+++ b/docs-src/tctl-v1/batch/start.md
@@ -9,7 +9,7 @@ tags:
 
 The `tctl batch start` command starts a batch job.
 
-`tctl batch start --query <value> [<modifiers>]`
+`tctl batch start --query <value> <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -33,8 +33,6 @@ tctl batch start --query <value>
 
 Specify a reason for running this batch job.
 
-Alias: `--re`
-
 **Example**
 
 ```bash
@@ -45,8 +43,6 @@ tctl batch start --query <value> --reason <string>
 
 Specify the operation that this batch job performs. The supported operations are `signal`, `cancel`, and `terminate`.
 
-Alias: `--bt`
-
 **Example**
 
 ```bash
@@ -56,8 +52,6 @@ tctl batch start --query <value> --batch_type <operation>
 ### `--signal_name`
 
 Specify the name of a [Signal](/concepts/what-is-a-signal). This modifier is required when `--batch_type` is `signal`.
-
-Alias: `--sig`
 
 **Example**
 
@@ -90,6 +84,8 @@ tctl batch start --query <value> --rps <value>
 ### `--yes`
 
 Disable the confirmation prompt.
+
+Alias: `y`
 
 **Example**
 

--- a/docs-src/tctl-v1/batch/terminate.md
+++ b/docs-src/tctl-v1/batch/terminate.md
@@ -9,7 +9,7 @@ tags:
 
 The `tctl batch terminate` command terminates a batch job.
 
-`tctl batch terminate --job_id <id> [<modifiers>]`
+`tctl batch terminate --job_id <id> <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -18,8 +18,6 @@ The following modifiers control the behavior of the command.
 _Required modifier_
 
 Specify the job ID of a batch job.
-
-Alias: `--jid`
 
 **Example**
 
@@ -30,8 +28,6 @@ tctl batch terminate --job_id <id>
 ### `--reason`
 
 Specify a reason for terminating this batch job.
-
-Alias: `--re`
 
 **Example**
 

--- a/docs-src/tctl-v1/dataconverter/index.md
+++ b/docs-src/tctl-v1/dataconverter/index.md
@@ -9,6 +9,4 @@ tags:
 
 The `tctl dataconverter` command enables custom [Data Converter](/concepts/what-is-a-data-converter) operations.
 
-Alias: `dc`
-
 - [tctl dataconverter web](/tctl-v1/dataconverter/web)

--- a/docs-src/tctl-v1/global-modifiers.md
+++ b/docs-src/tctl-v1/global-modifiers.md
@@ -15,8 +15,6 @@ You can supply the values for many of these modifiers by setting [environment va
 Specify a host and port for the Frontend Service.
 The default is `127.0.0.1:7233`.
 
-Alias: `--ad`
-
 ### --auto_confirm
 
 Automatically confirm all prompts.
@@ -26,19 +24,13 @@ Automatically confirm all prompts.
 Specify a timeout for the context of an RPC call in seconds.
 The default value is 5.
 
-Alias: `--ct`
-
 ### --data_converter_plugin
 
 Specify the name of the executable for a headers provider plugin.
 
-Alias: `--dcp`
-
 ### --headers_provider_plugin
 
 Specify the name of the executable for a custom Data Converter plugin.
-
-Alias: `--hpp`
 
 ### --help
 
@@ -52,7 +44,7 @@ Specify a Namespace.
 By using this modifier, you don't need to specify a `--namespace` modifier for a sub-command.
 The default Namespace is `default`.
 
-Alias: `--ns`
+Alias: `--n`
 
 ### --tls_ca_path
 
@@ -81,8 +73,6 @@ Specifying this modifier also enables host verification.
 ### --version
 
 Display the version of tctl in the CLI.
-
-Alias: `-v`
 
 ### --codec_endpoint
 

--- a/docs-src/tctl-v1/namespace/describe.md
+++ b/docs-src/tctl-v1/namespace/describe.md
@@ -11,8 +11,6 @@ The `tctl namespace describe` command describes a [Namespace](/namespaces).
 
 `tctl namespace describe`
 
-Alias: `desc`
-
 The following modifier controls the behavior of the command.
 
 ### `--namespace_id`

--- a/docs-src/tctl-v1/namespace/list.md
+++ b/docs-src/tctl-v1/namespace/list.md
@@ -7,8 +7,6 @@ tags:
   - tctl
 ---
 
-Alias: `l`
-
 The `tctl namespace list` command lists all [Namespaces](/concepts/what-is-a-namespace).
 
 `tctl namespace list`

--- a/docs-src/tctl-v1/namespace/register.md
+++ b/docs-src/tctl-v1/namespace/register.md
@@ -7,8 +7,6 @@ tags:
   - tctl
 ---
 
-Alias: `re`
-
 The `tctl namespace register` command registers a [Namespace](/concepts/what-is-a-namespace).
 
 `tctl namespace register`
@@ -29,8 +27,6 @@ The following modifiers control the behavior of the command.
 Specify the name of the active [Temporal Cluster](/concepts/what-is-a-temporal-cluster/) when registering a [Namespace](/concepts/what-is-a-namespace).
 This value changes for Global Namespaces when a failover occurs.
 
-Alias: `--ac`
-
 **Example**
 
 ```bash
@@ -47,8 +43,6 @@ This is a read-only setting and cannot be changed.
 
 This modifier is valid only when the `--global_namespace` modifier is set to true.
 
-Alias `--cl`
-
 **Example**
 
 ```bash
@@ -58,8 +52,6 @@ tctl namespace register --clusters <names>
 ### `--description`
 
 Specify a description when registering a [Namespace](/concepts/what-is-a-namespace).
-
-Alias `--desc`
 
 **Example**
 
@@ -73,8 +65,6 @@ Specifies whether a [Namespace](/concepts/what-is-a-namespace) is a [Global Name
 When enabled, it controls the creation of replication tasks on updates allowing the state to be replicated across Clusters.
 This is a read-only setting and cannot be changed.
 
-Alias `--gd`
-
 **Example**
 
 ```bash
@@ -85,8 +75,6 @@ tctl namespace register --global_namespace <boolean>
 
 Set the state of [Archival](/concepts/what-is-archival).
 Valid values are `disabled` and `enabled`.
-
-Alias `--has`
 
 **Example**
 
@@ -99,8 +87,6 @@ tctl namespace register --history_archival_state <value>
 Specify the URI for [Archival](/concepts/what-is-archival).
 The URI cannot be changed after Archival is first enabled.
 
-Alias `--huri`
-
 **Example**
 
 ```bash
@@ -111,8 +97,6 @@ tctl namespace register --history_uri <uri>
 
 Specify data for a [Namespace](/concepts/what-is-a-namespace) in the form of key-value pairs (such as `k1:v1,k2:v2,k3:v3`).
 
-Alias `--dmd`
-
 **Example**
 
 ```bash
@@ -122,8 +106,6 @@ tctl namespace register --namespace_data <data>
 ### `--owner_email`
 
 Specify the email address of the [Namespace](/concepts/what-is-a-namespace) owner.
-
-Alias `--oe`
 
 **Example**
 
@@ -137,8 +119,6 @@ Set the [Retention Period](/clusters#retention-period) for the [Namespace](/conc
 
 The Retention Period applies to Closed [Workflow Executions](/concepts/what-is-a-workflow-execution).
 
-Alias `--rd`
-
 **Example**
 
 ```bash
@@ -150,8 +130,6 @@ tctl namespace register --retention <value>
 Set the visibility state for [Archival](/concepts/what-is-archival).
 Valid values are `disabled` and `enabled`.
 
-Alias `--vas`
-
 **Example**
 
 ```bash
@@ -162,8 +140,6 @@ tctl namespace register --visibility_archival_state <value>
 
 Specify the visibility URI for [Archival](/concepts/what-is-archival).
 The URI cannot be changed after Archival is first enabled.
-
-Alias `--vuri`
 
 **Example**
 

--- a/docs-src/tctl-v1/namespace/update.md
+++ b/docs-src/tctl-v1/namespace/update.md
@@ -17,8 +17,6 @@ The following modifiers control the behavior of the command.
 
 Specify the name of the active [Temporal Cluster](/concepts/what-is-a-temporal-cluster/) when updating a [Namespace](/concepts/what-is-a-namespace).
 
-Alias: `--ac`
-
 **Example**
 
 ```bash
@@ -46,8 +44,6 @@ The list contains the names of Clusters (separated by spaces) to which the Names
 
 This modifier is valid only when the `--global_namespace` modifier is set to true.
 
-Alias `--cl`
-
 **Example**
 
 ```bash
@@ -57,8 +53,6 @@ tctl namespace update --clusters <names>
 ### `--description`
 
 Specify a description when updating a [Namespace](/concepts/what-is-a-namespace).
-
-Alias `--desc`
 
 **Example**
 
@@ -71,8 +65,6 @@ tctl namespace update --description <value>
 Set the state of [Archival](/concepts/what-is-archival).
 Valid values are `disabled` and `enabled`.
 
-Alias `--has`
-
 **Example**
 
 ```bash
@@ -84,8 +76,6 @@ tctl namespace update --history_archival_state <value>
 Specify the URI for URI for [Archival](/concepts/what-is-archival).
 The URI cannot be changed after Archival is first enabled.
 
-Alias `--huri`
-
 **Example**
 
 ```bash
@@ -96,8 +86,6 @@ tctl namespace update --history_uri <uri>
 
 Specify data for a [Namespace](/concepts/what-is-a-namespace) in the form of key-value pairs (such as `k1:v1,k2:v2,k3:v3`).
 
-Alias `--dmd`
-
 **Example**
 
 ```bash
@@ -107,8 +95,6 @@ tctl namespace update --namespace_data <data>
 ### `--owner_email`
 
 Specify the email address of the [Namespace](/concepts/what-is-a-namespace) owner.
-
-Alias `--oe`
 
 **Example**
 
@@ -142,8 +128,6 @@ tctl namespace update --remove_bad_binary <value>
 
 Specify the number of days to retain [Workflow Executions](/concepts/what-is-a-workflow-execution).
 
-Alias `--rd`
-
 **Example**
 
 ```bash
@@ -155,8 +139,6 @@ tctl namespace update --retention <value>
 Set the visibility state for [Archival](/concepts/what-is-archival).
 Valid values are `disabled` and `enabled`.
 
-Alias `--vas`
-
 **Example**
 
 ```bash
@@ -167,8 +149,6 @@ tctl namespace update --visibility_archival_state <value>
 
 Specify the visibility URI for [Archival](/concepts/what-is-archival).
 The URI cannot be changed after Archival is first enabled.
-
-Alias `--vuri`
 
 **Example**
 

--- a/docs-src/tctl-v1/taskqueue/describe.md
+++ b/docs-src/tctl-v1/taskqueue/describe.md
@@ -7,8 +7,6 @@ tags:
   - tctl
 ---
 
-Alias: `desc`
-
 The `tctl taskqueue describe` command describes the poller information of a [Task Queue](/concepts/what-is-a-task-queue).
 
 `tctl taskqueue describe <modifiers> <value>`
@@ -21,7 +19,7 @@ _Required modifier_
 
 Specify a [Task Queue](/concepts/what-is-a-task-queue).
 
-Alias: `--tq`
+Alias: `--t`
 
 **Example**
 
@@ -34,8 +32,6 @@ tctl taskqueue describe --taskqueue <value>
 Specify the type of a [Task Queue](/concepts/what-is-a-task-queue).
 The type can be `workflow` or `activity`.
 The default is `workflow`.
-
-Alias: `--tqt`
 
 **Example**
 

--- a/docs-src/tctl-v1/taskqueue/index.md
+++ b/docs-src/tctl-v1/taskqueue/index.md
@@ -9,7 +9,7 @@ tags:
 
 The `tctl taskqueue` command enables [Task Queue](/concepts/what-is-a-task-queue) operations.
 
-Alias: `tq`
+Alias: `t`
 
 - [tctl taskqueue describe](/tctl-v1/taskqueue/describe)
 - [tctl taskqueue list-partition](/tctl-v1/taskqueue/list-partition)

--- a/docs-src/tctl-v1/taskqueue/list-partition.md
+++ b/docs-src/tctl-v1/taskqueue/list-partition.md
@@ -19,7 +19,7 @@ _Required modifier_
 
 Specify a [Task Queue](/concepts/what-is-a-task-queue) description.
 
-Alias: `--tq`
+Alias: `--t`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/cancel.md
+++ b/docs-src/tctl-v1/workflow/cancel.md
@@ -15,7 +15,7 @@ After cancellation, the Workflow Execution can perform cleanup work.
 
 See also [`tctl workflow terminate`](/tctl-v1/workflow/terminate).
 
-`tctl workflow cancel [<modifiers>]`
+`tctl workflow cancel <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -23,7 +23,7 @@ The following modifiers control the behavior of the command.
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -35,7 +35,7 @@ tctl workflow cancel --workflow_id <id>
 
 Specify a [Run Id](/concepts/what-is-a-run-id).
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/count.md
+++ b/docs-src/tctl-v1/workflow/count.md
@@ -10,7 +10,7 @@ tags:
 The `tctl workflow count` command counts [Workflow Executions](/concepts/what-is-a-workflow-execution).
 This command requires Elasticsearch to be enabled.
 
-`tctl workflow count [<modifiers>]`
+`tctl workflow count <modifiers>`
 
 The following modifier controls the behavior of the command.
 

--- a/docs-src/tctl-v1/workflow/describe.md
+++ b/docs-src/tctl-v1/workflow/describe.md
@@ -14,8 +14,6 @@ To find a Workflow with a given Run Id, refer to [`tctl workflow describeid`](/t
 
 `tctl workflow describe <modifiers>`
 
-Alias: `d`
-
 The following modifiers control the behavior of the command.
 Always include required modifiers when executing this command.
 
@@ -25,7 +23,7 @@ Always include required modifiers when executing this command.
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -38,7 +36,7 @@ tctl workflow describe --workflow_id <id>
 Specify a [Run Id](/concepts/what-is-a-run-id).
 If a Run Id is not provided, the command will show the latest Workflow Execution of that Workflow Id.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -49,8 +47,6 @@ tctl workflow describe --run_id <id>
 ### `--print_raw`
 
 Print properties exactly as they are stored.
-
-Alias: `--praw`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/describeid.md
+++ b/docs-src/tctl-v1/workflow/describeid.md
@@ -19,8 +19,6 @@ The following modifiers control the behavior of the command.
 
 Print properties exactly as they are stored.
 
-Alias: `--praw`
-
 **Example**
 
 ```bash

--- a/docs-src/tctl-v1/workflow/index.md
+++ b/docs-src/tctl-v1/workflow/index.md
@@ -9,8 +9,6 @@ tags:
 
 The `tctl workflow` commands enable [Workflow Execution](/concepts/what-is-a-workflow-execution) operations.
 
-Alias: `w`
-
 - [tctl workflow cancel](/tctl-v1/workflow/cancel)
 - [tctl workflow count](/tctl-v1/workflow/count)
 - [tctl workflow describe](/tctl-v1/workflow/describe)

--- a/docs-src/tctl-v1/workflow/list.md
+++ b/docs-src/tctl-v1/workflow/list.md
@@ -25,8 +25,6 @@ The following modifiers control the behavior of the command.
 
 Print the raw timestamp.
 
-Alias: `--prt`
-
 **Example**
 
 ```bash
@@ -36,8 +34,6 @@ tctl workflow list --print_raw_time
 ### `--print_datetime`
 
 Print the timestamp.
-
-Alias: `--pdt`
 
 **Example**
 
@@ -49,8 +45,6 @@ tctl workflow list --print_datetime
 
 Print a memo.
 
-Alias: `--pme`
-
 **Example**
 
 ```bash
@@ -60,8 +54,6 @@ tctl workflow list --print_memo
 ### `--print_search_attr`
 
 Print the [Search Attributes](/concepts/what-is-a-search-attribute).
-
-Alias: `--psa`
 
 **Example**
 
@@ -73,8 +65,6 @@ tctl workflow list --print_search_attr
 
 Print the full message without table formatting.
 
-Alias: `--pf`
-
 **Example**
 
 ```bash
@@ -84,8 +74,6 @@ tctl workflow list --print_full
 ### `--print_json`
 
 Print the raw JSON objects.
-
-Alias: `--pjson`
 
 **Example**
 
@@ -97,8 +85,6 @@ tctl workflow list --print_json
 
 List open [Workflow Executions](/concepts/what-is-a-workflow-execution).
 (By default, the `tctl workflow list` command lists closed Workflow Executions.)
-
-Alias: `--op`
 
 **Example**
 
@@ -121,8 +107,6 @@ Supported format are as follows:
   - `week` or `w`
   - `month` or `M`
   - `year` or `y`
-
-Alias: `--et`
 
 **Examples**
 
@@ -154,8 +138,6 @@ Supported formats are as follows:
   - `month` or `M`
   - `year` or `y`
 
-Alias: `--lt`
-
 **Examples**
 
 To specify 11:02:17 PM Pacific Daylight Time on April 13, 2022:
@@ -174,7 +156,7 @@ tctl workflow list --latest_time '10second'
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -185,8 +167,6 @@ tctl workflow list --workflow_id <id>
 ### `--workflow_type`
 
 Specify the name of a [Workflow Type](/concepts/what-is-a-workflow-type).
-
-Alias: `--wt`
 
 **Example**
 
@@ -205,8 +185,6 @@ Supported values are as follows:
 - `terminated`
 - `continuedasnew`
 - `timedout`
-
-Alias: `-s`
 
 **Example**
 
@@ -264,8 +242,6 @@ tctl workflow list \
 List more than one page.
 (By default, the `tctl workflow list` command lists one page of results.)
 
-Alias: `-m`
-
 **Example**
 
 ```bash
@@ -276,8 +252,6 @@ tctl workflow list --more
 
 Specify the maximum number of [Workflow Executions](/concepts/what-is-a-workflow-execution) to list on a page.
 (By default, the `tctl workflow list` command lists 10 Workflow Executions per page.)
-
-Alias: `--ps`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/listall.md
+++ b/docs-src/tctl-v1/workflow/listall.md
@@ -14,15 +14,13 @@ To list open Workflow Executions, use the `--open` option.
 
 See also [`tctl workflow list`](/tctl-v1/workflow/list), [`tctl workflow listarchived`](/tctl-v1/workflow/listarchived), and [`tctl workflow scan`](/tctl-v1/workflow/scan).
 
-`tctl workflow listall [<modifiers>]`
+`tctl workflow listall <modifiers>`
 
 The following modifiers control the behavior of the command.
 
 ### `--print_raw_time`
 
 Print the raw timestamp.
-
-Alias: `--prt`
 
 **Example**
 
@@ -34,8 +32,6 @@ tctl workflow listall --print_raw_time
 
 Print the timestamp.
 
-Alias: `--pdt`
-
 **Example**
 
 ```bash
@@ -45,8 +41,6 @@ tctl workflow listall --print_datetime
 ### `--print_memo`
 
 Print a memo.
-
-Alias: `--pme`
 
 **Example**
 
@@ -58,8 +52,6 @@ tctl workflow listall --print_memo
 
 Print the [Search Attributes](/concepts/what-is-a-search-attribute).
 
-Alias: `--psa`
-
 **Example**
 
 ```bash
@@ -69,8 +61,6 @@ tctl workflow listall --print_search_attr
 ### `--print_full`
 
 Print the full message without table formatting.
-
-Alias: `--pf`
 
 **Example**
 
@@ -82,8 +72,6 @@ tctl workflow listall --print_full
 
 Print the raw JSON objects.
 
-Alias: `--pjson`
-
 **Example**
 
 ```bash
@@ -94,8 +82,6 @@ tctl workflow listall --print_json
 
 List open [Workflow Executions](/concepts/what-is-a-workflow-execution).
 (By default, the `tctl workflow listall` command lists closed Workflow Executions.)
-
-Alias: `--op`
 
 **Example**
 
@@ -117,8 +103,6 @@ Specify the earliest start time to list. Supported format are as follows:
   - `week` or `w`
   - `month` or `M`
   - `year` or `y`
-
-Alias: `--et`
 
 **Examples**
 
@@ -169,7 +153,7 @@ tctl workflow listall --latest-time '10second'
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -180,8 +164,6 @@ tctl workflow listall --workflow_id <id>
 ### `--workflow_type`
 
 Specify the name of a [Workflow Type](/concepts/what-is-a-workflow-type).
-
-Alias: `--wt`
 
 **Example**
 
@@ -200,8 +182,6 @@ Supported values are as follows:
 - `terminated`
 - `continuedasnew`
 - `timedout`
-
-Alias: `-s`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/listarchived.md
+++ b/docs-src/tctl-v1/workflow/listarchived.md
@@ -24,8 +24,6 @@ The following modifiers control the behavior of the command.
 
 Print the raw timestamp.
 
-Alias: `--prt`
-
 **Example**
 
 ```bash
@@ -35,8 +33,6 @@ tctl workflow listarchived --print_raw_time
 ### `--print_datetime`
 
 Print the timestamp.
-
-Alias: `--pdt`
 
 **Example**
 
@@ -48,8 +44,6 @@ tctl workflow listarchived --print_datetime
 
 Print a memo.
 
-Alias: `--pme`
-
 **Example**
 
 ```bash
@@ -59,8 +53,6 @@ tctl workflow listarchived --print_memo
 ### `--print_search_attr`
 
 Print the [Search Attributes](/concepts/what-is-a-search-attribute).
-
-Alias: `--psa`
 
 **Example**
 
@@ -72,8 +64,6 @@ tctl workflow listarchived --print_search_attr
 
 Print the full message without table formatting.
 
-Alias: `--pf`
-
 **Example**
 
 ```bash
@@ -83,8 +73,6 @@ tctl workflow listarchived --print_full
 ### `--print_json`
 
 Print the raw JSON objects.
-
-Alias: `--pjson`
 
 **Example**
 
@@ -111,8 +99,6 @@ tctl workflow listarchived --query <value>
 Specify the maximum number of [Workflow Executions](/concepts/what-is-a-workflow-execution) to list on a page.
 (By default, the `tctl workflow listarchived` command lists 100 Workflow Executions per page.)
 
-Alias: `--ps`
-
 **Example**
 
 ```bash
@@ -122,8 +108,6 @@ tctl workflow listarchived --pagesize <value>
 ### `--all`
 
 List all pages.
-
-Alias: `-a`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/observe.md
+++ b/docs-src/tctl-v1/workflow/observe.md
@@ -11,9 +11,7 @@ The `tctl workflow observe` command shows the progress of the [Event History](/c
 
 See also [`tctl workflow observeid`](/tctl-v1/workflow/observeid).
 
-`tctl workflow observe [<modifiers>]`
-
-Alias: `o`
+`tctl workflow observe <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -21,7 +19,7 @@ The following modifiers control the behavior of the command.
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -33,7 +31,7 @@ tctl workflow observe --workflow_id <id>
 
 Specify a [Run Id](/concepts/what-is-a-run-id).
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -45,8 +43,6 @@ tctl workflow observe --run_id <id>
 
 Show event details.
 
-Alias: `--sd`
-
 **Example**
 
 ```bash
@@ -57,8 +53,6 @@ tctl workflow observe --show_detail
 
 Specify the maximum length for each attribute field.
 The default value is 0.
-
-Alias: `--maxl`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/observeid.md
+++ b/docs-src/tctl-v1/workflow/observeid.md
@@ -9,7 +9,7 @@ tags:
 
 The `tctl workflow observeid` command shows the progress of the [Event History](/concepts/what-is-an-event-history) of a [Workflow Execution](/concepts/what-is-a-workflow-execution) for the specified [Workflow Id](/concepts/what-is-a-workflow-id) and optional [Run Id](/concepts/what-is-a-run-id).
 
-`tctl workflow observeid <workflow_id> [<run_id>] [<modifiers>]`
+`tctl workflow observeid <workflow_id> [<run_id>] <modifiers>`
 
 This command is a shortcut for `tctl workflow observe --workflow_id <workflowid> [--run_id <runid>]`.
 
@@ -18,8 +18,6 @@ The following modifiers control the behavior of the command.
 ### `--show_detail`
 
 Show event details.
-
-Alias: `--sd`
 
 **Example**
 
@@ -31,8 +29,6 @@ tctl workflow observeid --show_detail
 
 Specify the maximum length for each attribute field.
 The default value is 0.
-
-Alias: `--maxl`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/query.md
+++ b/docs-src/tctl-v1/workflow/query.md
@@ -7,6 +7,8 @@ tags:
   - tctl
 ---
 
+Alias: `q`
+
 The `tctl workflow query` command sends a [Query](/concepts/what-is-a-query) to a [Workflow Execution](/concepts/what-is-a-workflow-execution).
 
 Queries can be used to retrieve all or part of the Workflow state with given parameters.
@@ -39,7 +41,7 @@ Always include required modifiers when executing this command.
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id). **This modifier is required.**
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -51,7 +53,7 @@ tctl workflow query --workflow_id <id>
 
 Specify a [Run Id](/concepts/what-is-a-run-id).
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -62,8 +64,6 @@ tctl workflow query --run_id <id>
 ### `--query_type`
 
 Specify the type of Query to run.
-
-Alias: `--qt`
 
 **Example**
 
@@ -91,8 +91,6 @@ Pass input for the Query from a JSON file.
 For multiple JSON objects, concatenate them and use spaces or newline characters as separators.
 Input from the command line overwrites input from the file.
 
-Alias: `--if`
-
 **Example**
 
 ```bash
@@ -103,8 +101,6 @@ tctl workflow query --input_file <filename>
 
 Reject Queries based on Workflow state.
 Valid values are `not_open` and `not_completed_cleanly`.
-
-Alias: `--qrc`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/reset-batch.md
+++ b/docs-src/tctl-v1/workflow/reset-batch.md
@@ -24,8 +24,6 @@ Provide an input file that specifies [Workflow Execution](/concepts/what-is-a-wo
 Each line contains one [Workflow Id](/concepts/what-is-a-workflow-id) as the base Run and, optionally, a [Run Id](/concepts/what-is-a-run-id).
 If a Run Id is not specified, the current Run Id is used.
 
-Alias: `--if`
-
 **Example**
 
 ```bash
@@ -70,8 +68,6 @@ tctl workflow reset-batch --input_separator <string>
 ### `--reason`
 
 Specify a reason for resetting the [Workflow Executions](/concepts/what-is-a-workflow-execution).
-
-<!-- Alias: `--re` -->
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/reset.md
+++ b/docs-src/tctl-v1/workflow/reset.md
@@ -21,7 +21,7 @@ The following modifiers control the behavior of the command.
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -33,7 +33,7 @@ tctl workflow reset --workflow_id <id>
 
 Specify a [Run Id](/concepts/what-is-a-run-id).
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -55,8 +55,6 @@ tctl workflow reset --event_id <id>
 ### `--reason`
 
 Specify a reason for resetting the [Workflow Execution](/concepts/what-is-a-workflow-execution).
-
-<!-- Alias: `--re` -->
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/run.md
+++ b/docs-src/tctl-v1/workflow/run.md
@@ -14,11 +14,11 @@ The command is entered in the following format:
 
 To run a Workflow, the user must specify the following:
 
-- Task queue name (`--tq`)
-- Workflow Type (`--wt`)
+- Task queue name (`--taskqueue`)
+- Workflow Type (`--workflow_type`)
 
 ```bash
-tctl workflow run --tq your-task-queue-name --wt YourWorkflowDefinitionName
+tctl workflow run --taskqueue your-task-queue-name --workflow_type YourWorkflowDefinitionName
 ```
 
 Single quotes (`''`) are used to wrap input as JSON.
@@ -30,7 +30,7 @@ The following modifiers control the behavior of the command.
 
 Specify a [Task Queue](/concepts/what-is-a-task-queue).
 
-Alias: `--tq`
+Alias: `--t`
 
 **Example**
 
@@ -42,7 +42,7 @@ tctl workflow run --taskqueue <name>
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -53,8 +53,6 @@ tctl workflow run --workflow_id <id>
 ### `--workflow_type`
 
 Specify the name of a [Workflow Type](/concepts/what-is-a-workflow-type).
-
-Alias: `--wt`
 
 **Example**
 
@@ -67,8 +65,6 @@ tctl workflow run --workflow_type <name>
 Specify the [Start-To-Close Timeout](/concepts/what-is-a-start-to-close-timeout) of the [Workflow Execution](/concepts/what-is-a-workflow-execution) in seconds.
 The default value is 0.
 
-Alias: `--et`
-
 **Example**
 
 ```bash
@@ -79,8 +75,6 @@ tctl workflow run --execution_timeout <seconds>
 
 Specify the [Start-To-Close Timeout](/concepts/what-is-a-start-to-close-timeout) of the [Workflow Task](/concepts/what-is-a-workflow-task) in seconds.
 The default value is 10.
-
-Alias: `--wtt`
 
 **Example**
 
@@ -136,8 +130,6 @@ tctl workflow run --input <json>
 Pass input for the Workflow from a JSON file.
 For multiple JSON objects, concatenate them and use spaces or newline characters as separators.
 Input from the command line overwrites input from the file.
-
-Alias: `--if`
 
 **Example**
 
@@ -212,8 +204,6 @@ tctl workflow run --search_attr_value <value>
 
 Get event details.
 
-Alias: `--sd`
-
 **Example**
 
 ```bash
@@ -224,8 +214,6 @@ tctl workflow run --show_detail
 
 Specify the maximum length for each attribute field.
 The default value is 0.
-
-Alias: `--maxl`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/scan.md
+++ b/docs-src/tctl-v1/workflow/scan.md
@@ -15,15 +15,13 @@ To set the size of a page, use the `--pagesize` option.
 
 See also [`tctl workflow list`](/tctl-v1/workflow/list), [`tctl workflow listall`](/tctl-v1/workflow/listall), and [`tctl workflow listarchived`](/tctl-v1/workflow/listarchived).
 
-`tctl workflow scan [<modifiers>]`
+`tctl workflow scan <modifiers>`
 
 The following modifiers control the behavior of the command.
 
 ### `--print_raw_time`
 
 Print the raw timestamp.
-
-Alias: `--prt`
 
 **Example**
 
@@ -35,8 +33,6 @@ tctl workflow scan --print_raw_time
 
 Print the timestamp.
 
-Alias: `--pdt`
-
 **Example**
 
 ```bash
@@ -46,8 +42,6 @@ tctl workflow scan --print_datetime
 ### `--print_memo`
 
 Print a memo.
-
-Alias: `--pme`
 
 **Example**
 
@@ -59,8 +53,6 @@ tctl workflow scan --print_memo
 
 Print the [Search Attributes](/concepts/what-is-a-search-attribute).
 
-Alias: `--psa`
-
 **Example**
 
 ```bash
@@ -70,8 +62,6 @@ tctl workflow scan --print_search_attr
 ### `--print_full`
 
 Print the full message without table formatting.
-
-Alias: `--pf`
 
 **Example**
 
@@ -83,8 +73,6 @@ tctl workflow scan --print_full
 
 Print the raw JSON objects.
 
-Alias: `--pjson`
-
 **Example**
 
 ```bash
@@ -95,8 +83,6 @@ tctl workflow scan --print_json
 
 Specify the maximum number of [Workflow Execution](/concepts/what-is-a-workflow-execution) to list on a page.
 (By default, the `tctl workflow scan` command lists 2000 Workflow Executions per page.)
-
-Alias: `--ps`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/show.md
+++ b/docs-src/tctl-v1/workflow/show.md
@@ -19,7 +19,7 @@ The following modifiers control the behavior of the command.
 
 Show the History of a [Workflow Execution](/concepts/what-is-a-workflow-execution) by specifying a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -31,7 +31,7 @@ tctl workflow show --workflow_id <id>
 
 Show the History of a [Workflow Execution](/concepts/what-is-a-workflow-execution) by specifying a [Run Id](/concepts/what-is-a-run-id).
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -43,8 +43,6 @@ tctl workflow show --run_id <id>
 
 Print the timestamp.
 
-Alias: `--pdt`
-
 **Example**
 
 ```bash
@@ -54,8 +52,6 @@ tctl workflow show --print_datetime
 ### `--print_raw_time`
 
 Print the raw timestamp.
-
-Alias: `--prt`
 
 **Example**
 
@@ -67,8 +63,6 @@ tctl workflow show --print_raw_time
 
 Serialize an event to a file.
 
-Alias: `--of`
-
 **Example**
 
 ```bash
@@ -79,8 +73,6 @@ tctl workflow show --output_filename <filename>
 
 Print full event details.
 
-Alias: `--pf`
-
 **Example**
 
 ```bash
@@ -90,8 +82,6 @@ tctl workflow show --print_full
 ### `--print_event_version`
 
 Print the event version.
-
-Alias: `--pev`
 
 **Example**
 
@@ -104,8 +94,6 @@ tctl workflow show --print_event_version
 Print the details of a specified event.
 The default value is 0.
 
-Alias: `--eid`
-
 **Example**
 
 ```bash
@@ -116,8 +104,6 @@ tctl workflow show --event_id <id>
 
 Specify the maximum length for each attribute field.
 The default value is 500.
-
-Alias: `--maxl`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/showid.md
+++ b/docs-src/tctl-v1/workflow/showid.md
@@ -9,7 +9,7 @@ tags:
 
 The `tctl workflow showid` command shows the Workflow Execution Event History for the specified [Workflow Id](/concepts/what-is-a-workflow-id) and optional [Run Id](/concepts/what-is-a-run-id).
 
-`tctl workflow showid <workflow_id> [<run_id>] [<modifiers>]`
+`tctl workflow showid <workflow_id> [<run_id>] <modifiers>`
 
 This command is a shortcut for `tctl workflow show --workflow_id <workflowid> [--run_id <runid>]`.
 
@@ -50,8 +50,6 @@ The following modifiers control the behavior of the command.
 
 Print the timestamp.
 
-Alias: `--pdt`
-
 **Example**
 
 ```bash
@@ -61,8 +59,6 @@ tctl workflow showid <workflow_id> --print_datetime
 ### `--print_raw_time`
 
 Print the raw timestamp.
-
-Alias: `--prt`
 
 **Example**
 
@@ -74,8 +70,6 @@ tctl workflow showid <workflow_id> --print_raw_time
 
 Serialize an event to a file.
 
-Alias: `--of`
-
 **Example**
 
 ```bash
@@ -86,8 +80,6 @@ tctl workflow showid <workflow_id> --output_filename <filename>
 
 Print full event details.
 
-Alias: `--pf`
-
 **Example**
 
 ```bash
@@ -97,8 +89,6 @@ tctl workflow showid <workflow_id> --print_full
 ### `--print_event_version`
 
 Print the event version.
-
-Alias: `--pev`
 
 **Example**
 
@@ -111,8 +101,6 @@ tctl workflow showid <workflow_id> --print_event_version
 Print the details of a specified event.
 The default value is 0.
 
-Alias: `--eid`
-
 **Example**
 
 ```bash
@@ -123,8 +111,6 @@ tctl workflow showid <workflow_id> --event_id <id>
 
 Specify the maximum length for each attribute field.
 The default value is 500.
-
-Alias: `--maxl`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/signal.md
+++ b/docs-src/tctl-v1/workflow/signal.md
@@ -90,7 +90,7 @@ Make sure to include required modifiers in all command executions.
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id). **This modifier is required.**
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -102,7 +102,7 @@ tctl workflow signal --workflow_id <id>
 
 Specify a [Run Id](/concepts/what-is-a-run-id).
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -113,8 +113,6 @@ tctl workflow signal --run_id <id>
 ### `--name`
 
 Specify the name of a [Signal](/concepts/what-is-a-signal).
-
-Alias: `-n`
 
 **Example**
 
@@ -138,8 +136,6 @@ tctl workflow signal --input <json>
 ### `--input_file`
 
 Pass input for the [Signal](/concepts/what-is-a-signal) from a JSON file.
-
-Alias: `--if`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/stack.md
+++ b/docs-src/tctl-v1/workflow/stack.md
@@ -21,7 +21,7 @@ The following modifiers control the behavior of the command.
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -33,7 +33,7 @@ tctl workflow stack --workflow_id <id>
 
 Specify a [Run Id](/concepts/what-is-a-run-id).
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -61,8 +61,6 @@ Pass input for the query from a JSON file.
 For multiple JSON objects, concatenate them and use spaces or newline characters as separators.
 Input from the command line overwrites input from the file.
 
-Alias: `--if`
-
 **Example**
 
 ```bash
@@ -73,8 +71,6 @@ tctl workflow stack --input_file <filename>
 
 Reject queries based on Workflow state.
 Valid values are `not_open` and `not_completed_cleanly`.
-
-Alias: `--qrc`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/start.md
+++ b/docs-src/tctl-v1/workflow/start.md
@@ -19,7 +19,7 @@ Always include required modifiers when executing this command.
 
 Specify a [Task Queue](/concepts/what-is-a-task-queue).
 
-Alias: `--tq`
+Alias: `--t`
 
 **Example**
 
@@ -33,7 +33,7 @@ tctl workflow start --taskqueue <name>
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -54,8 +54,6 @@ tctl workflow start  --workflow_id "HelloTemporal1" --taskqueue HelloWorldTaskQu
 
 Specify the name of a [Workflow Type](/concepts/what-is-a-workflow-type).
 
-Alias: `--wt`
-
 **Example**
 
 ```bash
@@ -67,8 +65,6 @@ tctl workflow start --workflow_type <name>
 Specify the [Start-To-Close Timeout](/concepts/what-is-a-start-to-close-timeout) of the [Workflow Execution](/concepts/what-is-a-workflow-execution) in seconds.
 The default value is 0.
 
-Alias: `--et`
-
 **Example**
 
 ```bash
@@ -79,8 +75,6 @@ tctl workflow start --execution_timeout <seconds>
 
 Specify the [Start-To-Close Timeout](/concepts/what-is-a-start-to-close-timeout) of the [Workflow Task](/concepts/what-is-a-workflow-task) in seconds.
 The default value is 10.
-
-Alias: `--wtt`
 
 **Example**
 
@@ -143,8 +137,6 @@ tctl workflow start --input <json>
 Pass input for the Workflow from a JSON file.
 For multiple JSON objects, concatenate them and use spaces or newline characters as separators.
 Input from the command line overwrites input from the file.
-
-Alias: `--if`
 
 **Example**
 

--- a/docs-src/tctl-v1/workflow/terminate.md
+++ b/docs-src/tctl-v1/workflow/terminate.md
@@ -14,7 +14,7 @@ No more command tasks will be scheduled.
 
 See also [`tctl workflow cancel`](/tctl-v1/workflow/cancel).
 
-`tctl workflow terminate [<modifiers>]`
+`tctl workflow terminate <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -22,7 +22,7 @@ The following modifiers control the behavior of the command.
 
 Specify a [Workflow Id](/concepts/what-is-a-workflow-id).
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -34,7 +34,7 @@ tctl workflow terminate --workflow_id <id>
 
 Specify a [Run Id](/concepts/what-is-a-run-id).
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -45,8 +45,6 @@ tctl workflow terminate --run_id <id>
 ### `--reason`
 
 Specify a reason for terminating the [Workflow Execution](/concepts/what-is-a-workflow-execution).
-
-Alias: `--re`
 
 **Example**
 

--- a/docs/tctl-next/activity.md
+++ b/docs/tctl-next/activity.md
@@ -13,8 +13,6 @@ import TabItem from '@theme/TabItem';
 
 The `tctl activity` commands enable <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a> operations.
 
-Alias: `a`
-
 - [tctl activity complete](/tctl-next/activity#complete)
 - [tctl activity fail](/tctl-next/activity#fail)
 

--- a/docs/tctl-next/batch.md
+++ b/docs/tctl-next/batch.md
@@ -39,8 +39,6 @@ Terminating a batch job does not roll back the operations already performed by t
 
 ## list
 
-Alias: `l`
-
 The `tctl batch list` command lists all batch jobs.
 
 `tctl batch list <modifiers>`
@@ -57,8 +55,6 @@ Always include required modifiers when executing this command.
 - [--time-format](/tctl-next/modifiers#--time-format)
 
 ## describe
-
-Alias: `desc`
 
 The `tctl batch describe` command describes the progress of a batch job.
 

--- a/docs/tctl-next/data-converter.md
+++ b/docs/tctl-next/data-converter.md
@@ -13,8 +13,6 @@ import TabItem from '@theme/TabItem';
 
 The `tctl data-converter` command enables custom <a class="tdlp" href="/security#data-converter">Data Converter<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Data Converter?</p><p class="tdlppd">A Data Converter is a Temporal SDK component that encodes and decodes data entering and exiting a Temporal Server.</p><p class="tdlplm"><a class="tdlplma" href="/security#data-converter">Learn more</a></p></div></a> operations.
 
-Alias: `dc`
-
 - [tctl data-converter web](/tctl-next/data-converter#web)
 
 ## web

--- a/docs/tctl-next/index.md
+++ b/docs/tctl-next/index.md
@@ -12,11 +12,11 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
 This documentation reflects the "next" version of Temporal's tctl command line tool.
-Currently it is known as [tctl v2.0.0-beta](https://github.com/temporalio/tctl#trying-out-new-tctl-v200-beta-with-updated-ux), but the name may change in the future.
+`tctl next` was formerly known as [tctl v2.0.0-beta](https://github.com/temporalio/tctl#trying-out-new-tctl-v200-beta-with-updated-ux).
 
 :::note
 
-If you are using `tctl` version 1.16.12 or older, you must update to at least version 1.16.3 before you can switch to `tctl` v2.0.0-beta.1.
+Update to version 1.17 or later before switching to `tctl next`.
 
 :::
 

--- a/docs/tctl-next/modifiers.md
+++ b/docs/tctl-next/modifiers.md
@@ -204,8 +204,6 @@ Values: less, more, favoritePager..[$PAGER]
 
 Specify the maximum number of batch jobs to list on a page. The default value is 30.
 
-Alias: `--ps`
-
 ## --query
 
 _Required modifier_
@@ -216,6 +214,8 @@ Specify an SQL-like query of <a class="tdlp" href="/visibility#search-attribute"
 
 Using the `--query` option causes tctl to ignore all other filter options, including `open`, `earliest-time`, `latest-time`, `workflow-id`, and `workflow-type`.
 
+Alias: `--q`
+
 ## --raw
 
 Print properties exactly as they are stored.
@@ -223,8 +223,6 @@ Print properties exactly as they are stored.
 ## --reason
 
 Specify a reason for terminating the <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
-
-Alias: `-r`
 
 ## --reject-condition
 
@@ -271,8 +269,6 @@ Set the [Retention Period](/clusters#retention-period) for the <a class="tdlp" h
 
 The Retention Period applies to Closed <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
 
-Alias `--rd`
-
 ## --rps
 
 Specify RPS of processing. The default value is 50.
@@ -281,13 +277,11 @@ Specify RPS of processing. The default value is 50.
 
 Show the History of a <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> by specifying a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Alias: `--rid`
+Alias: `--r`
 
 ## --run-timeout
 
 Single Workflow Run timeout, in seconds.
-
-Alias: `--rt`
 
 ## --search-attribute
 
@@ -317,6 +311,8 @@ The default is `workflow`.
 ## --task-queue
 
 Specify a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a>.
+
+Alias: `--t`
 
 ## --task-timeout
 
@@ -351,4 +347,6 @@ Show the History of a <a class="tdlp" href="/workflows#workflow-execution">Workf
 ## --yes
 
 Use the --yes modifier to automatically confirm all prompts.
+
+Alias: `--y`
 

--- a/docs/tctl-next/namespace.md
+++ b/docs/tctl-next/namespace.md
@@ -38,8 +38,6 @@ The `tctl namespace describe` command describes a [Namespace](/namespaces).
 
 `tctl namespace describe`
 
-Alias: `d`
-
 The following modifiers are supported and control the behavior of the command.
 Always include required modifiers when executing this command.
 
@@ -73,8 +71,6 @@ Clusters: dc1, dc2
 ```
 
 ## list
-
-Alias: `l`
 
 The `tctl namespace list` command lists all <a class="tdlp" href="/namespaces#">Namespaces<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a>.
 

--- a/docs/tctl-next/task-queue.md
+++ b/docs/tctl-next/task-queue.md
@@ -20,8 +20,6 @@ Alias: `tq`
 
 ## describe
 
-Alias: `desc`
-
 The `tctl task-queue describe` command describes the poller information of a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a>.
 
 `tctl task-queue describe <modifiers>`

--- a/docs/tctl-next/workflow.md
+++ b/docs/tctl-next/workflow.md
@@ -13,8 +13,6 @@ import TabItem from '@theme/TabItem';
 
 The `tctl workflow` commands enable <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> operations.
 
-Alias: `w`
-
 - [tctl workflow cancel](/tctl-next/workflow#cancel)
 - [tctl workflow count](/tctl-next/workflow#count)
 - [tctl workflow describe](/tctl-next/workflow#describe)
@@ -87,8 +85,6 @@ The `tctl workflow describe` command shows information about a <a class="tdlp" h
 This information can be used to locate a failed Workflow Execution, for example.
 
 `tctl workflow describe <modifiers>`
-
-Alias: `d`
 
 The following modifiers control the behavior of the command.
 Always include required modifiers when executing this command.

--- a/docs/tctl-v1/activity.md
+++ b/docs/tctl-v1/activity.md
@@ -13,8 +13,6 @@ import TabItem from '@theme/TabItem';
 
 The `tctl activity` commands enable <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a> operations.
 
-Alias: `a`
-
 - <a class="tdlp" href="#complete">tctl activity complete<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl activity complete</p><p class="tdlppd">How to provide a result and complete an Activity Execution using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#complete">Learn more</a></p></div></a>
 - <a class="tdlp" href="#fail">tctl activity fail<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl activity fail</p><p class="tdlppd">How to fail an Activity Execution using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#fail">Learn more</a></p></div></a>
 
@@ -22,7 +20,7 @@ Alias: `a`
 
 The `tctl activity complete` command completes an <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a>.
 
-`tctl activity complete [<modifiers>]`
+`tctl activity complete <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -30,7 +28,7 @@ The following modifiers control the behavior of the command.
 
 Specify the <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a> of an <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a> to complete.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -42,7 +40,7 @@ tctl activity complete --workflow_id <id>
 
 Specify the <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a> of an <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a> to complete.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -53,8 +51,6 @@ tctl activity complete --run_id <id>
 ### --activity_id
 
 Specify the <a class="tdlp" href="/activities#activity-id">Activity Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Id?</p><p class="tdlppd">A unique identifier for an Activity Execution.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-id">Learn more</a></p></div></a> of an <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a> to complete.
-
-Alias: `--aid`
 
 **Example**
 
@@ -94,7 +90,7 @@ The following modifiers control the behavior of the command.
 
 Specify the <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a> of an <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a> to fail.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -106,7 +102,7 @@ tctl activity fail --workflow_id <id>
 
 Specify the <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a> of an <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a> to fail.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -117,8 +113,6 @@ tctl activity fail --run_id <id>
 ### --activity_id
 
 Specify the <a class="tdlp" href="/activities#activity-id">Activity Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Id?</p><p class="tdlppd">A unique identifier for an Activity Execution.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-id">Learn more</a></p></div></a> of an <a class="tdlp" href="/activities#activity-execution">Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Activity Execution?</p><p class="tdlppd">An Activity Execution is the full chain of Activity Task Executions.</p><p class="tdlplm"><a class="tdlplma" href="/activities#activity-execution">Learn more</a></p></div></a> to fail.
-
-Alias: `--aid`
 
 **Example**
 

--- a/docs/tctl-v1/admin.md
+++ b/docs/tctl-v1/admin.md
@@ -13,8 +13,6 @@ import TabItem from '@theme/TabItem';
 
 A `tctl admin` command allows the user to run admin operations.
 
-Alias : `adm`
-
 Modifiers:
 
 - Help: `tctl admin [--help | -h]`
@@ -22,8 +20,6 @@ Modifiers:
 ## cluster
 
 The `tctl admin cluster` command runs the administrator-level operations on a given Cluster.
-
-Alias: `cl`
 
 `tctl admin cluster command [command modifiers] [arguments...]`
 
@@ -36,8 +32,6 @@ Alias: `cl`
 - <a class="tdlp" href="#upsert_remote_cluster">`remove_remote_cluster`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl admin cluster upsert_remote_cluster</p><p class="tdlppd">How to run admin-level tctl commands.</p><p class="tdlplm"><a class="tdlplma" href="#upsert_remote_cluster">Learn more</a></p></div></a>
 
 ### add_search_attributes
-
-Alias: `asa`
 
 The `tctl admin cluster add-search-attributes` command allows Search Attributes to be added to a Cluster.
 Custom Search Attributes can be used to make a Cluster more identifiable.
@@ -66,15 +60,11 @@ This will only register in metadata.
 
 #### --name
 
-Alias: `-n value`
-
 The name of the Search Attribute to add. Names can have multiple values.
 
 Search Attribute names are case sensitive.
 
 #### --type
-
-Alias: `-t value`
 
 The type of Search Attribute to add.
 Multiple values can be added at once.
@@ -84,8 +74,6 @@ Values: Text, Keyword, Int, Double, Bool, Datetime
 ### describe
 
 The `tctl admin cluster describe` command provides information for the current Cluster.
-
-Alias: `d`
 
 The following modifier changes the behavior of the command:
 
@@ -99,21 +87,15 @@ This modifier is optional, and can default to the return of current Cluster info
 
 The `tctl admin cluster get_search_attributes` command retrieves existing Search Attributes for a given Cluster.
 
-Alias: `gsa`
-
 The following modifier will change the behavior of the command:
 
 #### --print_json
-
-Alias: `--pjson value`
 
 Prints the existing search attributes in JSON format.
 
 ### list
 
 The `tctl admin cluster list` command lists Cluster information on the given Cluster.
-
-Alias: `ls`
 
 Default: 100
 
@@ -126,8 +108,6 @@ The size of the page that the list is printed on.
 ### remove_remote_cluster
 
 The `tctl admin cluster remove_remote_cluster` command removes remote Cluster information on the given Cluster.
-
-Alias: `rrc`
 
 The modifier below changes the behavior of the operation:
 
@@ -165,17 +145,11 @@ Name of the Search Attribute to remove.
 
 The `tctl admin cluster upsert_remote_cluster` command adds or updates remote Cluster information in the current Cluster.
 
-Alias: `urc`
-
 #### --frontend_address
-
-Alias: `--fad value`
 
 The remote Cluster frontend address.
 
 #### --enable_connection
-
-Alias: `--ec`
 
 Enables remote Cluster connection.
 
@@ -415,12 +389,6 @@ The `tctl admin decode` command allows the user to decode payloads sent and rece
 - <a class="tdlp" href="#proto">`proto`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl admin decode proto</p><p class="tdlppd">Decoding proto payloads.</p><p class="tdlplm"><a class="tdlplma" href="#proto">Learn more</a></p></div></a>
 - <a class="tdlp" href="#base64">`base64`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl admin decode base64</p><p class="tdlppd">Decoding Payloads to Base64.</p><p class="tdlplm"><a class="tdlplma" href="#base64">Learn more</a></p></div></a>
 
-`--help`
-
-Alias: `-h`
-
-Shows helpful information for the given command.
-
 ### base64
 
 The `tctl admin decode base64` command decodes base64 Payloads.
@@ -463,23 +431,13 @@ The `tctl admin dlq` commands run admin operations on a given dead-letter queue 
 - <a class="tdlp" href="#purge">tctl admin dlq purge<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl admin dlq purge</p><p class="tdlppd">Deleting DLQ messages.</p><p class="tdlplm"><a class="tdlplma" href="#purge">Learn more</a></p></div></a>
 - <a class="tdlp" href="#merge">tctl admin dlq merge<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl admin dlq merge</p><p class="tdlppd">Merging DLQ messages.</p><p class="tdlplm"><a class="tdlplma" href="#merge">Learn more</a></p></div></a>
 
-`--help`
-
-Alias: `-h`
-
-Shows helpful information for the command.
-
 ### merge
 
 The `tctl admib dlq merge` command allows dead-letter queue (DLQ) messages to be merged.
 
 The messages must have TaskIds with an equal or lesser value than the given TaskId.
 
-Alias: `m`
-
 #### --dlq_type
-
-Alias: `--dt value`
 
 The type of DLQ to manage.
 
@@ -503,11 +461,7 @@ Default: 0
 
 The `tctl admin dlq purge` command deletes DLQ messages that have a Task Id equal to or less than the provided Task Id.
 
-Alias: `p`
-
 #### --dlq_type
-
-Alias: `--dt value`
 
 The type of DLQ to manage.
 
@@ -531,13 +485,9 @@ Default: 0
 
 The `tctl admin dlq read` command reads out messages from the dead-letter queue (DLQ).
 
-Alias: `r`
-
 ---
 
 #### --dlq_type
-
-Alias: `--dt value`
 
 The type of DLQ to manage.
 
@@ -573,8 +523,6 @@ Output is written to stdout on default.
 
 The `tctl admin history_host` command runs an admin-level operation on the history host.
 
-Alias: `hist`
-
 ## Usage
 
 `tctl admin history_host command [command options] [arguments...]`
@@ -588,39 +536,29 @@ Alias: `hist`
 
 The `tctl admin history_host describe` command describes the internal information of history host.
 
-Alias: `-desc`
-
 The following modifiers change the behavior of the command.
 
 #### --workflow_id
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The WorkflowId of the Workflow whose history host is to be described.
 
 #### --history_address
 
-Alias: `--had value`
-
 The history address of the history host.
 
 #### --shard_id
 
-Alias: `--sid value`
-
 The Id of the shard that belongs to the history host.
 
 #### --print_full
-
-Alias: `--pf`
 
 Print a full and detailed summary of the history host.
 
 ### get_shardid
 
 The `tctl admin history_host get_shardid` command gets the `shardId` for a given `namespaceId` and `workflowId`.
-
-Alias: `gsh`
 
 The following modifiers change the behavior of this command.
 
@@ -630,7 +568,7 @@ The `namespaceId` of the history host where we're getting the `shardId`.
 
 #### --workflow_id
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The WorkflowId of the history host where we're getting the shardId.
 
@@ -650,8 +588,8 @@ The `tctl admin membership` command allows admin operations to be run on members
 
 ### Commands
 
-- list_gossip
-- list_db
+- <a class="tdlp" href="#list_gossip">list_gossip<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl admin membership list_gossip</p><p class="tdlppd">How to describe ringpop membership items</p><p class="tdlplm"><a class="tdlplma" href="#list_gossip">Learn more</a></p></div></a>
+- <a class="tdlp" href="#list_db">list_db<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl admin membership list_db</p><p class="tdlppd">How to describe Cluster membership items</p><p class="tdlplm"><a class="tdlplma" href="#list_db">Learn more</a></p></div></a>
 
 ### list_db
 
@@ -678,7 +616,9 @@ The `tctl admin membership list_gossip` command lists the ringpop membership ite
 
 The following modifier changes the behavior of the command:
 
-`--role value` — filters the results by membership role
+#### `--role value`
+
+Filters the results by membership role
 
 Default: all
 Values: all, frontend, history, matching, worker
@@ -686,8 +626,6 @@ Values: all, frontend, history, matching, worker
 ## shard
 
 The `tctl admin shard` commands enable admin-level operations on a specified shard.
-
-Alias: `shar`
 
 #### tctl admin shard commands
 
@@ -701,13 +639,11 @@ Alias: `shar`
 
 The `tctl admin shard close_shard` command closes a shard with an Id that corresponds to the value given in the command.
 
-Alias: `clsh`
-
 `tctl admin shard close_shard [command options] [arguments...]`
 
 The modifier below will change the behavior and output of the command.
 
-`--share_id value`
+#### `--share_id value`
 
 ShareId managed by the Temporal Cluster.
 
@@ -715,11 +651,9 @@ ShareId managed by the Temporal Cluster.
 
 The `tctl admin shard describe_task` command describes a specified Task's Task Id, Task type, shard Id, and task visibility timestamp.
 
-Alias: `-dt`
-
 The modifiers below control the output and behavior of the command. Enter all modifiers after the command as such:
 
-`tctl admin shard describe_task [<modifiers>]`
+`tctl admin shard describe_task <modifiers>`
 
 #### --db_engine
 
@@ -815,11 +749,10 @@ Default: "active"
 
 The `tctl admin shard describe` command shows the Id for the specified shard.
 
-Alias: `d`
-
 The modifier below controls the behavior of the command.
 
-`--share_id value`
+#### `--share_id value`
+
 The Id of the shard to describe
 
 Default: 0
@@ -832,14 +765,10 @@ The modifiers below affect the output and behavior of the command.
 
 #### `--more`
 
-Alias: `-m`
-
 Lists more pages of list tasks.
 The default setting is to list one page of 10 list tasks.
 
 #### `--pagesize value`
-
-Alias: `--ps value`
 
 The size of the result page.
 Default: 10
@@ -900,8 +829,6 @@ The `tctl admin shard remove_task` command removes a Task from the shard.
 
 The Task removed must have values that matches what is given in the command line.
 
-Alias: `rmtk`
-
 The modifiers below change the behavior of the command.
 
 #### `--shard_id value`
@@ -932,8 +859,6 @@ Default: 0
 
 ## workflow
 
-Alias: `-wf`
-
 The `tctl admin workflow` commands enable administrator-level operations on Workflow Executions.
 
 `tctl admin workflow command [modifiers] [arguments...]`
@@ -951,8 +876,6 @@ The `tctl admin workflow` commands enable administrator-level operations on Work
   Show helpful information for `tctl admin workflow` commands.
 
 ### delete
-
-Alias: `del`
 
 The `tctl admin workflow delete` command deletes the current [Workflow Execution](/workflows/#workflow-execution) and the mutableState record.
 
@@ -1017,19 +940,17 @@ Elasticsearch index name.
 
 #### `--workflow_id value`
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The Id of the current Workflow.
 
 #### `--run_id value`
 
-Aliases: `--rid value`, `-r value`
+Alias: `-r`
 
 The Id of the current run.
 
 #### `--skip_errors`
-
-Alias: `--serr`
 
 Skip any errors that occur in the Workflow Execution.
 
@@ -1075,37 +996,33 @@ Note: tls must be enabled
 
 ## describe
 
-Alias: `desc`
-
 The `tctl admin workflow describe` command describes internal information of the current [Workflow Execution](/workflows/#workflow-execution).
 
 #### `--workflow_id value`
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The Id of the current Workflow.
 
 #### `--run_id value`
 
-Aliases: `--rid value`, `-r value`
+Alias: `-r`
 
 The Id of the current run.
 
 ## refresh_tasks
 
-Alias: `rt`
-
 The `tctl admin workflow refresh_tasks` command updates all [Tasks](/tasks) in a [Workflow](/workflows), provided that the command can fetch new information for Tasks.
 
 #### `--workflow_id value`
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The Id of the current Workflow.
 
 #### `--run_id value`
 
-Aliases: `--rid value`, `-r value`
+Alias: `-r`
 
 The Id of the current run.
 
@@ -1115,13 +1032,13 @@ The `tctl admin workflow show` command displays Workflow history from the databa
 
 #### `--workflow_id value`
 
-Aliases: `--wid value`, `-w value`
+Alias: `-w`
 
 The current Workflow.
 
 #### `--run_id value`
 
-Aliases: `--rid value`, `-r value`
+Alias: `-r`
 
 The current RunId.
 

--- a/docs/tctl-v1/batch.md
+++ b/docs/tctl-v1/batch.md
@@ -48,7 +48,7 @@ Terminating a batch job does not roll back the operations already performed by t
 
 The `tctl batch start` command starts a batch job.
 
-`tctl batch start --query <value> [<modifiers>]`
+`tctl batch start --query <value> <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -72,8 +72,6 @@ tctl batch start --query <value>
 
 Specify a reason for running this batch job.
 
-Alias: `--re`
-
 **Example**
 
 ```bash
@@ -84,8 +82,6 @@ tctl batch start --query <value> --reason <string>
 
 Specify the operation that this batch job performs. The supported operations are `signal`, `cancel`, and `terminate`.
 
-Alias: `--bt`
-
 **Example**
 
 ```bash
@@ -95,8 +91,6 @@ tctl batch start --query <value> --batch_type <operation>
 ### `--signal_name`
 
 Specify the name of a <a class="tdlp" href="/workflows#signal">Signal<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Signal?</p><p class="tdlppd">A Signal is an asynchronous request to a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#signal">Learn more</a></p></div></a>. This modifier is required when `--batch_type` is `signal`.
-
-Alias: `--sig`
 
 **Example**
 
@@ -130,6 +124,8 @@ tctl batch start --query <value> --rps <value>
 
 Disable the confirmation prompt.
 
+Alias: `y`
+
 **Example**
 
 ```bash
@@ -138,19 +134,15 @@ tctl batch start --query <value> --yes
 
 ## list
 
-Alias: `l`
-
 The `tctl batch list` command lists all batch jobs.
 
-`tctl batch list [<modifiers>]`
+`tctl batch list <modifiers>`
 
 The following modifier controls the behavior of the command.
 
 ### `--pagesize`
 
 Specify the maximum number of batch jobs to list on a page. The default value is 30.
-
-Alias: `--ps`
 
 **Example**
 
@@ -159,8 +151,6 @@ tctl batch list --pagesize <value>
 ```
 
 ## describe
-
-Alias: `desc`
 
 The `tctl batch describe` command describes the progress of a batch job.
 
@@ -174,8 +164,6 @@ _Required modifier_
 
 Specify the job ID of a batch job.
 
-Alias: `--jid`
-
 **Example**
 
 ```bash
@@ -186,7 +174,7 @@ tctl batch describe --job_id <id>
 
 The `tctl batch terminate` command terminates a batch job.
 
-`tctl batch terminate --job_id <id> [<modifiers>]`
+`tctl batch terminate --job_id <id> <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -195,8 +183,6 @@ The following modifiers control the behavior of the command.
 _Required modifier_
 
 Specify the job ID of a batch job.
-
-Alias: `--jid`
 
 **Example**
 
@@ -207,8 +193,6 @@ tctl batch terminate --job_id <id>
 ### `--reason`
 
 Specify a reason for terminating this batch job.
-
-Alias: `--re`
 
 **Example**
 

--- a/docs/tctl-v1/dataconverter.md
+++ b/docs/tctl-v1/dataconverter.md
@@ -13,8 +13,6 @@ import TabItem from '@theme/TabItem';
 
 The `tctl dataconverter` command enables custom <a class="tdlp" href="/security#data-converter">Data Converter<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Data Converter?</p><p class="tdlppd">A Data Converter is a Temporal SDK component that encodes and decodes data entering and exiting a Temporal Server.</p><p class="tdlplm"><a class="tdlplma" href="/security#data-converter">Learn more</a></p></div></a> operations.
 
-Alias: `dc`
-
 - <a class="tdlp" href="#web">tctl dataconverter web<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl dataconverter web</p><p class="tdlppd">How to specify the WebSocket URL of a custom Data Converter using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#web">Learn more</a></p></div></a>
 
 ## web

--- a/docs/tctl-v1/index.md
+++ b/docs/tctl-v1/index.md
@@ -75,8 +75,6 @@ You can supply the values for many of these modifiers by setting <a class="tdlp"
 Specify a host and port for the Frontend Service.
 The default is `127.0.0.1:7233`.
 
-Alias: `--ad`
-
 ### --auto_confirm
 
 Automatically confirm all prompts.
@@ -86,19 +84,13 @@ Automatically confirm all prompts.
 Specify a timeout for the context of an RPC call in seconds.
 The default value is 5.
 
-Alias: `--ct`
-
 ### --data_converter_plugin
 
 Specify the name of the executable for a headers provider plugin.
 
-Alias: `--dcp`
-
 ### --headers_provider_plugin
 
 Specify the name of the executable for a custom Data Converter plugin.
-
-Alias: `--hpp`
 
 ### --help
 
@@ -112,7 +104,7 @@ Specify a Namespace.
 By using this modifier, you don't need to specify a `--namespace` modifier for a sub-command.
 The default Namespace is `default`.
 
-Alias: `--ns`
+Alias: `--n`
 
 ### --tls_ca_path
 
@@ -141,8 +133,6 @@ Specifying this modifier also enables host verification.
 ### --version
 
 Display the version of tctl in the CLI.
-
-Alias: `-v`
 
 ### --codec_endpoint
 

--- a/docs/tctl-v1/namespace.md
+++ b/docs/tctl-v1/namespace.md
@@ -26,8 +26,6 @@ The `tctl namespace describe` command describes a [Namespace](/namespaces).
 
 `tctl namespace describe`
 
-Alias: `desc`
-
 The following modifier controls the behavior of the command.
 
 ### `--namespace_id`
@@ -59,8 +57,6 @@ Clusters: dc1, dc2
 
 ## list
 
-Alias: `l`
-
 The `tctl namespace list` command lists all <a class="tdlp" href="/namespaces#">Namespaces<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a>.
 
 `tctl namespace list`
@@ -68,8 +64,6 @@ The `tctl namespace list` command lists all <a class="tdlp" href="/namespaces#">
 The command has no modifiers.
 
 ## register
-
-Alias: `re`
 
 The `tctl namespace register` command registers a <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a>.
 
@@ -91,8 +85,6 @@ The following modifiers control the behavior of the command.
 Specify the name of the active [Temporal Cluster](/concepts/what-is-a-temporal-cluster/) when registering a <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a>.
 This value changes for Global Namespaces when a failover occurs.
 
-Alias: `--ac`
-
 **Example**
 
 ```bash
@@ -109,8 +101,6 @@ This is a read-only setting and cannot be changed.
 
 This modifier is valid only when the `--global_namespace` modifier is set to true.
 
-Alias `--cl`
-
 **Example**
 
 ```bash
@@ -120,8 +110,6 @@ tctl namespace register --clusters <names>
 ### `--description`
 
 Specify a description when registering a <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a>.
-
-Alias `--desc`
 
 **Example**
 
@@ -135,8 +123,6 @@ Specifies whether a <a class="tdlp" href="/namespaces#">Namespace<span class="td
 When enabled, it controls the creation of replication tasks on updates allowing the state to be replicated across Clusters.
 This is a read-only setting and cannot be changed.
 
-Alias `--gd`
-
 **Example**
 
 ```bash
@@ -147,8 +133,6 @@ tctl namespace register --global_namespace <boolean>
 
 Set the state of <a class="tdlp" href="/clusters#archival">Archival<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is Archival?</p><p class="tdlppd">Archival is a feature that automatically backs up Event Histories from Temporal Cluster persistence to a custom blob store after the Closed Workflow Execution retention period is reached.</p><p class="tdlplm"><a class="tdlplma" href="/clusters#archival">Learn more</a></p></div></a>.
 Valid values are `disabled` and `enabled`.
-
-Alias `--has`
 
 **Example**
 
@@ -161,8 +145,6 @@ tctl namespace register --history_archival_state <value>
 Specify the URI for <a class="tdlp" href="/clusters#archival">Archival<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is Archival?</p><p class="tdlppd">Archival is a feature that automatically backs up Event Histories from Temporal Cluster persistence to a custom blob store after the Closed Workflow Execution retention period is reached.</p><p class="tdlplm"><a class="tdlplma" href="/clusters#archival">Learn more</a></p></div></a>.
 The URI cannot be changed after Archival is first enabled.
 
-Alias `--huri`
-
 **Example**
 
 ```bash
@@ -173,8 +155,6 @@ tctl namespace register --history_uri <uri>
 
 Specify data for a <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a> in the form of key-value pairs (such as `k1:v1,k2:v2,k3:v3`).
 
-Alias `--dmd`
-
 **Example**
 
 ```bash
@@ -184,8 +164,6 @@ tctl namespace register --namespace_data <data>
 ### `--owner_email`
 
 Specify the email address of the <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a> owner.
-
-Alias `--oe`
 
 **Example**
 
@@ -199,8 +177,6 @@ Set the [Retention Period](/clusters#retention-period) for the <a class="tdlp" h
 
 The Retention Period applies to Closed <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
 
-Alias `--rd`
-
 **Example**
 
 ```bash
@@ -212,8 +188,6 @@ tctl namespace register --retention <value>
 Set the visibility state for <a class="tdlp" href="/clusters#archival">Archival<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is Archival?</p><p class="tdlppd">Archival is a feature that automatically backs up Event Histories from Temporal Cluster persistence to a custom blob store after the Closed Workflow Execution retention period is reached.</p><p class="tdlplm"><a class="tdlplma" href="/clusters#archival">Learn more</a></p></div></a>.
 Valid values are `disabled` and `enabled`.
 
-Alias `--vas`
-
 **Example**
 
 ```bash
@@ -224,8 +198,6 @@ tctl namespace register --visibility_archival_state <value>
 
 Specify the visibility URI for <a class="tdlp" href="/clusters#archival">Archival<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is Archival?</p><p class="tdlppd">Archival is a feature that automatically backs up Event Histories from Temporal Cluster persistence to a custom blob store after the Closed Workflow Execution retention period is reached.</p><p class="tdlplm"><a class="tdlplma" href="/clusters#archival">Learn more</a></p></div></a>.
 The URI cannot be changed after Archival is first enabled.
-
-Alias `--vuri`
 
 **Example**
 
@@ -244,8 +216,6 @@ The following modifiers control the behavior of the command.
 ### `--active_cluster`
 
 Specify the name of the active [Temporal Cluster](/concepts/what-is-a-temporal-cluster/) when updating a <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a>.
-
-Alias: `--ac`
 
 **Example**
 
@@ -274,8 +244,6 @@ The list contains the names of Clusters (separated by spaces) to which the Names
 
 This modifier is valid only when the `--global_namespace` modifier is set to true.
 
-Alias `--cl`
-
 **Example**
 
 ```bash
@@ -285,8 +253,6 @@ tctl namespace update --clusters <names>
 ### `--description`
 
 Specify a description when updating a <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a>.
-
-Alias `--desc`
 
 **Example**
 
@@ -299,8 +265,6 @@ tctl namespace update --description <value>
 Set the state of <a class="tdlp" href="/clusters#archival">Archival<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is Archival?</p><p class="tdlppd">Archival is a feature that automatically backs up Event Histories from Temporal Cluster persistence to a custom blob store after the Closed Workflow Execution retention period is reached.</p><p class="tdlplm"><a class="tdlplma" href="/clusters#archival">Learn more</a></p></div></a>.
 Valid values are `disabled` and `enabled`.
 
-Alias `--has`
-
 **Example**
 
 ```bash
@@ -312,8 +276,6 @@ tctl namespace update --history_archival_state <value>
 Specify the URI for URI for <a class="tdlp" href="/clusters#archival">Archival<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is Archival?</p><p class="tdlppd">Archival is a feature that automatically backs up Event Histories from Temporal Cluster persistence to a custom blob store after the Closed Workflow Execution retention period is reached.</p><p class="tdlplm"><a class="tdlplma" href="/clusters#archival">Learn more</a></p></div></a>.
 The URI cannot be changed after Archival is first enabled.
 
-Alias `--huri`
-
 **Example**
 
 ```bash
@@ -324,8 +286,6 @@ tctl namespace update --history_uri <uri>
 
 Specify data for a <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a> in the form of key-value pairs (such as `k1:v1,k2:v2,k3:v3`).
 
-Alias `--dmd`
-
 **Example**
 
 ```bash
@@ -335,8 +295,6 @@ tctl namespace update --namespace_data <data>
 ### `--owner_email`
 
 Specify the email address of the <a class="tdlp" href="/namespaces#">Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Namespace?</p><p class="tdlppd">A Namespace is a unit of isolation within the Temporal Platform</p><p class="tdlplm"><a class="tdlplma" href="/namespaces#">Learn more</a></p></div></a> owner.
-
-Alias `--oe`
 
 **Example**
 
@@ -370,8 +328,6 @@ tctl namespace update --remove_bad_binary <value>
 
 Specify the number of days to retain <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
 
-Alias `--rd`
-
 **Example**
 
 ```bash
@@ -383,8 +339,6 @@ tctl namespace update --retention <value>
 Set the visibility state for <a class="tdlp" href="/clusters#archival">Archival<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is Archival?</p><p class="tdlppd">Archival is a feature that automatically backs up Event Histories from Temporal Cluster persistence to a custom blob store after the Closed Workflow Execution retention period is reached.</p><p class="tdlplm"><a class="tdlplma" href="/clusters#archival">Learn more</a></p></div></a>.
 Valid values are `disabled` and `enabled`.
 
-Alias `--vas`
-
 **Example**
 
 ```bash
@@ -395,8 +349,6 @@ tctl namespace update --visibility_archival_state <value>
 
 Specify the visibility URI for <a class="tdlp" href="/clusters#archival">Archival<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is Archival?</p><p class="tdlppd">Archival is a feature that automatically backs up Event Histories from Temporal Cluster persistence to a custom blob store after the Closed Workflow Execution retention period is reached.</p><p class="tdlplm"><a class="tdlplma" href="/clusters#archival">Learn more</a></p></div></a>.
 The URI cannot be changed after Archival is first enabled.
-
-Alias `--vuri`
 
 **Example**
 

--- a/docs/tctl-v1/schedule.md
+++ b/docs/tctl-v1/schedule.md
@@ -11,9 +11,7 @@ toc_max_heading_level: 4
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-A <a class="tdlp" href="/workflows#schedule">Schedule<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Schedule</p><p class="tdlppd">A Schedule enables the scheduling of Workflow Executions.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#schedule">Learn more</a></p></div></a> is an experimental feature and the `schedule` command is available in versions 1.17.0-alpha.2 and later.
-Version 1.17.0-alpha.2 is currently available in version 1.16.2.
-Use `tctl config set version next` command while on version 1.16.2.
+A <a class="tdlp" href="/workflows#schedule">Schedule<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Schedule</p><p class="tdlppd">A Schedule enables the scheduling of Workflow Executions.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#schedule">Learn more</a></p></div></a> is an experimental feature available in `tctl 1.17` and `tctl next`.
 
 - <a class="tdlp" href="#backfill">Backfill a Schedule using tctl<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl schedule backfill</p><p class="tdlppd">How to backfill a Schedule using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#backfill">Learn more</a></p></div></a>
 - <a class="tdlp" href="#create">Create a Schedule using tctl<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl schedule create</p><p class="tdlppd">How to create a Schedule using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#create">Learn more</a></p></div></a>

--- a/docs/tctl-v1/taskqueue.md
+++ b/docs/tctl-v1/taskqueue.md
@@ -13,14 +13,12 @@ import TabItem from '@theme/TabItem';
 
 The `tctl taskqueue` command enables <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a> operations.
 
-Alias: `tq`
+Alias: `t`
 
 - <a class="tdlp" href="#describe">tctl taskqueue describe<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl taskqueue describe</p><p class="tdlppd">How to describe the poller information of a Task Queue using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#describe">Learn more</a></p></div></a>
 - <a class="tdlp" href="#list-partition">tctl taskqueue list-partition<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl taskqueue list-partition</p><p class="tdlppd">How to list Task Queue partitions and the hostname for partitions using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#list-partition">Learn more</a></p></div></a>
 
 ## describe
-
-Alias: `desc`
 
 The `tctl taskqueue describe` command describes the poller information of a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a>.
 
@@ -34,7 +32,7 @@ _Required modifier_
 
 Specify a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a>.
 
-Alias: `--tq`
+Alias: `--t`
 
 **Example**
 
@@ -47,8 +45,6 @@ tctl taskqueue describe --taskqueue <value>
 Specify the type of a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a>.
 The type can be `workflow` or `activity`.
 The default is `workflow`.
-
-Alias: `--tqt`
 
 **Example**
 
@@ -70,7 +66,7 @@ _Required modifier_
 
 Specify a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a> description.
 
-Alias: `--tq`
+Alias: `--t`
 
 **Example**
 

--- a/docs/tctl-v1/workflow.md
+++ b/docs/tctl-v1/workflow.md
@@ -13,8 +13,6 @@ import TabItem from '@theme/TabItem';
 
 The `tctl workflow` commands enable <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> operations.
 
-Alias: `w`
-
 - <a class="tdlp" href="#cancel">tctl workflow cancel<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow cancel</p><p class="tdlppd">How to cancel a Workflow Execution using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#cancel">Learn more</a></p></div></a>
 - <a class="tdlp" href="#count">tctl workflow count<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow count</p><p class="tdlppd">How to count Workflow Executions using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#count">Learn more</a></p></div></a>
 - <a class="tdlp" href="#describe">tctl workflow describe<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow describe</p><p class="tdlppd">How to show information about a Workflow Execution using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#describe">Learn more</a></p></div></a>
@@ -46,7 +44,7 @@ After cancellation, the Workflow Execution can perform cleanup work.
 
 See also <a class="tdlp" href="#terminate">`tctl workflow terminate`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow terminate</p><p class="tdlppd">How to terminate a Workflow Execution using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#terminate">Learn more</a></p></div></a>.
 
-`tctl workflow cancel [<modifiers>]`
+`tctl workflow cancel <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -54,7 +52,7 @@ The following modifiers control the behavior of the command.
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -66,7 +64,7 @@ tctl workflow cancel --workflow_id <id>
 
 Specify a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -79,7 +77,7 @@ tctl workflow cancel --run_id <id>
 The `tctl workflow count` command counts <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
 This command requires Elasticsearch to be enabled.
 
-`tctl workflow count [<modifiers>]`
+`tctl workflow count <modifiers>`
 
 The following modifier controls the behavior of the command.
 
@@ -108,8 +106,6 @@ To find a Workflow with a given Run Id, refer to <a class="tdlp" href="#describe
 
 `tctl workflow describe <modifiers>`
 
-Alias: `d`
-
 The following modifiers control the behavior of the command.
 Always include required modifiers when executing this command.
 
@@ -119,7 +115,7 @@ Always include required modifiers when executing this command.
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -132,7 +128,7 @@ tctl workflow describe --workflow_id <id>
 Specify a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 If a Run Id is not provided, the command will show the latest Workflow Execution of that Workflow Id.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -143,8 +139,6 @@ tctl workflow describe --run_id <id>
 ### `--print_raw`
 
 Print properties exactly as they are stored.
-
-Alias: `--praw`
 
 **Example**
 
@@ -176,8 +170,6 @@ The following modifiers control the behavior of the command.
 ### `--print_raw`
 
 Print properties exactly as they are stored.
-
-Alias: `--praw`
 
 **Example**
 
@@ -215,8 +207,6 @@ The following modifiers control the behavior of the command.
 
 Print the raw timestamp.
 
-Alias: `--prt`
-
 **Example**
 
 ```bash
@@ -226,8 +216,6 @@ tctl workflow list --print_raw_time
 ### `--print_datetime`
 
 Print the timestamp.
-
-Alias: `--pdt`
 
 **Example**
 
@@ -239,8 +227,6 @@ tctl workflow list --print_datetime
 
 Print a memo.
 
-Alias: `--pme`
-
 **Example**
 
 ```bash
@@ -250,8 +236,6 @@ tctl workflow list --print_memo
 ### `--print_search_attr`
 
 Print the <a class="tdlp" href="/visibility#search-attribute">Search Attributes<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Search Attribute?</p><p class="tdlppd">A Search Attribute is an indexed name used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.</p><p class="tdlplm"><a class="tdlplma" href="/visibility#search-attribute">Learn more</a></p></div></a>.
-
-Alias: `--psa`
 
 **Example**
 
@@ -263,8 +247,6 @@ tctl workflow list --print_search_attr
 
 Print the full message without table formatting.
 
-Alias: `--pf`
-
 **Example**
 
 ```bash
@@ -274,8 +256,6 @@ tctl workflow list --print_full
 ### `--print_json`
 
 Print the raw JSON objects.
-
-Alias: `--pjson`
 
 **Example**
 
@@ -287,8 +267,6 @@ tctl workflow list --print_json
 
 List open <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
 (By default, the `tctl workflow list` command lists closed Workflow Executions.)
-
-Alias: `--op`
 
 **Example**
 
@@ -311,8 +289,6 @@ Supported format are as follows:
   - `week` or `w`
   - `month` or `M`
   - `year` or `y`
-
-Alias: `--et`
 
 **Examples**
 
@@ -344,8 +320,6 @@ Supported formats are as follows:
   - `month` or `M`
   - `year` or `y`
 
-Alias: `--lt`
-
 **Examples**
 
 To specify 11:02:17 PM Pacific Daylight Time on April 13, 2022:
@@ -364,7 +338,7 @@ tctl workflow list --latest_time '10second'
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -375,8 +349,6 @@ tctl workflow list --workflow_id <id>
 ### `--workflow_type`
 
 Specify the name of a <a class="tdlp" href="/workflows#workflow-type">Workflow Type<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Type?</p><p class="tdlppd">A Workflow Type is a name that maps to a Workflow Definition.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-type">Learn more</a></p></div></a>.
-
-Alias: `--wt`
 
 **Example**
 
@@ -395,8 +367,6 @@ Supported values are as follows:
 - `terminated`
 - `continuedasnew`
 - `timedout`
-
-Alias: `-s`
 
 **Example**
 
@@ -454,8 +424,6 @@ tctl workflow list \
 List more than one page.
 (By default, the `tctl workflow list` command lists one page of results.)
 
-Alias: `-m`
-
 **Example**
 
 ```bash
@@ -466,8 +434,6 @@ tctl workflow list --more
 
 Specify the maximum number of <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> to list on a page.
 (By default, the `tctl workflow list` command lists 10 Workflow Executions per page.)
-
-Alias: `--ps`
 
 **Example**
 
@@ -484,15 +450,13 @@ To list open Workflow Executions, use the `--open` option.
 
 See also <a class="tdlp" href="#list">`tctl workflow list`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow list</p><p class="tdlppd">How to list open or closed Workflow Executions using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#list">Learn more</a></p></div></a>, <a class="tdlp" href="#listarchived">`tctl workflow listarchived`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow listarchived</p><p class="tdlppd">How to list archived Workflow Executions using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#listarchived">Learn more</a></p></div></a>, and <a class="tdlp" href="#scan">`tctl workflow scan`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow scan</p><p class="tdlppd">How to quickly list Workflow Executions without sorting using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#scan">Learn more</a></p></div></a>.
 
-`tctl workflow listall [<modifiers>]`
+`tctl workflow listall <modifiers>`
 
 The following modifiers control the behavior of the command.
 
 ### `--print_raw_time`
 
 Print the raw timestamp.
-
-Alias: `--prt`
 
 **Example**
 
@@ -504,8 +468,6 @@ tctl workflow listall --print_raw_time
 
 Print the timestamp.
 
-Alias: `--pdt`
-
 **Example**
 
 ```bash
@@ -515,8 +477,6 @@ tctl workflow listall --print_datetime
 ### `--print_memo`
 
 Print a memo.
-
-Alias: `--pme`
 
 **Example**
 
@@ -528,8 +488,6 @@ tctl workflow listall --print_memo
 
 Print the <a class="tdlp" href="/visibility#search-attribute">Search Attributes<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Search Attribute?</p><p class="tdlppd">A Search Attribute is an indexed name used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.</p><p class="tdlplm"><a class="tdlplma" href="/visibility#search-attribute">Learn more</a></p></div></a>.
 
-Alias: `--psa`
-
 **Example**
 
 ```bash
@@ -539,8 +497,6 @@ tctl workflow listall --print_search_attr
 ### `--print_full`
 
 Print the full message without table formatting.
-
-Alias: `--pf`
 
 **Example**
 
@@ -552,8 +508,6 @@ tctl workflow listall --print_full
 
 Print the raw JSON objects.
 
-Alias: `--pjson`
-
 **Example**
 
 ```bash
@@ -564,8 +518,6 @@ tctl workflow listall --print_json
 
 List open <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
 (By default, the `tctl workflow listall` command lists closed Workflow Executions.)
-
-Alias: `--op`
 
 **Example**
 
@@ -587,8 +539,6 @@ Specify the earliest start time to list. Supported format are as follows:
   - `week` or `w`
   - `month` or `M`
   - `year` or `y`
-
-Alias: `--et`
 
 **Examples**
 
@@ -639,7 +589,7 @@ tctl workflow listall --latest-time '10second'
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -650,8 +600,6 @@ tctl workflow listall --workflow_id <id>
 ### `--workflow_type`
 
 Specify the name of a <a class="tdlp" href="/workflows#workflow-type">Workflow Type<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Type?</p><p class="tdlppd">A Workflow Type is a name that maps to a Workflow Definition.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-type">Learn more</a></p></div></a>.
-
-Alias: `--wt`
 
 **Example**
 
@@ -670,8 +618,6 @@ Supported values are as follows:
 - `terminated`
 - `continuedasnew`
 - `timedout`
-
-Alias: `-s`
 
 **Example**
 
@@ -712,8 +658,6 @@ The following modifiers control the behavior of the command.
 
 Print the raw timestamp.
 
-Alias: `--prt`
-
 **Example**
 
 ```bash
@@ -723,8 +667,6 @@ tctl workflow listarchived --print_raw_time
 ### `--print_datetime`
 
 Print the timestamp.
-
-Alias: `--pdt`
 
 **Example**
 
@@ -736,8 +678,6 @@ tctl workflow listarchived --print_datetime
 
 Print a memo.
 
-Alias: `--pme`
-
 **Example**
 
 ```bash
@@ -747,8 +687,6 @@ tctl workflow listarchived --print_memo
 ### `--print_search_attr`
 
 Print the <a class="tdlp" href="/visibility#search-attribute">Search Attributes<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Search Attribute?</p><p class="tdlppd">A Search Attribute is an indexed name used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.</p><p class="tdlplm"><a class="tdlplma" href="/visibility#search-attribute">Learn more</a></p></div></a>.
-
-Alias: `--psa`
 
 **Example**
 
@@ -760,8 +698,6 @@ tctl workflow listarchived --print_search_attr
 
 Print the full message without table formatting.
 
-Alias: `--pf`
-
 **Example**
 
 ```bash
@@ -771,8 +707,6 @@ tctl workflow listarchived --print_full
 ### `--print_json`
 
 Print the raw JSON objects.
-
-Alias: `--pjson`
 
 **Example**
 
@@ -799,8 +733,6 @@ tctl workflow listarchived --query <value>
 Specify the maximum number of <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> to list on a page.
 (By default, the `tctl workflow listarchived` command lists 100 Workflow Executions per page.)
 
-Alias: `--ps`
-
 **Example**
 
 ```bash
@@ -810,8 +742,6 @@ tctl workflow listarchived --pagesize <value>
 ### `--all`
 
 List all pages.
-
-Alias: `-a`
 
 **Example**
 
@@ -825,9 +755,7 @@ The `tctl workflow observe` command shows the progress of the <a class="tdlp" hr
 
 See also <a class="tdlp" href="#observeid">`tctl workflow observeid`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow observeid</p><p class="tdlppd">How to show the progress of the Event History of a Workflow Execution for a specified Workflow Id and optional Run Id using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#observeid">Learn more</a></p></div></a>.
 
-`tctl workflow observe [<modifiers>]`
-
-Alias: `o`
+`tctl workflow observe <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -835,7 +763,7 @@ The following modifiers control the behavior of the command.
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -847,7 +775,7 @@ tctl workflow observe --workflow_id <id>
 
 Specify a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -858,8 +786,6 @@ tctl workflow observe --run_id <id>
 ### `--show_detail`
 
 Show event details.
-
-Alias: `--sd`
 
 **Example**
 
@@ -872,8 +798,6 @@ tctl workflow observe --show_detail
 Specify the maximum length for each attribute field.
 The default value is 0.
 
-Alias: `--maxl`
-
 **Example**
 
 ```bash
@@ -884,7 +808,7 @@ tctl workflow observe --max_field_length <length>
 
 The `tctl workflow observeid` command shows the progress of the <a class="tdlp" href="/workflows#event-history">Event History<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is an Event History?</p><p class="tdlppd">An append log of Events that represents the full state a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#event-history">Learn more</a></p></div></a> of a <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> for the specified <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a> and optional <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-`tctl workflow observeid <workflow_id> [<run_id>] [<modifiers>]`
+`tctl workflow observeid <workflow_id> [<run_id>] <modifiers>`
 
 This command is a shortcut for `tctl workflow observe --workflow_id <workflowid> [--run_id <runid>]`.
 
@@ -893,8 +817,6 @@ The following modifiers control the behavior of the command.
 ### `--show_detail`
 
 Show event details.
-
-Alias: `--sd`
 
 **Example**
 
@@ -907,8 +829,6 @@ tctl workflow observeid --show_detail
 Specify the maximum length for each attribute field.
 The default value is 0.
 
-Alias: `--maxl`
-
 **Example**
 
 ```bash
@@ -916,6 +836,8 @@ tctl workflow observeid --max_field_length <length>
 ```
 
 ## query
+
+Alias: `q`
 
 The `tctl workflow query` command sends a <a class="tdlp" href="/workflows#query">Query<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Query?</p><p class="tdlppd">A Query is a synchronous operation that is used to report the state of a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#query">Learn more</a></p></div></a> to a <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
 
@@ -949,7 +871,7 @@ Always include required modifiers when executing this command.
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>. **This modifier is required.**
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -961,7 +883,7 @@ tctl workflow query --workflow_id <id>
 
 Specify a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -972,8 +894,6 @@ tctl workflow query --run_id <id>
 ### `--query_type`
 
 Specify the type of Query to run.
-
-Alias: `--qt`
 
 **Example**
 
@@ -1001,8 +921,6 @@ Pass input for the Query from a JSON file.
 For multiple JSON objects, concatenate them and use spaces or newline characters as separators.
 Input from the command line overwrites input from the file.
 
-Alias: `--if`
-
 **Example**
 
 ```bash
@@ -1013,8 +931,6 @@ tctl workflow query --input_file <filename>
 
 Reject Queries based on Workflow state.
 Valid values are `not_open` and `not_completed_cleanly`.
-
-Alias: `--qrc`
 
 **Example**
 
@@ -1038,7 +954,7 @@ The following modifiers control the behavior of the command.
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -1050,7 +966,7 @@ tctl workflow reset --workflow_id <id>
 
 Specify a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -1072,8 +988,6 @@ tctl workflow reset --event_id <id>
 ### `--reason`
 
 Specify a reason for resetting the <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
-
-<!-- Alias: `--re` -->
 
 **Example**
 
@@ -1138,8 +1052,6 @@ Provide an input file that specifies <a class="tdlp" href="/workflows#workflow-e
 Each line contains one <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a> as the base Run and, optionally, a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 If a Run Id is not specified, the current Run Id is used.
 
-Alias: `--if`
-
 **Example**
 
 ```bash
@@ -1184,8 +1096,6 @@ tctl workflow reset-batch --input_separator <string>
 ### `--reason`
 
 Specify a reason for resetting the <a class="tdlp" href="/workflows#workflow-execution">Workflow Executions<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
-
-<!-- Alias: `--re` -->
 
 **Example**
 
@@ -1282,11 +1192,11 @@ The command is entered in the following format:
 
 To run a Workflow, the user must specify the following:
 
-- Task queue name (`--tq`)
-- Workflow Type (`--wt`)
+- Task queue name (`--taskqueue`)
+- Workflow Type (`--workflow_type`)
 
 ```bash
-tctl workflow run --tq your-task-queue-name --wt YourWorkflowDefinitionName
+tctl workflow run --taskqueue your-task-queue-name --workflow_type YourWorkflowDefinitionName
 ```
 
 Single quotes (`''`) are used to wrap input as JSON.
@@ -1298,7 +1208,7 @@ The following modifiers control the behavior of the command.
 
 Specify a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a>.
 
-Alias: `--tq`
+Alias: `--t`
 
 **Example**
 
@@ -1310,7 +1220,7 @@ tctl workflow run --taskqueue <name>
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -1321,8 +1231,6 @@ tctl workflow run --workflow_id <id>
 ### `--workflow_type`
 
 Specify the name of a <a class="tdlp" href="/workflows#workflow-type">Workflow Type<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Type?</p><p class="tdlppd">A Workflow Type is a name that maps to a Workflow Definition.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-type">Learn more</a></p></div></a>.
-
-Alias: `--wt`
 
 **Example**
 
@@ -1335,8 +1243,6 @@ tctl workflow run --workflow_type <name>
 Specify the <a class="tdlp" href="/activities#start-to-close-timeout">Start-To-Close Timeout<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Start-To-Close Timeout?</p><p class="tdlppd">A Start-To-Close Timeout is the maximum time allowed for a single Activity Task Execution.</p><p class="tdlplm"><a class="tdlplma" href="/activities#start-to-close-timeout">Learn more</a></p></div></a> of the <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> in seconds.
 The default value is 0.
 
-Alias: `--et`
-
 **Example**
 
 ```bash
@@ -1347,8 +1253,6 @@ tctl workflow run --execution_timeout <seconds>
 
 Specify the <a class="tdlp" href="/activities#start-to-close-timeout">Start-To-Close Timeout<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Start-To-Close Timeout?</p><p class="tdlppd">A Start-To-Close Timeout is the maximum time allowed for a single Activity Task Execution.</p><p class="tdlplm"><a class="tdlplma" href="/activities#start-to-close-timeout">Learn more</a></p></div></a> of the <a class="tdlp" href="/tasks#workflow-task">Workflow Task<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Task?</p><p class="tdlppd">A Workflow Task is a Task that contains the context needed to make progress with a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#workflow-task">Learn more</a></p></div></a> in seconds.
 The default value is 10.
-
-Alias: `--wtt`
 
 **Example**
 
@@ -1404,8 +1308,6 @@ tctl workflow run --input <json>
 Pass input for the Workflow from a JSON file.
 For multiple JSON objects, concatenate them and use spaces or newline characters as separators.
 Input from the command line overwrites input from the file.
-
-Alias: `--if`
 
 **Example**
 
@@ -1480,8 +1382,6 @@ tctl workflow run --search_attr_value <value>
 
 Get event details.
 
-Alias: `--sd`
-
 **Example**
 
 ```bash
@@ -1492,8 +1392,6 @@ tctl workflow run --show_detail
 
 Specify the maximum length for each attribute field.
 The default value is 0.
-
-Alias: `--maxl`
 
 **Example**
 
@@ -1511,15 +1409,13 @@ To set the size of a page, use the `--pagesize` option.
 
 See also <a class="tdlp" href="#list">`tctl workflow list`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow list</p><p class="tdlppd">How to list open or closed Workflow Executions using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#list">Learn more</a></p></div></a>, <a class="tdlp" href="#listall">`tctl workflow listall`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow listall</p><p class="tdlppd">How to list all open or closed Workflow Executions using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#listall">Learn more</a></p></div></a>, and <a class="tdlp" href="#listarchived">`tctl workflow listarchived`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow listarchived</p><p class="tdlppd">How to list archived Workflow Executions using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#listarchived">Learn more</a></p></div></a>.
 
-`tctl workflow scan [<modifiers>]`
+`tctl workflow scan <modifiers>`
 
 The following modifiers control the behavior of the command.
 
 ### `--print_raw_time`
 
 Print the raw timestamp.
-
-Alias: `--prt`
 
 **Example**
 
@@ -1531,8 +1427,6 @@ tctl workflow scan --print_raw_time
 
 Print the timestamp.
 
-Alias: `--pdt`
-
 **Example**
 
 ```bash
@@ -1542,8 +1436,6 @@ tctl workflow scan --print_datetime
 ### `--print_memo`
 
 Print a memo.
-
-Alias: `--pme`
 
 **Example**
 
@@ -1555,8 +1447,6 @@ tctl workflow scan --print_memo
 
 Print the <a class="tdlp" href="/visibility#search-attribute">Search Attributes<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Search Attribute?</p><p class="tdlppd">A Search Attribute is an indexed name used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.</p><p class="tdlplm"><a class="tdlplma" href="/visibility#search-attribute">Learn more</a></p></div></a>.
 
-Alias: `--psa`
-
 **Example**
 
 ```bash
@@ -1566,8 +1456,6 @@ tctl workflow scan --print_search_attr
 ### `--print_full`
 
 Print the full message without table formatting.
-
-Alias: `--pf`
 
 **Example**
 
@@ -1579,8 +1467,6 @@ tctl workflow scan --print_full
 
 Print the raw JSON objects.
 
-Alias: `--pjson`
-
 **Example**
 
 ```bash
@@ -1591,8 +1477,6 @@ tctl workflow scan --print_json
 
 Specify the maximum number of <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> to list on a page.
 (By default, the `tctl workflow scan` command lists 2000 Workflow Executions per page.)
-
-Alias: `--ps`
 
 **Example**
 
@@ -1626,7 +1510,7 @@ The following modifiers control the behavior of the command.
 
 Show the History of a <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> by specifying a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -1638,7 +1522,7 @@ tctl workflow show --workflow_id <id>
 
 Show the History of a <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> by specifying a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -1650,8 +1534,6 @@ tctl workflow show --run_id <id>
 
 Print the timestamp.
 
-Alias: `--pdt`
-
 **Example**
 
 ```bash
@@ -1661,8 +1543,6 @@ tctl workflow show --print_datetime
 ### `--print_raw_time`
 
 Print the raw timestamp.
-
-Alias: `--prt`
 
 **Example**
 
@@ -1674,8 +1554,6 @@ tctl workflow show --print_raw_time
 
 Serialize an event to a file.
 
-Alias: `--of`
-
 **Example**
 
 ```bash
@@ -1686,8 +1564,6 @@ tctl workflow show --output_filename <filename>
 
 Print full event details.
 
-Alias: `--pf`
-
 **Example**
 
 ```bash
@@ -1697,8 +1573,6 @@ tctl workflow show --print_full
 ### `--print_event_version`
 
 Print the event version.
-
-Alias: `--pev`
 
 **Example**
 
@@ -1711,8 +1585,6 @@ tctl workflow show --print_event_version
 Print the details of a specified event.
 The default value is 0.
 
-Alias: `--eid`
-
 **Example**
 
 ```bash
@@ -1723,8 +1595,6 @@ tctl workflow show --event_id <id>
 
 Specify the maximum length for each attribute field.
 The default value is 500.
-
-Alias: `--maxl`
 
 **Example**
 
@@ -1746,7 +1616,7 @@ tctl workflow show --reset_points_only
 
 The `tctl workflow showid` command shows the Workflow Execution Event History for the specified <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a> and optional <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-`tctl workflow showid <workflow_id> [<run_id>] [<modifiers>]`
+`tctl workflow showid <workflow_id> [<run_id>] <modifiers>`
 
 This command is a shortcut for `tctl workflow show --workflow_id <workflowid> [--run_id <runid>]`.
 
@@ -1787,8 +1657,6 @@ The following modifiers control the behavior of the command.
 
 Print the timestamp.
 
-Alias: `--pdt`
-
 **Example**
 
 ```bash
@@ -1798,8 +1666,6 @@ tctl workflow showid <workflow_id> --print_datetime
 ### `--print_raw_time`
 
 Print the raw timestamp.
-
-Alias: `--prt`
 
 **Example**
 
@@ -1811,8 +1677,6 @@ tctl workflow showid <workflow_id> --print_raw_time
 
 Serialize an event to a file.
 
-Alias: `--of`
-
 **Example**
 
 ```bash
@@ -1823,8 +1687,6 @@ tctl workflow showid <workflow_id> --output_filename <filename>
 
 Print full event details.
 
-Alias: `--pf`
-
 **Example**
 
 ```bash
@@ -1834,8 +1696,6 @@ tctl workflow showid <workflow_id> --print_full
 ### `--print_event_version`
 
 Print the event version.
-
-Alias: `--pev`
 
 **Example**
 
@@ -1848,8 +1708,6 @@ tctl workflow showid <workflow_id> --print_event_version
 Print the details of a specified event.
 The default value is 0.
 
-Alias: `--eid`
-
 **Example**
 
 ```bash
@@ -1860,8 +1718,6 @@ tctl workflow showid <workflow_id> --event_id <id>
 
 Specify the maximum length for each attribute field.
 The default value is 500.
-
-Alias: `--maxl`
 
 **Example**
 
@@ -1964,7 +1820,7 @@ Make sure to include required modifiers in all command executions.
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>. **This modifier is required.**
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -1976,7 +1832,7 @@ tctl workflow signal --workflow_id <id>
 
 Specify a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -1987,8 +1843,6 @@ tctl workflow signal --run_id <id>
 ### `--name`
 
 Specify the name of a <a class="tdlp" href="/workflows#signal">Signal<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Signal?</p><p class="tdlppd">A Signal is an asynchronous request to a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#signal">Learn more</a></p></div></a>.
-
-Alias: `-n`
 
 **Example**
 
@@ -2013,8 +1867,6 @@ tctl workflow signal --input <json>
 
 Pass input for the <a class="tdlp" href="/workflows#signal">Signal<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Signal?</p><p class="tdlppd">A Signal is an asynchronous request to a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#signal">Learn more</a></p></div></a> from a JSON file.
 
-Alias: `--if`
-
 **Example**
 
 ```bash
@@ -2037,7 +1889,7 @@ The following modifiers control the behavior of the command.
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -2049,7 +1901,7 @@ tctl workflow stack --workflow_id <id>
 
 Specify a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -2077,8 +1929,6 @@ Pass input for the query from a JSON file.
 For multiple JSON objects, concatenate them and use spaces or newline characters as separators.
 Input from the command line overwrites input from the file.
 
-Alias: `--if`
-
 **Example**
 
 ```bash
@@ -2089,8 +1939,6 @@ tctl workflow stack --input_file <filename>
 
 Reject queries based on Workflow state.
 Valid values are `not_open` and `not_completed_cleanly`.
-
-Alias: `--qrc`
 
 **Example**
 
@@ -2112,7 +1960,7 @@ Always include required modifiers when executing this command.
 
 Specify a <a class="tdlp" href="/tasks#task-queue">Task Queue<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Task Queue?</p><p class="tdlppd">A Task Queue is a first-in, first-out queue that a Worker Process polls for Tasks.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#task-queue">Learn more</a></p></div></a>.
 
-Alias: `--tq`
+Alias: `--t`
 
 **Example**
 
@@ -2126,7 +1974,7 @@ tctl workflow start --taskqueue <name>
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -2147,8 +1995,6 @@ tctl workflow start  --workflow_id "HelloTemporal1" --taskqueue HelloWorldTaskQu
 
 Specify the name of a <a class="tdlp" href="/workflows#workflow-type">Workflow Type<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Type?</p><p class="tdlppd">A Workflow Type is a name that maps to a Workflow Definition.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-type">Learn more</a></p></div></a>.
 
-Alias: `--wt`
-
 **Example**
 
 ```bash
@@ -2160,8 +2006,6 @@ tctl workflow start --workflow_type <name>
 Specify the <a class="tdlp" href="/activities#start-to-close-timeout">Start-To-Close Timeout<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Start-To-Close Timeout?</p><p class="tdlppd">A Start-To-Close Timeout is the maximum time allowed for a single Activity Task Execution.</p><p class="tdlplm"><a class="tdlplma" href="/activities#start-to-close-timeout">Learn more</a></p></div></a> of the <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a> in seconds.
 The default value is 0.
 
-Alias: `--et`
-
 **Example**
 
 ```bash
@@ -2172,8 +2016,6 @@ tctl workflow start --execution_timeout <seconds>
 
 Specify the <a class="tdlp" href="/activities#start-to-close-timeout">Start-To-Close Timeout<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Start-To-Close Timeout?</p><p class="tdlppd">A Start-To-Close Timeout is the maximum time allowed for a single Activity Task Execution.</p><p class="tdlplm"><a class="tdlplma" href="/activities#start-to-close-timeout">Learn more</a></p></div></a> of the <a class="tdlp" href="/tasks#workflow-task">Workflow Task<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Task?</p><p class="tdlppd">A Workflow Task is a Task that contains the context needed to make progress with a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/tasks#workflow-task">Learn more</a></p></div></a> in seconds.
 The default value is 10.
-
-Alias: `--wtt`
 
 **Example**
 
@@ -2236,8 +2078,6 @@ tctl workflow start --input <json>
 Pass input for the Workflow from a JSON file.
 For multiple JSON objects, concatenate them and use spaces or newline characters as separators.
 Input from the command line overwrites input from the file.
-
-Alias: `--if`
 
 **Example**
 
@@ -2326,7 +2166,7 @@ No more command tasks will be scheduled.
 
 See also <a class="tdlp" href="#cancel">`tctl workflow cancel`<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">tctl workflow cancel</p><p class="tdlppd">How to cancel a Workflow Execution using tctl.</p><p class="tdlplm"><a class="tdlplma" href="#cancel">Learn more</a></p></div></a>.
 
-`tctl workflow terminate [<modifiers>]`
+`tctl workflow terminate <modifiers>`
 
 The following modifiers control the behavior of the command.
 
@@ -2334,7 +2174,7 @@ The following modifiers control the behavior of the command.
 
 Specify a <a class="tdlp" href="/workflows#workflow-id">Workflow Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Id?</p><p class="tdlppd">A Workflow Id is a customizable, application-level identifier for a Workflow Execution that is unique to an Open Workflow Execution within a Namespace.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-id">Learn more</a></p></div></a>.
 
-Aliases: `--wid`, `-w`
+Alias: `-w`
 
 **Example**
 
@@ -2346,7 +2186,7 @@ tctl workflow terminate --workflow_id <id>
 
 Specify a <a class="tdlp" href="/workflows#run-id">Run Id<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Run Id?</p><p class="tdlppd">A Run Id is a globally unique, platform-level identifier for a Workflow Execution.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#run-id">Learn more</a></p></div></a>.
 
-Aliases: `--rid`, `-r`
+Alias: `-r`
 
 **Example**
 
@@ -2357,8 +2197,6 @@ tctl workflow terminate --run_id <id>
 ### `--reason`
 
 Specify a reason for terminating the <a class="tdlp" href="/workflows#workflow-execution">Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><div class="tdlpc"><p class="tdlppt">What is a Workflow Execution?</p><p class="tdlppd">A Temporal Workflow Execution is a durable, scalable, reliable, and reactive function execution. It is the main unit of execution of a Temporal Application.</p><p class="tdlplm"><a class="tdlplma" href="/workflows#workflow-execution">Learn more</a></p></div></a>.
-
-Alias: `--re`
 
 **Example**
 


### PR DESCRIPTION
Ruslan noted that most of the current aliases for tctl commands and modifiers have been removed. Docs need to be updated to reflect all the removed aliases, so that users don't try a shortcut and wonder why it doesn't work.
