### PR TITLE
Fix descriptions in metadata for TypeScript Versioning topic

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday May 30 2023 08:31:15 AM -0700
+Last assembled: Tuesday May 30 2023 09:54:43 AM -0700
 
 Assembly Workflow Id: docs-full-assembly-dail-macbook
 

--- a/assembly/guide-configs/app-dev/typescript/versioning.json
+++ b/assembly/guide-configs/app-dev/typescript/versioning.json
@@ -6,7 +6,7 @@
   "title": "TypeScript SDK developer's guide - Versioning",
   "sidebar_label": "Versioning",
   "sidebar_position": 5,
-  "description": "The Versioning section of the Temporal TypeScript SDK developer's guide explains how to update Workflow Definitions without disrupting current long-running Workflows.",
+  "description": "The Versioning section of the Temporal TypeScript SDK developer's guide explains how to update Workflow Definitions without causing non-deterministic behavior in current long-running Workflows.",
   "use_description": false,
   "toc_max_heading_level": 4,
   "add_tabs_support": false,

--- a/docs-src/typescript/versioning.md
+++ b/docs-src/typescript/versioning.md
@@ -1,7 +1,7 @@
 ---
 id: versioning
 title: Versioning
-description: Versioning lets you update Workflow Definitions without disrupting current long-running Workflows.
+description: Versioning lets you update Workflow Definitions without causing non-deterministic behavior in current long-running Workflows.
 sidebar_label: Versioning
 tags:
   - guide-context

--- a/docs/dev-guide/tscript/versioning.md
+++ b/docs/dev-guide/tscript/versioning.md
@@ -3,7 +3,7 @@ id: versioning
 title: TypeScript SDK developer's guide - Versioning
 sidebar_label: Versioning
 sidebar_position: 5
-description: The Versioning section of the Temporal TypeScript SDK developer's guide explains how to update Workflow Definitions without disrupting current long-running Workflows.
+description: The Versioning section of the Temporal TypeScript SDK developer's guide explains how to update Workflow Definitions without causing non-deterministic behavior in current long-running Workflows.
 slug: /dev-guide/typescript/versioning
 toc_max_heading_level: 4
 ---


### PR DESCRIPTION
## What does this PR do?

Updates descriptions in metadata for TypeScript Versioning topic to match opening sentence. (Should've been in [PR 2063](https://github.com/temporalio/documentation/pull/2063), but I merged it too soon.)
