### PR TITLE
TW 246: update limit sheet

### DIFF
--- a/kb/temporal-platform-limits-sheet.md
+++ b/kb/temporal-platform-limits-sheet.md
@@ -36,9 +36,9 @@ Unless otherwise stated, Event limits apply to all Events running in parallel on
   - This is configurable with [`HistoryCountLimitError` and `HistoryCountLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L382-L383), if you know what you are doing.
 
   - We fail the following Commands at 50,000 Events for OSS and 2,000 Events for Cloud:
-  - `ScheduleActivityTask`
-  - `SignalExternalWorkflowExecution`
-  - `RequestCancelExternalWorkflowExecution`
-  - `StartChildWorkflowExecution`
+    - `ScheduleActivityTask`
+    - `SignalExternalWorkflowExecution`
+    - `RequestCancelExternalWorkflowExecution`
+    - `StartChildWorkflowExecution`
 
 - [Search Attributes maximums](/visibility/#search-attributes-maximums)

--- a/kb/temporal-platform-limits-sheet.md
+++ b/kb/temporal-platform-limits-sheet.md
@@ -29,16 +29,12 @@ Unless otherwise stated, Event limits apply to all Events occurring simultaneous
   - We error at 50 MB: [`history size exceeds error limit.`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/workflowExecutionContext.go#L1204)
   - This is configurable with [`HistorySizeLimitError` and `HistorySizeLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L380-L381), if you know what you are doing.
 - **History total count limit** (leading to a terminated Workflow Execution):
