### PR TITLE
TW-357: Cloud certificate information updates

### DIFF
--- a/docs-src/cloud-context/certificates-namespace.md
+++ b/docs-src/cloud-context/certificates-namespace.md
@@ -21,6 +21,9 @@ Add reminders to your calendar to issue new CA certificates well before the expi
 When updating CA certificates, it's important to follow a rollover process.
 Doing so enables your Namespace to serve both CA certificates for a period of time until traffic to your old CA certificate ceases.
 
+Be aware that the subject of the existing certificate and the subject of the new certificate must not be identical.
+One way to meet this requirement is to add a version or a date to the common name (CN).
+
 <!--- How to update certificates in Temporal Cloud using Temporal Cloud UI --->
 
 ### Update certificates using Temporal Cloud UI

--- a/docs-src/cloud-context/certificates-requirements.md
+++ b/docs-src/cloud-context/certificates-requirements.md
@@ -7,12 +7,6 @@ tags:
   - guide-context
 ---
 
-:::caution
-
-Temporal Cloud does not support TLS version 1.3.
-
-:::
-
 Certificates provided to Temporal for your [Namespaces](/namespaces) _must_ meet the following requirements.
 
 ### CA certificates

--- a/docs/cloud/how-to-manage-certificates-in-temporal-cloud.md
+++ b/docs/cloud/how-to-manage-certificates-in-temporal-cloud.md
@@ -15,12 +15,6 @@ This protocol requires a CA certificate from you.
 
 ## Certificate requirements
 
-:::caution
-
-Temporal Cloud does not support TLS version 1.3.
-
-:::
-
 Certificates provided to Temporal for your [Namespaces](/namespaces) _must_ meet the following requirements.
 
 ### CA certificates
@@ -113,6 +107,9 @@ Add reminders to your calendar to issue new CA certificates well before the expi
 
 When updating CA certificates, it's important to follow a rollover process.
 Doing so enables your Namespace to serve both CA certificates for a period of time until traffic to your old CA certificate ceases.
+
+Be aware that the subject of the existing certificate and the subject of the new certificate must not be identical.
+One way to meet this requirement is to add a version or a date to the common name (CN).
 
 <!--- How to update certificates in Temporal Cloud using Temporal Cloud UI --->
 

--- a/docs/visibility.md
+++ b/docs/visibility.md
@@ -40,12 +40,6 @@ A List Filter that uses a time range has a resolution of 1 ns on Elasticsearch 7
 
 ### Supported operators
 
-:::note
-
-Custom Search Attributes of `Text` type cannot be used in **ORDER BY** clauses.
-
-:::
-
 A List Filter contains <a class="tdlp" href="#search-attribute">Search Attribute<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What is a Search Attribute?</span><br /><br /><span class="tdlppd">A Search Attribute is an indexed name used in List Filters to filter a list of Workflow Executions that have the Search Attribute in their metadata.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#search-attribute">Learn more</a></span></span></a> names, Search Attribute values, and the following supported operators:
 
 - **=, !=, >, >=, <, <=**
@@ -55,6 +49,7 @@ A List Filter contains <a class="tdlp" href="#search-attribute">Search Attribute
 - **ORDER BY**
 
 The **ORDER BY** operator is supported only when Elasticsearch is used as the Visibility store.
+Additionally, custom Search Attributes of the `Text` type cannot be used in **ORDER BY** clauses.
 
 ### Partial string match
 
@@ -65,7 +60,6 @@ The `=` operator works like **CONTAINS** to find Workflows with Search Attribute
 For example, if you have a Search Attribute `Description` of `Text` type with the value of "The quick brown fox jumps over the lazy dog", searching for `Description=quick` or `Description=fox` will successfully return the Workflow.
 However, partial word searches such as `Description=qui` or `Description=laz` will not return the Workflow.
 This is because [Elasticsearch's tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) is configured to return complete words as tokens.
-
 
 ### Efficient API usage
 


### PR DESCRIPTION
## What does this PR do?

Updates two portions of [How to manage certificates in Temporal Cloud](https://docs.temporal.io/cloud/how-to-manage-certificates-in-temporal-cloud#manage-certificates):
- Removes outdated admonition that Temporal Cloud doesn't support TLS 1.3.
- Adds requirement that, when assigning multiple certificates to a Namespace (such as when rotating certificates), the subjects must not be identical.

## Notes to reviewers

The changes to `docs/visibility.md` are not part of this PR. They're changes merged from another PR and do not need review here.
