### PR TITLE
Update TS SDK telemetry options examples

### DIFF
--- a/docs-src/typescript/how-to-emit-metrics-typescript.md
+++ b/docs-src/typescript/how-to-emit-metrics-typescript.md
@@ -21,6 +21,9 @@ telemetryOptions: {
     metrics: {
       prometheus: { bindAddress: '0.0.0.0:9464' },
     },
-    logging: { forward: { level: 'DEBUG' } },
+    logging: {
+      forward: {},
+      filter: makeTelemetryFilterString({ core: 'INFO', other: 'WARN' })
+     },
   },
 ```

--- a/docs-src/typescript/how-to-emit-metrics-typescript.md
+++ b/docs-src/typescript/how-to-emit-metrics-typescript.md
@@ -17,13 +17,9 @@ Workers can emit metrics and traces. There are a few [telemetry options](https:/
 To set up tracing of Workflows and Activities, use our [opentelemetry-interceptors](https://legacy-documentation-sdks.temporal.io/typescript/logging#opentelemetry-tracing) package.
 
 ```typescript
-telemetryOptions: {
+  telemetryOptions: {
     metrics: {
       prometheus: { bindAddress: '0.0.0.0:9464' },
     },
-    logging: {
-      forward: {},
-      filter: makeTelemetryFilterString({ core: 'INFO', other: 'WARN' })
-     },
   },
 ```

--- a/docs-src/typescript/how-to-set-the-default-logger-in-typescript.md
+++ b/docs-src/typescript/how-to-set-the-default-logger-in-typescript.md
@@ -19,7 +19,7 @@ Runtime.install({
   telemetryOptions: {
     logging: {
       forward: {},
-      filter: makeTelemetryFilterString({ core: 'DEBUG', other: 'DEBUG' }),
+      filter: makeTelemetryFilterString({ core: 'DEBUG' }),
     },
   },
 });
@@ -28,7 +28,12 @@ Runtime.install({
 The following code sets the `DefaultLogger` to `'Debug'` and creates a Worker that can execute Activities or Workflows.
 
 ```typescript
-import { DefaultLogger, Runtime, Worker } from '@temporalio/worker';
+import {
+  DefaultLogger,
+  makeTelemetryFilterString,
+  Runtime,
+  Worker,
+} from '@temporalio/worker';
 import * as activities from './activities';
 async function main() {
   const argv = arg({

--- a/docs-src/typescript/how-to-set-the-default-logger-in-typescript.md
+++ b/docs-src/typescript/how-to-set-the-default-logger-in-typescript.md
@@ -39,8 +39,10 @@ async function main() {
     Runtime.install({
       logger: new DefaultLogger('DEBUG'),
       telemetryOptions: {
-        forward: {},
-        filter: makeTelemetryFilterString({ core: 'DEBUG', other: 'DEBUG' }),
+        logging: {
+          forward: {}, // This enables log forwarding
+          filter: makeTelemetryFilterString({ core: 'DEBUG' }),
+        },
       },
     });
   }

--- a/docs-src/typescript/how-to-set-the-default-logger-in-typescript.md
+++ b/docs-src/typescript/how-to-set-the-default-logger-in-typescript.md
@@ -17,8 +17,10 @@ The following is an example of setting the `DefaultLogger` to `'Debug'`.
 Runtime.install({
   logger: new DefaultLogger('DEBUG'),
   telemetryOptions: {
-    tracingFilter: 'temporal_sdk_core=DEBUG',
-    logging: { forward: { level: 'DEBUG' } },
+    logging: {
+      forward: {},
+      filter: makeTelemetryFilterString({ core: 'DEBUG', other: 'DEBUG' }),
+    },
   },
 });
 ```
@@ -37,8 +39,8 @@ async function main() {
     Runtime.install({
       logger: new DefaultLogger('DEBUG'),
       telemetryOptions: {
-        tracingFilter: 'temporal_sdk_core=DEBUG',
-        logging: { forward: { level: 'DEBUG' } },
+        forward: {},
+        filter: makeTelemetryFilterString({ core: 'DEBUG', other: 'DEBUG' }),
       },
     });
   }

--- a/docs-src/typescript/workers.md
+++ b/docs-src/typescript/workers.md
@@ -120,10 +120,12 @@ import {
   Worker,
 } from '@temporalio/worker';
 
-const logger = new DefaultLogger('DEBUG');
 Runtime.install({
-  logger,
-  telemetryOptions: { logForwardingLevel: 'INFO' },
+  logger: new DefaultLogger('DEBUG'),
+  logging: {
+    forward: {},
+    filter: makeTelemetryFilterString({ core: 'INFO' }),
+  },
 });
 const connection = await NativeConnection.connect({
   address: 'temporal.myorg.io',
@@ -242,7 +244,7 @@ export async function fileProcessingWorkflow(maxAttempts = 5): Promise<void> {
       const downloadPath = `/tmp/${uuid4()}`;
       await activities.downloadFileToWorkerFileSystem(
         'https://temporal.io',
-        downloadPath,
+        downloadPath
       );
       try {
         await activities.workOnFileInWorkerFileSystem(downloadPath);

--- a/docs-src/typescript/workers.md
+++ b/docs-src/typescript/workers.md
@@ -115,6 +115,7 @@ In production settings, you can configure the `address` and `namespace` the Work
 ```js
 import {
   DefaultLogger,
+  makeTelemetryFilterString,
   NativeConnection,
   Runtime,
   Worker,
@@ -122,9 +123,11 @@ import {
 
 Runtime.install({
   logger: new DefaultLogger('DEBUG'),
-  logging: {
-    forward: {},
-    filter: makeTelemetryFilterString({ core: 'INFO' }),
+  telemetryOptions: {
+    logging: {
+      forward: {},
+      filter: makeTelemetryFilterString({ core: 'INFO' }),
+    },
   },
 });
 const connection = await NativeConnection.connect({

--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -138,7 +138,10 @@ telemetryOptions: {
     metrics: {
       prometheus: { bindAddress: '0.0.0.0:9464' },
     },
-    logging: { forward: { level: 'DEBUG' } },
+    logging: {
+      forward: {},
+      filter: makeTelemetryFilterString({ core: 'INFO', other: 'WARN' })
+    },
   },
 ```
 
@@ -275,7 +278,7 @@ To extend the default ([Trace Context](https://github.com/open-telemetry/opentel
         new W3CBaggagePropagator(),
         new JaegerPropagator(),
       ],
-    }),
+    })
   );
   ```
 
@@ -341,7 +344,7 @@ To get a standard `slf4j` logger in your Workflow code, use the [`Workflow.getLo
 private static final Logger logger = Workflow.getLogger(DynamicDslWorkflow.class);
 ```
 
-Logs in replay mode are omitted unless the [`WorkerFactoryOptions.Builder.setEnableLoggingInReplay(boolean)`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerFactoryOptions.Builder.html#setEnableLoggingInReplay(boolean)) method is set to true.
+Logs in replay mode are omitted unless the [`WorkerFactoryOptions.Builder.setEnableLoggingInReplay(boolean)`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerFactoryOptions.Builder.html#setEnableLoggingInReplay(boolean)>) method is set to true.
 
 </TabItem>
 <TabItem value="php">
@@ -752,7 +755,7 @@ func (c *Client) CallYourWorkflow(ctx context.Context, workflowID string, payloa
 </TabItem>
 <TabItem value="java">
 
-To set a custom Search Attribute, call the [`setSearchAttributes()`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.Builder.html#setSearchAttributes(java.util.Map)) method.
+To set a custom Search Attribute, call the [`setSearchAttributes()`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.Builder.html#setSearchAttributes(java.util.Map)>) method.
 
 ```java
 WorkflowOptions workflowOptions =
@@ -884,7 +887,7 @@ map[string]interface{}{
 </TabItem>
 <TabItem value="java">
 
-In your Workflow code, call the [`upsertSearchAttributes(Map<String, ?> searchAttributes)`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#upsertSearchAttributes(java.util.Map)) method.
+In your Workflow code, call the [`upsertSearchAttributes(Map<String, ?> searchAttributes)`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#upsertSearchAttributes(java.util.Map)>) method.
 
 ```java
  Map<String, Object> attr1 = new HashMap<>();

--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -344,7 +344,7 @@ To get a standard `slf4j` logger in your Workflow code, use the [`Workflow.getLo
 private static final Logger logger = Workflow.getLogger(DynamicDslWorkflow.class);
 ```
 
-Logs in replay mode are omitted unless the [`WorkerFactoryOptions.Builder.setEnableLoggingInReplay(boolean)`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerFactoryOptions.Builder.html#setEnableLoggingInReplay(boolean)) method is set to true.
+Logs in replay mode are omitted unless the [`WorkerFactoryOptions.Builder.setEnableLoggingInReplay(boolean)`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerFactoryOptions.Builder.html#setEnableLoggingInReplay(boolean)>) method is set to true.
 
 </TabItem>
 <TabItem value="php">
@@ -755,7 +755,7 @@ func (c *Client) CallYourWorkflow(ctx context.Context, workflowID string, payloa
 </TabItem>
 <TabItem value="java">
 
-To set a custom Search Attribute, call the [`setSearchAttributes()`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.Builder.html#setSearchAttributes(java.util.Map)) method.
+To set a custom Search Attribute, call the [`setSearchAttributes()`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.Builder.html#setSearchAttributes(java.util.Map)>) method.
 
 ```java
 WorkflowOptions workflowOptions =
@@ -887,7 +887,7 @@ map[string]interface{}{
 </TabItem>
 <TabItem value="java">
 
-In your Workflow code, call the [`upsertSearchAttributes(Map<String, ?> searchAttributes)`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#upsertSearchAttributes(java.util.Map)) method.
+In your Workflow code, call the [`upsertSearchAttributes(Map<String, ?> searchAttributes)`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#upsertSearchAttributes(java.util.Map)>) method.
 
 ```java
  Map<String, Object> attr1 = new HashMap<>();

--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -344,7 +344,7 @@ To get a standard `slf4j` logger in your Workflow code, use the [`Workflow.getLo
 private static final Logger logger = Workflow.getLogger(DynamicDslWorkflow.class);
 ```
 
-Logs in replay mode are omitted unless the [`WorkerFactoryOptions.Builder.setEnableLoggingInReplay(boolean)`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerFactoryOptions.Builder.html#setEnableLoggingInReplay(boolean)>) method is set to true.
+Logs in replay mode are omitted unless the [`WorkerFactoryOptions.Builder.setEnableLoggingInReplay(boolean)`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/worker/WorkerFactoryOptions.Builder.html#setEnableLoggingInReplay(boolean)) method is set to true.
 
 </TabItem>
 <TabItem value="php">
@@ -755,7 +755,7 @@ func (c *Client) CallYourWorkflow(ctx context.Context, workflowID string, payloa
 </TabItem>
 <TabItem value="java">
 
-To set a custom Search Attribute, call the [`setSearchAttributes()`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.Builder.html#setSearchAttributes(java.util.Map)>) method.
+To set a custom Search Attribute, call the [`setSearchAttributes()`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowOptions.Builder.html#setSearchAttributes(java.util.Map)) method.
 
 ```java
 WorkflowOptions workflowOptions =
@@ -887,7 +887,7 @@ map[string]interface{}{
 </TabItem>
 <TabItem value="java">
 
-In your Workflow code, call the [`upsertSearchAttributes(Map<String, ?> searchAttributes)`](<https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#upsertSearchAttributes(java.util.Map)>) method.
+In your Workflow code, call the [`upsertSearchAttributes(Map<String, ?> searchAttributes)`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#upsertSearchAttributes(java.util.Map)) method.
 
 ```java
  Map<String, Object> attr1 = new HashMap<>();

--- a/docs/application-development/observability.md
+++ b/docs/application-development/observability.md
@@ -140,7 +140,7 @@ telemetryOptions: {
     },
     logging: {
       forward: {},
-      filter: makeTelemetryFilterString({ core: 'INFO', other: 'WARN' })
+      filter: makeTelemetryFilterString({ core: 'INFO' })
     },
   },
 ```


### PR DESCRIPTION
## What does this PR do?

- Updated examples of how to use `telemetryOptions: { ... }`. See this [PR](https://github.com/temporalio/sdk-typescript/pull/963).