-
   - We warn at 10,000 Events: `history size exceeds warn limit.`
   - We error at 50,000 Events: [`history size exceeds error limit.`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/workflowExecutionContext.go#L1204)
-
   - This is configurable with [`HistoryCountLimitError` and `HistoryCountLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L382-L383), if you know what you are doing.
-
   - We fail the following Commands at 50,000 Events for OSS and 2,000 Events for Cloud:
-  - `ScheduleActivityTask`
-  - `SignalExternalWorkflowExecution`
-  - `RequestCancelExternalWorkflowExecution`
-  - `StartChildWorkflowExecution`
-
+    - `ScheduleActivityTask`
+    - `SignalExternalWorkflowExecution`
+    - `RequestCancelExternalWorkflowExecution`
+    - `StartChildWorkflowExecution`
 - [Search Attributes maximums](/visibility/#search-attributes-maximums)

--- a/kb/temporal-platform-limits-sheet.md
+++ b/kb/temporal-platform-limits-sheet.md
@@ -12,7 +12,7 @@ Running into limits can cause unexpected failures, so be mindful when you design
 
 Here is a list of many hard (error) or soft (warn) limits that you could encounter while using the Temporal Platform.
 
-Unless otherwise stated, Event limits apply to all Events running in parallel on a system.
+Unless otherwise stated, Event limits apply to all Events occurring simultaneously on a system.
 
 <!-- truncate -->
 
@@ -20,7 +20,7 @@ Unless otherwise stated, Event limits apply to all Events running in parallel on
 - **Event batch size**: The `DefaultTransactionSizeLimit` limit is [4 MB](https://github.com/temporalio/temporal/pull/1363).
   This is the largest transaction size we allow for Event Histories to be persisted.
   - This is configurable with `TransactionSizeLimit`, if you know what you are doing.
-- **Blob size limit** for incoming payloads (including Workflow context; _[source](https://github.com/temporalio/temporal/blob/v1.7.0/service/frontend/service.go#L133-L134)_):
+- **Blob size limit** for incoming payloads and results (including Workflow context; _[source](https://github.com/temporalio/temporal/blob/v1.7.0/service/frontend/service.go#L133-L134)_):
   - We warn at 512 KB: [`Blob size exceeds limit.`](https://github.com/temporalio/temporal/blob/fee1c43823699e90b330680a8efeb9d8dbee8cf3/common/util.go#L568)
   - We error at 2 MB: `ErrBlobSizeExceedsLimit: Blob data size exceeds limit.`
   - This is configurable with [`BlobSizeLimitError` and `BlobSizeLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L378-L379), if you know what you are doing.
@@ -36,9 +36,9 @@ Unless otherwise stated, Event limits apply to all Events running in parallel on
   - This is configurable with [`HistoryCountLimitError` and `HistoryCountLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L382-L383), if you know what you are doing.
 
   - We fail the following Commands at 50,000 Events for OSS and 2,000 Events for Cloud:
-    - `ScheduleActivityTask`
-    - `SignalExternalWorkflowExecution`
-    - `RequestCancelExternalWorkflowExecution`
-    - `StartChildWorkflowExecution`
+  - `ScheduleActivityTask`
+  - `SignalExternalWorkflowExecution`
+  - `RequestCancelExternalWorkflowExecution`
+  - `StartChildWorkflowExecution`
 
 - [Search Attributes maximums](/visibility/#search-attributes-maximums)

--- a/kb/temporal-platform-limits-sheet.md
+++ b/kb/temporal-platform-limits-sheet.md
@@ -9,6 +9,7 @@ date: 2022-06-07T00:00:00Z
 ---
 
 Running into limits can cause unexpected failures, so be mindful when you design your systems.
+
 Here is a list of many hard (error) or soft (warn) limits that you could encounter while using the Temporal Platform.
 
 <!-- truncate -->
@@ -32,7 +33,7 @@ Here is a list of many hard (error) or soft (warn) limits that you could encount
 
   - This is configurable with [`HistoryCountLimitError` and `HistoryCountLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L382-L383), if you know what you are doing.
 
-  - We fail the following Commands at 50,000 Events for OSS and 2,000 Events for Cloud:
+  - We fail the following Commands at 50,000 Events for OSS and 2,000 parallel Events for Cloud:
     - `ScheduleActivityTask`
     - `SignalExternalWorkflowExecution`
     - `RequestCancelExternalWorkflowExecution`

--- a/kb/temporal-platform-limits-sheet.md
+++ b/kb/temporal-platform-limits-sheet.md
@@ -12,6 +12,8 @@ Running into limits can cause unexpected failures, so be mindful when you design
 
 Here is a list of many hard (error) or soft (warn) limits that you could encounter while using the Temporal Platform.
 
+Unless otherwise stated, Event limits apply to all Events running in parallel on a system.
+
 <!-- truncate -->
 
 - **gRPC**: gRPC has a limit of 4 MB for [each message received](https://github.com/grpc/grpc/blob/v1.36.2/include/grpc/impl/codegen/grpc_types.h#L466).
@@ -33,7 +35,7 @@ Here is a list of many hard (error) or soft (warn) limits that you could encount
 
   - This is configurable with [`HistoryCountLimitError` and `HistoryCountLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L382-L383), if you know what you are doing.
 
-  - We fail the following Commands at 50,000 Events for OSS and 2,000 parallel Events for Cloud:
+  -  We fail the following Commands at 50,000 Events for OSS and 2,000 Events for Cloud:
     - `ScheduleActivityTask`
     - `SignalExternalWorkflowExecution`
     - `RequestCancelExternalWorkflowExecution`

--- a/kb/temporal-platform-limits-sheet.md
+++ b/kb/temporal-platform-limits-sheet.md
@@ -35,10 +35,10 @@ Unless otherwise stated, Event limits apply to all Events running in parallel on
 
   - This is configurable with [`HistoryCountLimitError` and `HistoryCountLimitWarn`](https://github.com/temporalio/temporal/blob/v1.7.0/service/history/configs/config.go#L382-L383), if you know what you are doing.
 
-  -  We fail the following Commands at 50,000 Events for OSS and 2,000 Events for Cloud:
-    - `ScheduleActivityTask`
-    - `SignalExternalWorkflowExecution`
-    - `RequestCancelExternalWorkflowExecution`
-    - `StartChildWorkflowExecution`
+  - We fail the following Commands at 50,000 Events for OSS and 2,000 Events for Cloud:
+  - `ScheduleActivityTask`
+  - `SignalExternalWorkflowExecution`
+  - `RequestCancelExternalWorkflowExecution`
+  - `StartChildWorkflowExecution`
 
 - [Search Attributes maximums](/visibility/#search-attributes-maximums)


### PR DESCRIPTION
This PR addresses a recent Slack thread that made a note of limits applying to parallel Events across Cloud, rather than per Workflow. I added a sentence at the start that should make it clear that all Event limits on this page apply to Events running in parallel. Could use feedback, so please let me know what else should change.