### PR TITLE
EDU-769: Migrate legacy TypeScript Local Activity content into dev guide

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,14 +1,14 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday June 08 2023 15:58:18 PM -0700
+Last assembled: Monday June 12 2023 17:10:59 PM -0700
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly-dail-macbook
 
 86 guide configurations found.
 
-1448 information nodes found.
+1449 information nodes found.
 
-1204 information nodes are attached to guides.
+1205 information nodes are attached to guides.
 
 The "Link Magic" Activity transformed the following "information node" identifiers into site paths:
 

--- a/assembly/guide-configs/app-dev/typescript/features.json
+++ b/assembly/guide-configs/app-dev/typescript/features.json
@@ -149,6 +149,10 @@
     },
     {
       "type": "h2",
+      "id": "typescript/local-activities"
+    },
+    {
+      "type": "h2",
       "id": "typescript/cancel-activity"
     },
     {

--- a/docs-src/typescript/local-activities.md
+++ b/docs-src/typescript/local-activities.md
@@ -1,0 +1,25 @@
+---
+id: local-activities
+title: Local Activities
+description: To call Local Activities in TypeScript, use proxyLocalActivities.
+sidebar_label: Local Activities
+tags:
+  - guide-context
+---
+
+To call [Local Activities](/concepts/what-is-a-local-activity/) in TypeScript, use [`proxyLocalActivities`](https://typescript.temporal.io/api/namespaces/workflow/#proxylocalactivities).
+
+```ts
+import * as workflow from '@temporalio/workflow';
+
+const { getEnvVar } = workflow.proxyLocalActivities({
+  startToCloseTimeout: '2 seconds',
+});
+
+export async function yourWorkflow(): Promise<void> {
+  const someSetting = await getEnvVar('SOME_SETTING');
+  // ...
+}
+```
+
+Local Activities must be registered with the Worker the same way non-local Activities are.

--- a/docs-src/typescript/local-activities.md
+++ b/docs-src/typescript/local-activities.md
@@ -7,7 +7,7 @@ tags:
   - guide-context
 ---
 
-To call [Local Activities](/concepts/what-is-a-local-activity/) in TypeScript, use [`proxyLocalActivities`](https://typescript.temporal.io/api/namespaces/workflow/#proxylocalactivities).
+To call [Local Activities](/concepts/what-is-a-local-activity) in TypeScript, use [`proxyLocalActivities`](https://typescript.temporal.io/api/namespaces/workflow/#proxylocalactivities).
 
 ```ts
 import * as workflow from '@temporalio/workflow';

--- a/docs/dev-guide/tscript/features.md
+++ b/docs/dev-guide/tscript/features.md
@@ -510,6 +510,25 @@ async function doSomeWork(taskToken: Uint8Array): Promise<void> {
 
 <!--SNIPEND-->
 
+## Local Activities
+
+To call <a class="tdlp" href="/activities#local-activity">Local Activities<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What is a Local Activity?</span><br /><br /><span class="tdlppd">A Local Activity is an Activity Execution that executes in the same process as the Workflow Execution that spawns it.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/activities#local-activity">Learn more</a></span></span></a> in TypeScript, use [`proxyLocalActivities`](https://typescript.temporal.io/api/namespaces/workflow/#proxylocalactivities).
+
+```ts
+import * as workflow from '@temporalio/workflow';
+
+const { getEnvVar } = workflow.proxyLocalActivities({
+  startToCloseTimeout: '2 seconds',
+});
+
+export async function yourWorkflow(): Promise<void> {
+  const someSetting = await getEnvVar('SOME_SETTING');
+  // ...
+}
+```
+
+Local Activities must be registered with the Worker the same way non-local Activities are.
+
 ## Cancel an Activity
 
 Canceling an Activity from within a Workflow requires that the Activity Execution sends Heartbeats and sets a Heartbeat Timeout.


### PR DESCRIPTION
## What does this PR do?

Migrates legacy content [Local Activities (experimental)](https://legacy-documentation-sdks.temporal.io/typescript/activities#local-activities-experimental) to the TypeScript SDK developer's guide.
