### PR TITLE
EDU 147: add redirect for Cloud Namespace Name

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1194,6 +1194,10 @@
       "destination": "/workflows#workflow-task-timeout"
     },
     {
+      "source": "/concepts/what-is-a-cloud-namespace-name",
+      "destination": "/cloud#temporal-cloud-namespace-name"
+    },
+    {
       "source": "/concepts/what-is-a-workflow-type",
       "destination": "/workflows#workflow-type"
     },


### PR DESCRIPTION
## What does this PR do?
Adds a redirect for Cloud Namespace name to go to the proper spot (cloud#temporal-cloud-namespace-name) in the generated docs.

