### PR TITLE
Remove CLI installation incorrect statement

### DIFF
--- a/docs-src/concepts/what-is-the-temporal-cli.md
+++ b/docs-src/concepts/what-is-the-temporal-cli.md
@@ -24,7 +24,7 @@ The tool runs as a single process with zero runtime dependencies and supports pe
 
 ## Installation
 
-Temporal CLI can be installed through several different methods. While most of them can be used across all operating systems, please note that Homebrew is macOS-exclusive.
+Temporal CLI can be installed through several different methods.
 
 For more information, see our guide to [running a Development Cluster](/clusters/how-to-install-temporal-cli).
 


### PR DESCRIPTION
## What does this PR do?

Removed incorrect statement that homebrew CLI installation is macOS-only

## Notes to reviewers

Removed as this seems unnecessary in this section of the docs. Feel free to correct instead that it works for linux too

<!-- delete if n/a -->
