### PR TITLE
Fix TS replay docs

### DIFF
--- a/docs-src/typescript/activities.md
+++ b/docs-src/typescript/activities.md
@@ -471,10 +471,11 @@ The [`Context.current().cancellationSignal`](https://typescript.temporal.io/api/
 ```ts
 import { Context } from '@temporalio/activity';
 import fetch from 'node-fetch';
+import type { AbortSignal as FetchAbortSignal } from 'node-fetch/externals';
 
 export async function cancellableFetch(url: string): Promise<Uint8Array> {
   const response = await fetch(url, {
-    signal: Context.current().cancellationSignal,
+    signal: Context.current().cancellationSignal as FetchAbortSignal,
   });
   const contentLengthHeader = response.headers.get('Content-Length');
   if (contentLengthHeader === null) {

--- a/docs-src/typescript/data-converters.md
+++ b/docs-src/typescript/data-converters.md
@@ -256,9 +256,7 @@ To serialize values as [Protocol Buffers](https://en.wikipedia.org/wiki/Protocol
 [protobufs/protos/root.js](https://github.com/temporalio/samples-typescript/blob/master/protobufs/protos/root.js)
 
 ```js
-const { patchProtobufRoot } = require(
-  '@temporalio/common/lib/converter/patch-protobuf-root',
-);
+const { patchProtobufRoot } = require('@temporalio/common/lib/protobufs');
 const unpatchedRoot = require('./json-module');
 module.exports = patchProtobufRoot(unpatchedRoot);
 ```

--- a/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
+++ b/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
@@ -17,13 +17,13 @@ If replay fails for any other reason, [ReplayError](https://typescript.temporal.
 In the following example, a single Event History is loaded from a JSON file on disk (as obtained from the [Web UI](/web-ui) or the [Temporal CLI](/cli/workflow#show)):
 
 ```ts
-const filePath = './history_file.json';
-const history = await JSON.parse(fs.promises.readFile(filePath, 'utf8'));
+const filePath = "./history_file.json";
+const history = await JSON.parse(fs.promises.readFile(filePath, "utf8"));
 await Worker.runReplayHistory(
   {
-    workflowsPath: require.resolve('./your/workflows'),
+    workflowsPath: require.resolve("./your/workflows"),
   },
-  history,
+  history
 );
 ```
 
@@ -31,14 +31,14 @@ Alternatively, we can download the Event History programmatically using a Client
 
 ```ts
 const connection = await Connection.connect({ address });
-const client = new Client({ connection, namespace: 'your-namespace' });
-const handle = client.workflow.getHandle('your-workflow-id');
+const client = new Client({ connection, namespace: "your-namespace" });
+const handle = client.workflow.getHandle("your-workflow-id");
 const history = await handle.fetchHistory();
 await Worker.runReplayHistory(
   {
-    workflowsPath: require.resolve('./your/workflows'),
+    workflowsPath: require.resolve("./your/workflows"),
   },
-  history,
+  history
 );
 ```
 
@@ -55,13 +55,13 @@ const executions = client.workflow.list({
 const histories = executions.intoHistories();
 const results = Worker.runReplayHistories(
   {
-    workflowsPath: require.resolve('./your/workflows'),
+    workflowsPath: require.resolve("./your/workflows"),
   },
-  histories,
+  histories
 );
 for await (const result of results) {
   if (result.error) {
-    console.error('Replay failed', result);
+    console.error("Replay failed", result);
   }
 }
 ```

--- a/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
+++ b/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
@@ -9,76 +9,69 @@ tags:
   - typescript
 ---
 
-To replay one or more Event Histories, use [worker.runReplayHistories](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistories) or [worker.runReplayHistory](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistory).
+To replay a single Event History, use [worker.runReplayHistory](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistory).
 
-In all examples if Workflow History is non-deterministic, a
-[`DeterminismViolationError`](https://typescript.temporal.io/api/classes/workflow.determinismviolationerror/)
+If non-determinism is caught while replaying the history, meaning that the Workflow code is incompatible with the
+History, a [`DeterminismViolationError`](https://typescript.temporal.io/api/classes/workflow.DeterminismViolationError)
 will be thrown.
+If replay fails for any other reason a [`ReplayError`](https://typescript.temporal.io/api/classes/worker.ReplayError)
+will be thrown.
+
+In the next example, a single history is loaded from a JSON file on disk (as obtained from the [Web
+UI](https://docs.temporal.io/web-ui) or the [Temporal CLI](https://docs.temporal.io/cli/workflow#show)):
+
+```ts
+const filePath = "./history_file.json";
+const history = await JSON.parse(fs.promises.readFile(filePath, "utf8"));
+await Worker.runReplayHistory(
+  {
+    workflowsPath: require.resolve("./your/workflows"),
+  },
+  history
+);
+```
+
+Alternatively, we can download the history programatically using a Client:
+
+```ts
+const connection = await Connection.connect({ address });
+const client = new Client({ connection, namespace: "your-namespace" });
+const handle = client.workflow.getHandle("your-workflow-id");
+const history = await handle.fetchHistory();
+await Worker.runReplayHistory(
+  {
+    workflowsPath: require.resolve("./your/workflows"),
+  },
+  history
+);
+```
+
+In order to gain confidence that a Workflow changes are safe to deploy, it is recommended to obtain Histories from the
+relevant task queue and replay them in bulk.
+This can be achieved by combining the
+[workflow.list](https://typescript.temporal.io/api/classes/client.WorkflowClient#list) and
+[worker.runReplayHistories](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistories) APIs.
 
 In the following example (which, as of server 1.18, requires advanced visibility to be enabled),
 histories are downloaded from the server and then replayed by passing in a client and a set of
-executions. The code will throw an exception if any replay fails.
+Executions.
+The [results](https://typescript.temporal.io/api/interfaces/worker.ReplayResult) returned by the async iterator below
+contain information about the Workflow Execution and whether or not an error occured during replay.
 
 ```ts
 const executions = client.workflow.list({
   query: 'TaskQueue=foo and StartTime > "2022-01-01T12:00:00"',
 });
 const histories = executions.intoHistories();
-await Worker.runReplayHistories(
+const results = Worker.runReplayHistories(
   {
-    workflowsPath: require.resolve('./your/workflows'),
+    workflowsPath: require.resolve("./your/workflows"),
   },
-  histories,
+  histories
 );
+for await (const result of results) {
+  if (result.error) {
+    console.error("Replay failed", result);
+  }
+}
 ```
-
-In the next example, a single history is loaded from a JSON file on disk:
-
-```ts
-const filePath = './history_file.json';
-const hist = await JSON.parse(fs.promises.readFile(filePath, 'utf8'));
-await Worker.runReplayHistory(
-  {
-    workflowsPath: require.resolve('./your/workflows'),
-  },
-  hist,
-);
-```
-
-Here, we show downloading a history and replaying it separately:
-
-<!--SNIPSTART typescript-history-get-workflowhistory-->
-
-[replay-history/src/replayer.ts](https://github.com/temporalio/samples-typescript/blob/master/replay-history/src/replayer.ts)
-
-```ts
-const conn = await Connection.connect(
-  /* { address: 'temporal.prod.company.com' } */
-);
-const { history } = await conn.workflowService.getWorkflowExecutionHistory({
-  namespace: 'default',
-  execution: {
-    workflowId: 'calc',
-  },
-});
-```
-
-<!--SNIPEND-->
-
-Then call [`Worker.runReplayHistory`](https://typescript.temporal.io/api/classes/worker.worker/#runreplayhistory).
-
-<!--SNIPSTART typescript-history-replay-->
-
-[replay-history/src/replayer.ts](https://github.com/temporalio/samples-typescript/blob/master/replay-history/src/replayer.ts)
-
-```ts
-await Worker.runReplayHistory(
-  {
-    workflowsPath: require.resolve('./workflows'),
-    replayName: 'calc',
-  },
-  history,
-);
-```
-
-<!--SNIPEND-->

--- a/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
+++ b/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
@@ -17,17 +17,16 @@ will be thrown.
 If replay fails for any other reason a [`ReplayError`](https://typescript.temporal.io/api/classes/worker.ReplayError)
 will be thrown.
 
-In the next example, a single history is loaded from a JSON file on disk (as obtained from the [Web
-UI](https://docs.temporal.io/web-ui) or the [Temporal CLI](https://docs.temporal.io/cli/workflow#show)):
+In the next example, a single history is loaded from a JSON file on disk (as obtained from the [WebUI](https://docs.temporal.io/web-ui) or the [Temporal CLI](https://docs.temporal.io/cli/workflow#show)):
 
 ```ts
-const filePath = "./history_file.json";
-const history = await JSON.parse(fs.promises.readFile(filePath, "utf8"));
+const filePath = './history_file.json';
+const history = await JSON.parse(fs.promises.readFile(filePath, 'utf8'));
 await Worker.runReplayHistory(
   {
-    workflowsPath: require.resolve("./your/workflows"),
+    workflowsPath: require.resolve('./your/workflows'),
   },
-  history
+  history,
 );
 ```
 
@@ -35,14 +34,14 @@ Alternatively, we can download the history programatically using a Client:
 
 ```ts
 const connection = await Connection.connect({ address });
-const client = new Client({ connection, namespace: "your-namespace" });
-const handle = client.workflow.getHandle("your-workflow-id");
+const client = new Client({ connection, namespace: 'your-namespace' });
+const handle = client.workflow.getHandle('your-workflow-id');
 const history = await handle.fetchHistory();
 await Worker.runReplayHistory(
   {
-    workflowsPath: require.resolve("./your/workflows"),
+    workflowsPath: require.resolve('./your/workflows'),
   },
-  history
+  history,
 );
 ```
 
@@ -65,13 +64,13 @@ const executions = client.workflow.list({
 const histories = executions.intoHistories();
 const results = Worker.runReplayHistories(
   {
-    workflowsPath: require.resolve("./your/workflows"),
+    workflowsPath: require.resolve('./your/workflows'),
   },
-  histories
+  histories,
 );
 for await (const result of results) {
   if (result.error) {
-    console.error("Replay failed", result);
+    console.error('Replay failed', result);
   }
 }
 ```

--- a/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
+++ b/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
@@ -11,13 +11,10 @@ tags:
 
 To replay a single Event History, use [worker.runReplayHistory](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistory).
 
-If non-determinism is caught while replaying the history, meaning that the Workflow code is incompatible with the
-History, a [`DeterminismViolationError`](https://typescript.temporal.io/api/classes/workflow.DeterminismViolationError)
-will be thrown.
-If replay fails for any other reason a [`ReplayError`](https://typescript.temporal.io/api/classes/worker.ReplayError)
-will be thrown.
+When an Event History is replayed and non-determinism is detected (that is, the Workflow code is incompatible with the History), [DeterminismViolationError](https://typescript.temporal.io/api/classes/workflow.DeterminismViolationError) is thrown.
+If replay fails for any other reason, [ReplayError](https://typescript.temporal.io/api/classes/worker.ReplayError) is thrown.
 
-In the next example, a single history is loaded from a JSON file on disk (as obtained from the [WebUI](https://docs.temporal.io/web-ui) or the [Temporal CLI](https://docs.temporal.io/cli/workflow#show)):
+In the following example, a single Event History is loaded from a JSON file on disk (as obtained from the [Web UI](/web-ui) or the [Temporal CLI](/cli/workflow#show)):
 
 ```ts
 const filePath = './history_file.json';
@@ -30,7 +27,7 @@ await Worker.runReplayHistory(
 );
 ```
 
-Alternatively, we can download the history programatically using a Client:
+Alternatively, we can download the Event History programmatically using a Client:
 
 ```ts
 const connection = await Connection.connect({ address });
@@ -45,17 +42,11 @@ await Worker.runReplayHistory(
 );
 ```
 
-In order to gain confidence that a Workflow changes are safe to deploy, it is recommended to obtain Histories from the
-relevant task queue and replay them in bulk.
-This can be achieved by combining the
-[workflow.list](https://typescript.temporal.io/api/classes/client.WorkflowClient#list) and
-[worker.runReplayHistories](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistories) APIs.
+To gain confidence that changes to a Workflow are safe to deploy, we recommend that you obtain Event Histories from the relevant Task Queue and replay them in bulk.
+You can do so by combining the [workflow.list](https://typescript.temporal.io/api/classes/client.WorkflowClient#list) and [worker.runReplayHistories](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistories) APIs.
 
-In the following example (which, as of server 1.18, requires advanced visibility to be enabled),
-histories are downloaded from the server and then replayed by passing in a client and a set of
-Executions.
-The [results](https://typescript.temporal.io/api/interfaces/worker.ReplayResult) returned by the async iterator below
-contain information about the Workflow Execution and whether or not an error occured during replay.
+In the following example (which, as of server 1.18, requires [Advanced Visibility](/concepts/what-is-advanced-visibility) to be enabled), Event Histories are downloaded from the server and then replayed by passing in a client and a set of Workflows Executions.
+The [results](https://typescript.temporal.io/api/interfaces/worker.ReplayResult) returned by the async iterator contain information about the Workflow Execution and whether an error occurred during replay.
 
 ```ts
 const executions = client.workflow.list({

--- a/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
+++ b/docs-src/typescript/how-to-replay-a-workflow-execution-in-typescript.md
@@ -17,13 +17,13 @@ If replay fails for any other reason, [ReplayError](https://typescript.temporal.
 In the following example, a single Event History is loaded from a JSON file on disk (as obtained from the [Web UI](/web-ui) or the [Temporal CLI](/cli/workflow#show)):
 
 ```ts
-const filePath = "./history_file.json";
-const history = await JSON.parse(fs.promises.readFile(filePath, "utf8"));
+const filePath = './history_file.json';
+const history = await JSON.parse(fs.promises.readFile(filePath, 'utf8'));
 await Worker.runReplayHistory(
   {
-    workflowsPath: require.resolve("./your/workflows"),
+    workflowsPath: require.resolve('./your/workflows'),
   },
-  history
+  history,
 );
 ```
 
@@ -31,14 +31,14 @@ Alternatively, we can download the Event History programmatically using a Client
 
 ```ts
 const connection = await Connection.connect({ address });
-const client = new Client({ connection, namespace: "your-namespace" });
-const handle = client.workflow.getHandle("your-workflow-id");
+const client = new Client({ connection, namespace: 'your-namespace' });
+const handle = client.workflow.getHandle('your-workflow-id');
 const history = await handle.fetchHistory();
 await Worker.runReplayHistory(
   {
-    workflowsPath: require.resolve("./your/workflows"),
+    workflowsPath: require.resolve('./your/workflows'),
   },
-  history
+  history,
 );
 ```
 
@@ -55,13 +55,13 @@ const executions = client.workflow.list({
 const histories = executions.intoHistories();
 const results = Worker.runReplayHistories(
   {
-    workflowsPath: require.resolve("./your/workflows"),
+    workflowsPath: require.resolve('./your/workflows'),
   },
-  histories
+  histories,
 );
 for await (const result of results) {
   if (result.error) {
-    console.error("Replay failed", result);
+    console.error('Replay failed', result);
   }
 }
 ```

--- a/docs/application-development/testing.md
+++ b/docs/application-development/testing.md
@@ -1272,79 +1272,62 @@ If the Workflow History is exported by [Temporal Web UI](/web-ui) or through [tc
 </TabItem>
 <TabItem value="typescript">
 
-To replay one or more Event Histories, use [worker.runReplayHistories](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistories) or [worker.runReplayHistory](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistory).
+To replay a single Event History, use [worker.runReplayHistory](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistory).
 
-In all examples if Workflow History is non-deterministic, a
-[`DeterminismViolationError`](https://typescript.temporal.io/api/classes/workflow.determinismviolationerror/)
-will be thrown.
+When an Event History is replayed and non-determinism is detected (that is, the Workflow code is incompatible with the History), [DeterminismViolationError](https://typescript.temporal.io/api/classes/workflow.DeterminismViolationError) is thrown.
+If replay fails for any other reason, [ReplayError](https://typescript.temporal.io/api/classes/worker.ReplayError) is thrown.
 
-In the following example (which, as of server 1.18, requires advanced visibility to be enabled),
-histories are downloaded from the server and then replayed by passing in a client and a set of
-executions. The code will throw an exception if any replay fails.
+In the following example, a single Event History is loaded from a JSON file on disk (as obtained from the [Web UI](/web-ui) or the [Temporal CLI](/cli/workflow#show)):
+
+```ts
+const filePath = './history_file.json';
+const history = await JSON.parse(fs.promises.readFile(filePath, 'utf8'));
+await Worker.runReplayHistory(
+  {
+    workflowsPath: require.resolve('./your/workflows'),
+  },
+  history,
+);
+```
+
+Alternatively, we can download the Event History programmatically using a Client:
+
+```ts
+const connection = await Connection.connect({ address });
+const client = new Client({ connection, namespace: 'your-namespace' });
+const handle = client.workflow.getHandle('your-workflow-id');
+const history = await handle.fetchHistory();
+await Worker.runReplayHistory(
+  {
+    workflowsPath: require.resolve('./your/workflows'),
+  },
+  history,
+);
+```
+
+To gain confidence that changes to a Workflow are safe to deploy, we recommend that you obtain Event Histories from the relevant Task Queue and replay them in bulk.
+You can do so by combining the [workflow.list](https://typescript.temporal.io/api/classes/client.WorkflowClient#list) and [worker.runReplayHistories](https://typescript.temporal.io/api/classes/worker.Worker#runreplayhistories) APIs.
+
+In the following example (which, as of server 1.18, requires <a class="tdlp" href="/visibility#advanced-visibility">Advanced Visibility<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What is Advanced Visibility?</span><br /><br /><span class="tdlppd">Advanced Visibility, within the Temporal Platform, is the subsystem and APIs that enable the listing, filtering, and sorting of Workflow Executions through an SQL-like query syntax.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/visibility#advanced-visibility">Learn more</a></span></span></a> to be enabled), Event Histories are downloaded from the server and then replayed by passing in a client and a set of Workflows Executions.
+The [results](https://typescript.temporal.io/api/interfaces/worker.ReplayResult) returned by the async iterator contain information about the Workflow Execution and whether an error occurred during replay.
 
 ```ts
 const executions = client.workflow.list({
   query: 'TaskQueue=foo and StartTime > "2022-01-01T12:00:00"',
 });
 const histories = executions.intoHistories();
-await Worker.runReplayHistories(
+const results = Worker.runReplayHistories(
   {
     workflowsPath: require.resolve('./your/workflows'),
   },
   histories,
 );
+for await (const result of results) {
+  if (result.error) {
+    console.error('Replay failed', result);
+  }
+}
 ```
-
-In the next example, a single history is loaded from a JSON file on disk:
-
-```ts
-const filePath = './history_file.json';
-const hist = await JSON.parse(fs.promises.readFile(filePath, 'utf8'));
-await Worker.runReplayHistory(
-  {
-    workflowsPath: require.resolve('./your/workflows'),
-  },
-  hist,
-);
-```
-
-Here, we show downloading a history and replaying it separately:
-
-<!--SNIPSTART typescript-history-get-workflowhistory-->
-
-[replay-history/src/replayer.ts](https://github.com/temporalio/samples-typescript/blob/master/replay-history/src/replayer.ts)
-
-```ts
-const conn = await Connection.connect(
-  /* { address: 'temporal.prod.company.com' } */
-);
-const { history } = await conn.workflowService.getWorkflowExecutionHistory({
-  namespace: 'default',
-  execution: {
-    workflowId: 'calc',
-  },
-});
-```
-
-<!--SNIPEND-->
-
-Then call [`Worker.runReplayHistory`](https://typescript.temporal.io/api/classes/worker.worker/#runreplayhistory).
-
-<!--SNIPSTART typescript-history-replay-->
-
-[replay-history/src/replayer.ts](https://github.com/temporalio/samples-typescript/blob/master/replay-history/src/replayer.ts)
-
-```ts
-await Worker.runReplayHistory(
-  {
-    workflowsPath: require.resolve('./workflows'),
-    replayName: 'calc',
-  },
-  history,
-);
-```
-
-<!--SNIPEND-->
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
The mass replayer API changed in 1.6.0 and the docs haven't been updated since.
I've also restructured the content a bit so it progresses from single to bulk replay.