### PR TITLE
Fix incorrect reference to kernel panic

### DIFF
--- a/docs-src/references/sdk-metrics.md
+++ b/docs-src/references/sdk-metrics.md
@@ -130,7 +130,7 @@ from the queue.
 
 ### activity_task_error
 
-An internal error or kernel panic occurred during Activity Task handling or execution.
+An internal error or panic occurred during Activity Task handling or execution.
 
 - Type: Counter
 - Available in: Go, PHP


### PR DESCRIPTION
## What does this PR do?
A kernel panic means the OS is going down hard. We can't possibly recover from such a situation, or write a metric about it.
## Notes to reviewers

<!-- delete if n/a -->
