### PR TITLE
Adding .env files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ package-lock.json
 
 # .vscode
 .vscode/*
+
+# Env
+.env
+/assembly/.env


### PR DESCRIPTION
In the future, we will be using .env for secure items, adding files to gitignore now.