### PR TITLE
Add shared logger interface example to TypeScript logging section

### DIFF
--- a/docs-src/typescript/how-to-log-from-a-workflow-in-typescript.md
+++ b/docs-src/typescript/how-to-log-from-a-workflow-in-typescript.md
@@ -137,12 +137,12 @@ Instead of explicitly calling `proxySinks()` to create a logger sink in your Wor
 [logger-shared/src/sharedLogger.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/sharedLogger.ts)
 
 ```ts
-import { proxySinks, inWorkflowContext } from '@temporalio/workflow';
+import { inWorkflowContext, proxySinks } from '@temporalio/workflow';
 import logger from './logger';
 
-const sharedLogger = inWorkflowContext() ?
-  proxySinks().defaultWorkerLogger :
-  logger;
+const sharedLogger = inWorkflowContext()
+  ? proxySinks().defaultWorkerLogger
+  : logger;
 export default sharedLogger;
 ```
 
@@ -171,8 +171,8 @@ export async function greet(name: string): Promise<string> {
 
 ```ts
 import { proxyActivities } from '@temporalio/workflow';
-import logger from '../sharedLogger';
 import type * as activities from '../activities';
+import logger from '../sharedLogger';
 
 const { greet } = proxyActivities<typeof activities>({
   startToCloseTimeout: '5 minutes',

--- a/docs-src/typescript/logging.md
+++ b/docs-src/typescript/logging.md
@@ -229,6 +229,65 @@ Some important features of the [InjectedSinkFunction](https://typescript.tempora
 - **Limited arguments types**: The remaining Sink function arguments are copied between the sandbox and the Node.js environment using the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 - **No return value**: To prevent breaking determinism, Sink functions cannot return values to the Workflow.
 
+#### Shared logger interface
+
+Instead of explicitly calling `proxySinks()` to create a logger sink in your Workflow, you can also create a `sharedLogger.ts` file that handles calling `proxySinks()` for you.
+
+<!--SNIPSTART typescript-shared-logger-->
+
+[logger-shared/src/sharedLogger.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/sharedLogger.ts)
+
+```ts
+import { proxySinks, inWorkflowContext } from '@temporalio/workflow';
+import logger from './logger';
+
+const sharedLogger = inWorkflowContext() ?
+  proxySinks().defaultWorkerLogger :
+  logger;
+export default sharedLogger;
+```
+
+<!--SNIPEND-->
+
+You can then import `sharedLogger.ts` from Activities and Workflows.
+
+<!--SNIPSTART typescript-shared-logger-activity-->
+
+[logger-shared/src/activities/index.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/activities/index.ts)
+
+```ts
+import logger from '../sharedLogger';
+
+export async function greet(name: string): Promise<string> {
+  logger.info('Log from Activity', { name });
+  return `Hello, ${name}!`;
+}
+```
+
+<!--SNIPEND-->
+
+<!--SNIPSTART typescript-shared-logger-workflow-->
+
+[logger-shared/src/workflows/index.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/workflows/index.ts)
+
+```ts
+import { proxyActivities } from '@temporalio/workflow';
+import logger from '../sharedLogger';
+import type * as activities from '../activities';
+
+const { greet } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '5 minutes',
+});
+
+export async function logSampleWorkflow(): Promise<void> {
+  const greeting = await greet('Temporal');
+  logger.info('Log from Workflow', { greeting });
+}
+```
+
+<!--SNIPEND-->
+
+
 #### Advanced: Performance considerations and non-blocking Sinks
 
 The injected sink function contributes to the overall Workflow Task processing duration.

--- a/docs-src/typescript/logging.md
+++ b/docs-src/typescript/logging.md
@@ -238,12 +238,12 @@ Instead of explicitly calling `proxySinks()` to create a logger sink in your Wor
 [logger-shared/src/sharedLogger.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/sharedLogger.ts)
 
 ```ts
-import { proxySinks, inWorkflowContext } from '@temporalio/workflow';
+import { inWorkflowContext, proxySinks } from '@temporalio/workflow';
 import logger from './logger';
 
-const sharedLogger = inWorkflowContext() ?
-  proxySinks().defaultWorkerLogger :
-  logger;
+const sharedLogger = inWorkflowContext()
+  ? proxySinks().defaultWorkerLogger
+  : logger;
 export default sharedLogger;
 ```
 
@@ -272,8 +272,8 @@ export async function greet(name: string): Promise<string> {
 
 ```ts
 import { proxyActivities } from '@temporalio/workflow';
-import logger from '../sharedLogger';
 import type * as activities from '../activities';
