### PR TITLE
TS: Add hints about recurrent support questions

### DIFF
--- a/docs/typescript/production-deploy.md
+++ b/docs/typescript/production-deploy.md
@@ -92,7 +92,7 @@ We endeavor to give you good defaults, so you don't have to worry about them, bu
 
 Workers based on TypeScript SDK can be deployed and run as Docker containers.
 
-At this moment, we recommend usage of NodeJS 16 (note that there are known issues with NodeJS 18). Both `amd64` and `arm64` platforms are supported. A glibc-based image is required; musl-based images are _not_ supported (see below).
+At this moment, we recommend usage of NodeJS 16 for production scenarios (support for NodeJS 18 is currently being tested). Both `amd64` and `arm64` platforms are supported. A glibc-based image is required; musl-based images are _not_ supported (see below).
 
 The easiest way to deploy a TypeScript SDK Worker on Docker is to start with the `node:16-bullseye` image. For example:
 
@@ -107,6 +107,8 @@ RUN npm install --only=production \
 
 CMD ["build/worker.js"]
 ```
+
+Make sure to add `node_modules` to your `.dockerignore` file (ie. `echo node_modules >> .dockerignore`). Not doing so may results in an error message similar to: `Module build failed (from swc-loader). Error: Bindings not found` when starting your worker.
 
 For smaller images and/or more secure deployments, it is also possible to use `-slim` Docker image variants (like `node:16-bullseye-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs:16`) with the below caveats.
 

--- a/docs/typescript/testing.md
+++ b/docs/typescript/testing.md
@@ -31,7 +31,7 @@ import { MockActivityEnvironment } from '@temporalio/testing';
 const env = new MockActivityEnvironment({ attempt: 2 });
 const result = await env.run(
   async (x) => x + Context.current().info.attempt,
-  2,
+  2
 );
 assert.equal(result, 4);
 ```
@@ -65,7 +65,7 @@ await assert.rejects(
     }),
   (err) => {
     assert.ok(err instanceof CancelledFailure);
-  },
+  }
 );
 ```
 
@@ -125,7 +125,7 @@ test('httpWorkflow with mock activity', async () => {
     await client.workflow.execute(httpWorkflow, {
       workflowId: uuid4(),
       taskQueue: 'test',
-    }),
+    })
   );
   assert.strictEqual(result, 'The answer is 99');
 });
@@ -162,7 +162,7 @@ test('sleep completes almost immediately', async () => {
     testEnv.client.workflow.execute(sleeperWorkflow, {
       workflowId: uuid(),
       taskQueue: 'test',
-    }),
+    })
   );
 });
 ```
@@ -247,7 +247,7 @@ export async function processOrderWorkflow({
   const { processOrder } = proxyActivities<ReturnType<typeof createActivities>>(
     {
       startToCloseTimeout: orderProcessingMS,
-    },
+    }
   );
 
   const processOrderPromise = processOrder().then(() => {
@@ -302,7 +302,7 @@ test('countdownWorkflow sends reminder email if processing does not complete in 
           sendDelayedEmailTimeoutMS: ms('1 day'),
         },
       ],
-    }),
+    })
   );
   assert.strictEqual(emailSent, true);
 });
@@ -333,12 +333,12 @@ const worker = await Worker.create({
   ...someOtherOptions,
   connection: testEnv.nativeConnection,
   workflowsPath: require.resolve(
-    './workflows/file-with-workflow-function-to-test',
+    './workflows/file-with-workflow-function-to-test'
   ),
 });
 
 await worker.runUntil(
-  testEnv.client.workflow.execute(functionToTest, workflowOptions),
+  testEnv.client.workflow.execute(functionToTest, workflowOptions)
 );
 ```
 
@@ -376,12 +376,12 @@ const worker = await Worker.create({
     workflowModules: workflowInterceptorModules,
   },
   workflowsPath: require.resolve(
-    './workflows/file-with-workflow-function-to-test',
+    './workflows/file-with-workflow-function-to-test'
   ),
 });
 
 await worker.runUntil(
-  testEnv.client.workflow.execute(functionToTest, workflowOptions), // Throws WorkflowFailedError
+  testEnv.client.workflow.execute(functionToTest, workflowOptions) // Throws WorkflowFailedError
 );
 ```
 
