### PR TITLE
Launch temporalite docs

### DIFF
--- a/docs-src/clusters/quick-install.md
+++ b/docs-src/clusters/quick-install.md
@@ -36,7 +36,7 @@ The following steps start and run a Temporal Cluster.
    ```
 2. Start Temporalite by using the `start` command.
    ```bash
-   temporalite start --namespace default
+   ./temporalite start --namespace default
    ```
    Replace `default` with your [Namespace Name](/namespaces).
 

--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -67,7 +67,7 @@ The following steps start and run a Temporal Cluster.
    ```
 2. Start Temporalite by using the `start` command.
    ```bash
-   temporalite start --namespace default
+   ./temporalite start --namespace default
    ```
    Replace `default` with your [Namespace Name](/namespaces).
 


### PR DESCRIPTION
## What does this PR do?

Fixes command for running temporalite.

## Notes to reviewers

When running this command, it places the binary in the current folder, so command needs to be prepended with `./` in order to run it.
