### PR TITLE
EDU-768: Migrate legacy "Running [Workers] in Docker" content into TypeScript dev guide

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday June 12 2023 13:44:27 PM -0700
+Last assembled: Wednesday June 14 2023 07:58:10 AM -0700
 
 Assembly Workflow Id: docs-full-assembly-dail-macbook
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,14 +1,14 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday June 08 2023 15:58:18 PM -0700
+Last assembled: Monday June 12 2023 13:44:27 PM -0700
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly-dail-macbook
 
 86 guide configurations found.
 
-1448 information nodes found.
+1449 information nodes found.
 
-1204 information nodes are attached to guides.
+1205 information nodes are attached to guides.
 
 The "Link Magic" Activity transformed the following "information node" identifiers into site paths:
 
@@ -880,6 +880,8 @@ cli/cmd-options/fold -> /cli/cmd-options#fold
 
 cli/cmd-options/no-fold -> /cli/cmd-options#no-fold
 
+typescript/testing -> /dev-guide/typescript/testing#replay
+
 typescript/tracing -> /dev-guide/typescript/observability#tracing
 
 typescript/logging -> /dev-guide/typescript/observability#logging
@@ -891,6 +893,8 @@ cloud-context/namespaces-create -> /cloud/how-to-manage-namespaces-in-temporal-c
 clusters/how-to-install-temporal-cli -> #run-a-development-server
 
 typescript/connect-to-a-dev-cluster -> #connect-to-a-dev-cluster
+
+typescript/how-to-run-a-worker-on-docker -> #run-a-worker-on-docker
 
 concepts/what-is-the-temporal-platform -> /temporal#temporal-platform
 