@@ -391,3 +391,9 @@ There are a couple of caveats for testing with Jest:
 
 1. The Temporal TypeScript SDK only supports Jest `>= 27.0.0`.
 1. Make sure you run Jest with [`testEnvironment: 'node'`](https://jestjs.io/docs/configuration#testenvironment-string). `testEnvironment: 'jsdom'` is not supported.
+1. Debugger breakpoints set on workflow code may not be caught when running through Jest. The following tips might help:
+
+- Run Jest with the following options `--runInBand --collectCoverage false`;
+- Instead of using regular breakpoints, manually add `debugger` statements to your workflow code.
+- Breakpoints set very early inside a workflow function are likely to be missed. Consider adding a `sleep(0)` as the very first line of your workflow function.
+- If everything else fail, avoid importing your workflow code from test files. `import type` is correct. That probably means that in your test, you should use workflow/signal/query names rather than the corresponding functions. For example, instead of `client.workflow.execute(httpWorkflow, ...)`, you will have to do `client.workflow.execute('httpWorkflow', ...)`.

--- a/docs/typescript/testing.md
+++ b/docs/typescript/testing.md
@@ -31,7 +31,7 @@ import { MockActivityEnvironment } from '@temporalio/testing';
 const env = new MockActivityEnvironment({ attempt: 2 });
 const result = await env.run(
   async (x) => x + Context.current().info.attempt,
-  2
+  2,
 );
 assert.equal(result, 4);
 ```
@@ -65,7 +65,7 @@ await assert.rejects(
     }),
   (err) => {
     assert.ok(err instanceof CancelledFailure);
-  }
+  },
 );
 ```
 
@@ -125,7 +125,7 @@ test('httpWorkflow with mock activity', async () => {
     await client.workflow.execute(httpWorkflow, {
       workflowId: uuid4(),
       taskQueue: 'test',
-    })
+    }),
   );
   assert.strictEqual(result, 'The answer is 99');
 });
@@ -162,7 +162,7 @@ test('sleep completes almost immediately', async () => {
     testEnv.client.workflow.execute(sleeperWorkflow, {
       workflowId: uuid(),
       taskQueue: 'test',
-    })
+    }),
   );
 });
 ```
@@ -247,7 +247,7 @@ export async function processOrderWorkflow({
   const { processOrder } = proxyActivities<ReturnType<typeof createActivities>>(
     {
       startToCloseTimeout: orderProcessingMS,
-    }
+    },
   );
 
   const processOrderPromise = processOrder().then(() => {
@@ -302,7 +302,7 @@ test('countdownWorkflow sends reminder email if processing does not complete in 
           sendDelayedEmailTimeoutMS: ms('1 day'),
         },
       ],
-    })
+    }),
   );
   assert.strictEqual(emailSent, true);
 });
@@ -333,12 +333,12 @@ const worker = await Worker.create({
   ...someOtherOptions,
   connection: testEnv.nativeConnection,
   workflowsPath: require.resolve(
-    './workflows/file-with-workflow-function-to-test'
+    './workflows/file-with-workflow-function-to-test',
   ),
 });
 
 await worker.runUntil(
-  testEnv.client.workflow.execute(functionToTest, workflowOptions)
+  testEnv.client.workflow.execute(functionToTest, workflowOptions),
 );
 ```
 
@@ -376,12 +376,12 @@ const worker = await Worker.create({
     workflowModules: workflowInterceptorModules,
   },
   workflowsPath: require.resolve(
-    './workflows/file-with-workflow-function-to-test'
+    './workflows/file-with-workflow-function-to-test',
   ),
 });
 
 await worker.runUntil(
-  testEnv.client.workflow.execute(functionToTest, workflowOptions) // Throws WorkflowFailedError
+  testEnv.client.workflow.execute(functionToTest, workflowOptions), // Throws WorkflowFailedError
 );
 ```
 


### PR DESCRIPTION
## What changed

- We still recommend Node 16 for production deployments, but there are no longer any outstanding issues with Node 18 (we're adding to test matrix at this moment)
- When bundling TS SDK workers with docker, add `node_modules` to `.gitignore`
- Debugger breakpoints in workflow code doesn't work correctly when running in Jest.
- How to add support for "TS paths aliases" in workflow bundler