### PR TITLE
rename Typescript to Go

### DIFF
--- a/docs/go/how-to-log-from-a-workflow-in-go.md
+++ b/docs/go/how-to-log-from-a-workflow-in-go.md
@@ -1,6 +1,6 @@
 ---
 id: how-to-log-from-a-workflow-in-go
-title: How to log from a Workflow in TypeScript
+title: How to log from a Workflow in Go
 sidebar_label: Log from a Workflow
 description: Log from a Workflow
 tags:


### PR DESCRIPTION
Wrongly title said Typescript where it should've been Go

That's it 😃 