--- a/assembly/guide-configs/app-dev/typescript/foundations.json
+++ b/assembly/guide-configs/app-dev/typescript/foundations.json
@@ -157,6 +157,10 @@
     },
     {
       "type": "h2",
+      "id": "typescript/how-to-run-a-worker-on-docker"
+    },
+    {
+      "type": "h2",
       "id": "typescript/run-a-temporal-cloud-worker"
     },
     {

--- a/docs-src/typescript/debug-environment-production.md
+++ b/docs-src/typescript/debug-environment-production.md
@@ -11,7 +11,7 @@ You can debug production Workflows using:
 
 - [Web UI](/web-ui)
 - [tctl](/tctl-v1)
-- [Replay](#replay)
+- [Replay](/typescript/testing#replay)
 - [Tracing](/typescript/tracing)
 - [Logging](/typescript/logging)
 

--- a/docs-src/typescript/foundations.md
+++ b/docs-src/typescript/foundations.md
@@ -29,5 +29,6 @@ In this section you can find the following:
 - [Develop an Activity](/typescript/developing-activities)
 - [Start an Activity Execution](/typescript/spawning-activities)
 - [Run a dev Worker](/typescript/run-a-dev-worker)
+- [Run a Worker on Docker](/typescript/how-to-run-a-worker-on-docker)
 - [Run a Temporal Cloud Worker](/typescript/run-a-dev-worker)
 - [Start a Workflow Execution](/typescript/spawning-workflows)

--- a/docs-src/typescript/how-to-run-a-worker-on-docker.md
+++ b/docs-src/typescript/how-to-run-a-worker-on-docker.md
@@ -1,0 +1,114 @@
+---
+id: how-to-run-a-worker-on-docker
+title: How to run a Worker on Docker in TypeScript
+sidebar_label: Run a Worker on Docker
+description: Workers based on the TypeScript SDK can be deployed and run as Docker containers.
+tags:
+  - developer-guide
+  - sdk
+  - typescript
+---
+
+Workers based on the TypeScript SDK can be deployed and run as Docker containers.
+
+At this moment, we recommend usage of Node.js 16.
+(Node.js 18 has known issues.)
+Both `amd64` and `arm64` platforms are supported.
+A glibc-based image is required; musl-based images are _not_ supported (see below).
+
+The easiest way to deploy a TypeScript SDK Worker on Docker is to start with the `node:16-bullseye` image.
+For example:
+
+```dockerfile
+FROM node:16-bullseye
+
+COPY . /app
+WORKDIR /app
+
+RUN npm install --only=production \
+    && npm run build
+
+CMD ["build/worker.js"]
+```
+
+For smaller images and/or more secure deployments, it is also possible to use `-slim` Docker image variants (like `node:16-bullseye-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs:16`) with the following caveats.
+
+### Using `node:slim` images
+
+`node:slim` images do not contain some of the common packages found in regular images. This results in significantly smaller images.
+
+However, TypeScript SDK requires the presence of root TLS certificates (the `ca-certificates` package), which are not included in `slim` images. `ca-certificates` package is required even when connecting to a local Temporal Server or when using a server connection config that doesn't explicitly use TLS.
+
+For this reason, the `ca-certificates` package must be installed during the construction of the Docker image. For example:
+
+```dockerfile
+FROM node:16-bulleyes-slim
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ... same as with regular image
+```
+
+Failure to install this dependency results in a `[TransportError: transport error]` runtime error, because the certificates cannot be verified.
+
+### Using `distroless/nodejs` images
+
+`distroless/nodejs` images include only the files that are strictly required to execute `node`.
+This results in even smaller images (approximately half the size of `node:slim` images).
+It also significantly reduces the surface of potential security issues that could be exploited by a hacker in the resulting Docker images.
+
+It is generally possible and safe to execute TypeScript SDK Workers using `distroless/nodejs` images (unless your code itself requires dependencies that are not included in `distroless/nodejs`).
+
+However, some tools required for the build process (notably the `npm` command) are _not_ included in the `distroless/nodejs` image.
+This might result in various error messages during the Docker build.
+
+The recommanded solution is to use a multi-step Dockerfile.
+For example:
+
+```dockerfile
+# -- BUILD STEP --
+
+FROM node:16-bulleyes AS builder
+
+COPY . /app
+WORKDIR /app
+
+RUN npm install --only=production \
+    && npm run build
+
+# -- RESULTING IMAGE --
+
+FROM gcr.io/distroless/nodejs:16
+
+COPY --from=builder /app /app
+WORKDIR /app
+
+CMD ["build/worker.js"]
+```
+
+### Properly configure Node.js memory in Docker
+
+By default, `node` configures its maximum old-gen memory to 25% of the _physical memory_ of the machine on which it is executing, with a maximum of 4 GB.
+This is likely inappropriate when running Node.js in a Docker environment and can result in either underusage of available memory (`node` only uses a fraction of the memory allocated to the container) or overusage (`node` tries to use more memory than what is allocated to the container, which will eventually lead to the process being killed by the operating system).
+
+Therefore we recommended that you always explicitly set the `--max-old-space-size` `node` argument to approximately 80% of the maximum size (in megabytes) that you want to allocate the `node` process.
+You might need some experimentation and adjustment to find the most appropriate value based on your specific application.
+
+In practice, it is generally easier to provide this argument through the [`NODE_OPTIONS` environment variable](https://nodejs.org/api/cli.html#node_optionsoptions).
+
+### Do not use Alpine
+
+Alpine replaces glibc with musl, which is incompatible with the Rust core of the TypeScript SDK.
+If you receive errors like the following, it's probably because you are using Alpine.
+
+```sh
+Error: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /opt/app/node_modules/@temporalio/core-bridge/index.node)
+```
+
+Or like this:
+
+```sh
+Error: Error relocating /opt/app/node_modules/@temporalio/core-bridge/index.node: __register_atfork: symbol not found
+```

--- a/docs-src/typescript/how-to-run-a-worker-on-docker.md
+++ b/docs-src/typescript/how-to-run-a-worker-on-docker.md
@@ -11,16 +11,16 @@ tags:
 
 Workers based on the TypeScript SDK can be deployed and run as Docker containers.
 
-At this moment, we recommend usage of Node.js 16.
-(Node.js 18 has known issues.)
+At this moment, we recommend using Node.js 18.
+(Node.js 20 has known issues.)
 Both `amd64` and `arm64` platforms are supported.
 A glibc-based image is required; musl-based images are _not_ supported (see below).
 
-The easiest way to deploy a TypeScript SDK Worker on Docker is to start with the `node:16-bullseye` image.
+The easiest way to deploy a TypeScript SDK Worker on Docker is to start with the `node:18-bullseye` image.
 For example:
 
 ```dockerfile
-FROM node:16-bullseye
+FROM node:18-bullseye
 
 COPY . /app
 WORKDIR /app
@@ -31,18 +31,20 @@ RUN npm install --only=production \
 CMD ["build/worker.js"]
 ```
 
-For smaller images and/or more secure deployments, it is also possible to use `-slim` Docker image variants (like `node:16-bullseye-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs:16`) with the following caveats.
+For smaller images and/or more secure deployments, it is also possible to use `-slim` Docker image variants (like `node:18-bullseye-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs:18`) with the following caveats.
 
 ### Using `node:slim` images
 
 `node:slim` images do not contain some of the common packages found in regular images. This results in significantly smaller images.
 
-However, TypeScript SDK requires the presence of root TLS certificates (the `ca-certificates` package), which are not included in `slim` images. `ca-certificates` package is required even when connecting to a local Temporal Server or when using a server connection config that doesn't explicitly use TLS.
+However, TypeScript SDK requires the presence of root TLS certificates (the `ca-certificates` package), which are not included in `slim` images.
+The `ca-certificates` package is required even when connecting to a local Temporal Server or when using a server connection config that doesn't explicitly use TLS.
 
-For this reason, the `ca-certificates` package must be installed during the construction of the Docker image. For example:
+For this reason, the `ca-certificates` package must be installed during the construction of the Docker image.
+For example:
 
 ```dockerfile
-FROM node:16-bulleyes-slim
+FROM node:18-bulleyes-slim
 
 RUN apt-get update \
     && apt-get install -y ca-certificates \
@@ -70,7 +72,7 @@ For example:
 ```dockerfile
 # -- BUILD STEP --
 
-FROM node:16-bulleyes AS builder
+FROM node:18-bulleyes AS builder
 
 COPY . /app
 WORKDIR /app
@@ -80,7 +82,7 @@ RUN npm install --only=production \
 
 # -- RESULTING IMAGE --
 
-FROM gcr.io/distroless/nodejs:16
+FROM gcr.io/distroless/nodejs:18
 
 COPY --from=builder /app /app
 WORKDIR /app

--- a/docs/dev-guide/tscript/debugging.md
+++ b/docs/dev-guide/tscript/debugging.md
@@ -24,7 +24,7 @@ You can debug production Workflows using:
 
 - [Web UI](/web-ui)
 - [tctl](/tctl-v1)
-- [Replay](#replay)
+- <a class="tdlp" href="/dev-guide/typescript/testing#replay">Replay<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">Testing</span><br /><br /><span class="tdlppd">The Testing section of the Temporal Application development guide describes the frameworks that facilitate Workflow and integration testing.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/dev-guide/typescript/testing#replay">Learn more</a></span></span></a>
 - <a class="tdlp" href="/dev-guide/typescript/observability#tracing">Tracing<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to setup Tracing</span><br /><br /><span class="tdlppd">Tracing allows you to view the call graph of a Workflow along with its Activities and any Child Workflows.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/dev-guide/typescript/observability#tracing">Learn more</a></span></span></a>
 - <a class="tdlp" href="/dev-guide/typescript/observability#logging">Logging<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to log from a Workflow</span><br /><br /><span class="tdlppd">Send logs and errors to a logging service, so that when things go wrong, you can see what happened.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/dev-guide/typescript/observability#logging">Learn more</a></span></span></a>
 

--- a/docs/dev-guide/tscript/foundations.md
+++ b/docs/dev-guide/tscript/foundations.md
@@ -708,16 +708,16 @@ This is a selected subset of options you are likely to use. Even more advanced o
 
 Workers based on the TypeScript SDK can be deployed and run as Docker containers.
 
-At this moment, we recommend usage of Node.js 16.
-(Node.js 18 has known issues.)
+At this moment, we recommend using Node.js 18.
+(Node.js 20 has known issues.)
 Both `amd64` and `arm64` platforms are supported.
 A glibc-based image is required; musl-based images are _not_ supported (see below).
 
-The easiest way to deploy a TypeScript SDK Worker on Docker is to start with the `node:16-bullseye` image.
+The easiest way to deploy a TypeScript SDK Worker on Docker is to start with the `node:18-bullseye` image.
 For example:
 
 ```dockerfile
-FROM node:16-bullseye
+FROM node:18-bullseye
 
 COPY . /app
 WORKDIR /app
@@ -728,18 +728,20 @@ RUN npm install --only=production \
 CMD ["build/worker.js"]
 ```
 
-For smaller images and/or more secure deployments, it is also possible to use `-slim` Docker image variants (like `node:16-bullseye-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs:16`) with the following caveats.
+For smaller images and/or more secure deployments, it is also possible to use `-slim` Docker image variants (like `node:18-bullseye-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs:18`) with the following caveats.
 
 ### Using `node:slim` images
 
 `node:slim` images do not contain some of the common packages found in regular images. This results in significantly smaller images.
 
-However, TypeScript SDK requires the presence of root TLS certificates (the `ca-certificates` package), which are not included in `slim` images. `ca-certificates` package is required even when connecting to a local Temporal Server or when using a server connection config that doesn't explicitly use TLS.
+However, TypeScript SDK requires the presence of root TLS certificates (the `ca-certificates` package), which are not included in `slim` images.
+The `ca-certificates` package is required even when connecting to a local Temporal Server or when using a server connection config that doesn't explicitly use TLS.
 
-For this reason, the `ca-certificates` package must be installed during the construction of the Docker image. For example:
+For this reason, the `ca-certificates` package must be installed during the construction of the Docker image.
+For example:
 
 ```dockerfile
-FROM node:16-bulleyes-slim
+FROM node:18-bulleyes-slim
 
 RUN apt-get update \
     && apt-get install -y ca-certificates \
@@ -767,7 +769,7 @@ For example:
 ```dockerfile
 # -- BUILD STEP --
 
-FROM node:16-bulleyes AS builder
+FROM node:18-bulleyes AS builder
 
 COPY . /app
 WORKDIR /app
@@ -777,7 +779,7 @@ RUN npm install --only=production \
 
 # -- RESULTING IMAGE --
 
-FROM gcr.io/distroless/nodejs:16
+FROM gcr.io/distroless/nodejs:18
 
 COPY --from=builder /app /app
 WORKDIR /app

--- a/docs/dev-guide/tscript/foundations.md
+++ b/docs/dev-guide/tscript/foundations.md
@@ -43,6 +43,7 @@ In this section you can find the following:
 - <a class="tdlp" href="#develop-activities">Develop an Activity<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to develop a basic Activity</span><br /><br /><span class="tdlppd">One of the primary things that Workflows do is orchestrate the execution of Activities.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#develop-activities">Learn more</a></span></span></a>
 - <a class="tdlp" href="#activity-execution">Start an Activity Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to start an Activity Execution</span><br /><br /><span class="tdlppd">Calls to spawn Activity Executions are written within a Workflow Definition.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#activity-execution">Learn more</a></span></span></a>
 - <a class="tdlp" href="#run-a-dev-worker">Run a dev Worker<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to run Worker Processes</span><br /><br /><span class="tdlppd">The Worker Process is where Workflow Functions and Activity Functions are executed.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#run-a-dev-worker">Learn more</a></span></span></a>
+- <a class="tdlp" href="#run-a-worker-on-docker">Run a Worker on Docker<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to run a Worker on Docker in TypeScript</span><br /><br /><span class="tdlppd">Workers based on the TypeScript SDK can be deployed and run as Docker containers.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#run-a-worker-on-docker">Learn more</a></span></span></a>
 - <a class="tdlp" href="#run-a-dev-worker">Run a Temporal Cloud Worker<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to run Worker Processes</span><br /><br /><span class="tdlppd">The Worker Process is where Workflow Functions and Activity Functions are executed.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#run-a-dev-worker">Learn more</a></span></span></a>
 - <a class="tdlp" href="#start-workflow-execution">Start a Workflow Execution<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to start a Workflow Execution</span><br /><br /><span class="tdlppd">Workflow Execution semantics rely on several parameters—that is, to start a Workflow Execution you must supply a Task Queue that will be used for the Tasks (one that a Worker is polling), the Workflow Type, language-specific contextual data, and Workflow Function parameters.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#start-workflow-execution">Learn more</a></span></span></a>
 
@@ -702,6 +703,112 @@ This is a selected subset of options you are likely to use. Even more advanced o
 **Operation guides:**
 
 - [How to tune Workers](/dev-guide/worker-performance)
+
+## Run a Worker on Docker
+
+Workers based on the TypeScript SDK can be deployed and run as Docker containers.
+
+At this moment, we recommend usage of Node.js 16.
+(Node.js 18 has known issues.)
+Both `amd64` and `arm64` platforms are supported.
+A glibc-based image is required; musl-based images are _not_ supported (see below).
+
+The easiest way to deploy a TypeScript SDK Worker on Docker is to start with the `node:16-bullseye` image.
+For example:
+
+```dockerfile
+FROM node:16-bullseye
+
+COPY . /app
+WORKDIR /app
+
+RUN npm install --only=production \
+    && npm run build
+
+CMD ["build/worker.js"]
+```
+
+For smaller images and/or more secure deployments, it is also possible to use `-slim` Docker image variants (like `node:16-bullseye-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs:16`) with the following caveats.
+
+### Using `node:slim` images
+
+`node:slim` images do not contain some of the common packages found in regular images. This results in significantly smaller images.
+
+However, TypeScript SDK requires the presence of root TLS certificates (the `ca-certificates` package), which are not included in `slim` images. `ca-certificates` package is required even when connecting to a local Temporal Server or when using a server connection config that doesn't explicitly use TLS.
+
+For this reason, the `ca-certificates` package must be installed during the construction of the Docker image. For example:
+
+```dockerfile
+FROM node:16-bulleyes-slim
+
+RUN apt-get update \
+    && apt-get install -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ... same as with regular image
+```
+
+Failure to install this dependency results in a `[TransportError: transport error]` runtime error, because the certificates cannot be verified.
+
+### Using `distroless/nodejs` images
+
+`distroless/nodejs` images include only the files that are strictly required to execute `node`.
+This results in even smaller images (approximately half the size of `node:slim` images).
+It also significantly reduces the surface of potential security issues that could be exploited by a hacker in the resulting Docker images.
+
+It is generally possible and safe to execute TypeScript SDK Workers using `distroless/nodejs` images (unless your code itself requires dependencies that are not included in `distroless/nodejs`).
+
+However, some tools required for the build process (notably the `npm` command) are _not_ included in the `distroless/nodejs` image.
+This might result in various error messages during the Docker build.
+
+The recommanded solution is to use a multi-step Dockerfile.
+For example:
+
+```dockerfile
+# -- BUILD STEP --
+
+FROM node:16-bulleyes AS builder
+
+COPY . /app
+WORKDIR /app
+
+RUN npm install --only=production \
+    && npm run build
+
+# -- RESULTING IMAGE --
+
+FROM gcr.io/distroless/nodejs:16
+
+COPY --from=builder /app /app
+WORKDIR /app
+
+CMD ["build/worker.js"]
+```
+
+### Properly configure Node.js memory in Docker
+
+By default, `node` configures its maximum old-gen memory to 25% of the _physical memory_ of the machine on which it is executing, with a maximum of 4 GB.
+This is likely inappropriate when running Node.js in a Docker environment and can result in either underusage of available memory (`node` only uses a fraction of the memory allocated to the container) or overusage (`node` tries to use more memory than what is allocated to the container, which will eventually lead to the process being killed by the operating system).
+
+Therefore we recommended that you always explicitly set the `--max-old-space-size` `node` argument to approximately 80% of the maximum size (in megabytes) that you want to allocate the `node` process.
+You might need some experimentation and adjustment to find the most appropriate value based on your specific application.
+
+In practice, it is generally easier to provide this argument through the [`NODE_OPTIONS` environment variable](https://nodejs.org/api/cli.html#node_optionsoptions).
+
+### Do not use Alpine
+
+Alpine replaces glibc with musl, which is incompatible with the Rust core of the TypeScript SDK.
+If you receive errors like the following, it's probably because you are using Alpine.
+
+```sh
+Error: Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by /opt/app/node_modules/@temporalio/core-bridge/index.node)
+```
+
+Or like this:
+
+```sh
+Error: Error relocating /opt/app/node_modules/@temporalio/core-bridge/index.node: __register_atfork: symbol not found
+```
 
 ## Run a Temporal Cloud Worker
 


### PR DESCRIPTION
## What does this PR do?

- Migrates content wholesale from the "Running in Docker" section of the legacy page "Production Deploy Checklist for TypeScript SDK" into the TypeScript SDK developer's guide.
- Fixes a broken link in the "Debugging" section of  the TypeScript SDK developer's guide.

## Notes to reviewers

This PR only migrates content. Reviewing and updating the content is out of scope and can be addressed separately.
