### PR TITLE
Removes mention of TLite in dev guide

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday May 03 2023 09:50:58 AM -0700
+Last assembled: Thursday May 04 2023 09:35:07 AM -0700
 
 Assembly Workflow Id: docs-full-assembly-rachfop-123
 

--- a/docs-src/app-dev-context/connect-to-a-dev-cluster.md
+++ b/docs-src/app-dev-context/connect-to-a-dev-cluster.md
@@ -23,5 +23,5 @@ However, it is acceptable and common to use a Temporal Client inside an Activity
 
 :::
 
-When you are running a Cluster locally (such as [Temporalite](/kb/all-the-ways-to-run-a-cluster#temporalite)), the number of connection options you must provide is minimal.
-Many SDKs default to the local host or IP address and port that Temporalite and [Docker Compose](/kb/all-the-ways-to-run-a-cluster#docker-compose) serve (`127.0.0.1:7233`).
+When you are running a Cluster locally, the number of connection options you must provide is minimal.
+Many SDKs default to the local host or IP address and port that [Temporal CLI](/kb/all-the-ways-to-run-a-cluster#temporal-cli) and [Docker Compose](/kb/all-the-ways-to-run-a-cluster#docker-compose) serve (`127.0.0.1:7233`).

--- a/docs/application-development/foundations.md
+++ b/docs/application-development/foundations.md
@@ -361,8 +361,8 @@ However, it is acceptable and common to use a Temporal Client inside an Activity
 
 :::
 
-When you are running a Cluster locally (such as [Temporalite](/kb/all-the-ways-to-run-a-cluster#temporalite)), the number of connection options you must provide is minimal.
-Many SDKs default to the local host or IP address and port that Temporalite and [Docker Compose](/kb/all-the-ways-to-run-a-cluster#docker-compose) serve (`127.0.0.1:7233`).
+When you are running a Cluster locally, the number of connection options you must provide is minimal.
+Many SDKs default to the local host or IP address and port that [Temporal CLI](/kb/all-the-ways-to-run-a-cluster#temporal-cli) and [Docker Compose](/kb/all-the-ways-to-run-a-cluster#docker-compose) serve (`127.0.0.1:7233`).
 
 <Tabs
 defaultValue="go"


### PR DESCRIPTION
## What does this PR do?

When running a cluster, the prose makes mention of Temporalite.
It should point to Temporal CLI instead.

## Notes to reviewers

<!-- delete if n/a -->