### PR TITLE
Added links to Go installation prerequisite

### DIFF
--- a/docs-src/clusters/quick-install.md
+++ b/docs-src/clusters/quick-install.md
@@ -22,7 +22,7 @@ It supports persistence to disk and in-memory mode through SQLite.
 
 **Prerequisites**
 
-Temporalite requires Go 1.18 or later.
+Temporalite requires [Go 1.18](https://go.dev/dl/) or later.
 
 **Build and start Temporalite**
 

--- a/docs-src/clusters/quick-install.md
+++ b/docs-src/clusters/quick-install.md
@@ -22,7 +22,7 @@ It supports persistence to disk and in-memory mode through SQLite.
 
 **Prerequisites**
 
-Temporalite requires [Go 1.18](https://go.dev/dl/) or later.
+Temporalite requires [Go 1.18 or later](https://go.dev/dl/).
 
 **Build and start Temporalite**
 

--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -53,7 +53,7 @@ It supports persistence to disk and in-memory mode through SQLite.
 
 **Prerequisites**
 
-Temporalite requires [Go 1.18](https://go.dev/dl/) or later.
+Temporalite requires [Go 1.18 or later](https://go.dev/dl/).
 
 **Build and start Temporalite**
 

--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -53,7 +53,7 @@ It supports persistence to disk and in-memory mode through SQLite.
 
 **Prerequisites**
 
-Temporalite requires Go 1.18 or later.
+Temporalite requires [Go 1.18](https://go.dev/dl/) or later.
 
 **Build and start Temporalite**
 


### PR DESCRIPTION
## What does this PR do?
Makes the mention of Go version required to be a link so that the user can click on it and download Go.

## Notes to reviewers