+import logger from '../sharedLogger';
 
 const { greet } = proxyActivities<typeof activities>({
   startToCloseTimeout: '5 minutes',
@@ -286,7 +286,6 @@ export async function logSampleWorkflow(): Promise<void> {
 ```
 
 <!--SNIPEND-->
-
 
 #### Advanced: Performance considerations and non-blocking Sinks
 

--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -504,7 +504,7 @@ Some important features of the [InjectedSinkFunction](https://typescript.tempora
 
 **Shared logger interface**
 
-Instead of explicitly calling `proxySinks()` to create a logger sink in your Workflow, you can also create a `sharedLogger.ts` file that handles calling `proxySinks()` for you.
+If you want to call the same logger in your Workflow and Activity code, then you can only use `proxySinks()` if the code is running in Workflow context:
 
 <!--SNIPSTART typescript-shared-logger-->
 

--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -502,6 +502,64 @@ Some important features of the [InjectedSinkFunction](https://typescript.tempora
 - **Limited arguments types**: The remaining Sink function arguments are copied between the sandbox and the Node.js environment using the [structured clone algorithm](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm).
 - **No return value**: To prevent breaking determinism, Sink functions cannot return values to the Workflow.
 
+**Shared logger interface**
+
+Instead of explicitly calling `proxySinks()` to create a logger sink in your Workflow, you can also create a `sharedLogger.ts` file that handles calling `proxySinks()` for you.
+
+<!--SNIPSTART typescript-shared-logger-->
+
+[logger-shared/src/sharedLogger.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/sharedLogger.ts)
+
+```ts
+import { proxySinks, inWorkflowContext } from '@temporalio/workflow';
+import logger from './logger';
+
+const sharedLogger = inWorkflowContext() ?
+  proxySinks().defaultWorkerLogger :
+  logger;
+export default sharedLogger;
+```
+
+<!--SNIPEND-->
+
+You can then import `sharedLogger.ts` from Activities and Workflows.
+
+<!--SNIPSTART typescript-shared-logger-activity-->
+
+[logger-shared/src/activities/index.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/activities/index.ts)
+
+```ts
+import logger from '../sharedLogger';
+
+export async function greet(name: string): Promise<string> {
+  logger.info('Log from Activity', { name });
+  return `Hello, ${name}!`;
+}
+```
+
+<!--SNIPEND-->
+
+<!--SNIPSTART typescript-shared-logger-workflow-->
+
+[logger-shared/src/workflows/index.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/workflows/index.ts)
+
+```ts
+import { proxyActivities } from '@temporalio/workflow';
+import logger from '../sharedLogger';
+import type * as activities from '../activities';
+
+const { greet } = proxyActivities<typeof activities>({
+  startToCloseTimeout: '5 minutes',
+});
+
+export async function logSampleWorkflow(): Promise<void> {
+  const greeting = await greet('Temporal');
+  logger.info('Log from Workflow', { greeting });
+}
+```
+
+<!--SNIPEND-->
+
 **Advanced: Performance considerations and non-blocking Sinks**
 
 The injected sink function contributes to the overall Workflow Task processing duration.
@@ -1010,3 +1068,4 @@ async function yourWorkflow() {
 
 </TabItem>
 </Tabs>
+

--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -511,12 +511,12 @@ Instead of explicitly calling `proxySinks()` to create a logger sink in your Wor
 [logger-shared/src/sharedLogger.ts](https://github.com/temporalio/samples-typescript/blob/master/logger-shared/src/sharedLogger.ts)
 
 ```ts
-import { proxySinks, inWorkflowContext } from '@temporalio/workflow';
+import { inWorkflowContext, proxySinks } from '@temporalio/workflow';
 import logger from './logger';
 
-const sharedLogger = inWorkflowContext() ?
-  proxySinks().defaultWorkerLogger :
-  logger;
+const sharedLogger = inWorkflowContext()
+  ? proxySinks().defaultWorkerLogger
+  : logger;
 export default sharedLogger;
 ```
 
@@ -545,8 +545,8 @@ export async function greet(name: string): Promise<string> {
 
 ```ts
 import { proxyActivities } from '@temporalio/workflow';
-import logger from '../sharedLogger';
 import type * as activities from '../activities';
+import logger from '../sharedLogger';
 
 const { greet } = proxyActivities<typeof activities>({
   startToCloseTimeout: '5 minutes',
@@ -1068,4 +1068,3 @@ async function yourWorkflow() {
 
 </TabItem>
 </Tabs>
-


### PR DESCRIPTION
## What does this PR do?

Pulls in example from https://github.com/temporalio/samples-typescript/pull/228 to demonstrate how to use a shared logger interface, so you can import the same logger file from both Workflows and Activities.

**PREVIEW:** https://temporal-documentation-c487w9adt.preview.thundergun.io/application-development/observability?lang=ts#logging
