### PR TITLE
EDU-826: Migrate legacy ECMAScript modules content into TypeScript dev guide

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday June 20 2023 11:29:49 AM -0700
+Last assembled: Tuesday June 20 2023 11:48:17 AM -0700
 
 Assembly Workflow Id: docs-full-assembly-dail-macbook
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday June 20 2023 10:48:02 AM -0700
+Last assembled: Tuesday June 20 2023 11:29:49 AM -0700
 
 Assembly Workflow Id: docs-full-assembly-dail-macbook
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,14 +1,14 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday June 19 2023 12:15:33 PM -0700
+Last assembled: Tuesday June 20 2023 10:48:02 AM -0700
 
-Assembly Workflow Id: docs-full-assembly
+Assembly Workflow Id: docs-full-assembly-dail-macbook
 
 87 guide configurations found.
 
-1461 information nodes found.
+1462 information nodes found.
 
-1221 information nodes are attached to guides.
+1222 information nodes are attached to guides.
 
 The "Link Magic" Activity transformed the following "information node" identifiers into site paths:
 

--- a/assembly/guide-configs/app-dev/typescript/foundations.json
+++ b/assembly/guide-configs/app-dev/typescript/foundations.json
@@ -133,6 +133,10 @@
     },
     {
       "type": "h3",
+      "id": "typescript/activity-import-esm"
+    },
+    {
+      "type": "h3",
       "id": "typescript/activity-design-patterns"
     },
     {

--- a/assembly/guide-configs/app-dev/typescript/foundations.json
+++ b/assembly/guide-configs/app-dev/typescript/foundations.json
@@ -40,6 +40,10 @@
       "id": "typescript/code-samples-typescript"
     },
     {
+      "type": "h3",
+      "id": "typescript/how-to-import-an-ecmascript-module"
+    },
+    {
       "type": "h2",
       "id": "typescript/linting-and-types"
     },
@@ -130,10 +134,6 @@
     {
       "type": "p",
       "id": "typescript/how-to-customize-activity-type-in-typescript"
-    },
-    {
-      "type": "h3",
-      "id": "typescript/how-to-import-an-ecmascript-module"
     },
     {
       "type": "h3",

--- a/assembly/guide-configs/app-dev/typescript/foundations.json
+++ b/assembly/guide-configs/app-dev/typescript/foundations.json
@@ -133,7 +133,7 @@
     },
     {
       "type": "h3",
-      "id": "typescript/activity-import-esm"
+      "id": "typescript/how-to-import-an-ecmascript-module"
     },
     {
       "type": "h3",

--- a/docs-src/typescript/how-to-import-an-ecmascript-module.md
+++ b/docs-src/typescript/how-to-import-an-ecmascript-module.md
@@ -7,9 +7,10 @@ tags:
   - guide-context
 ---
 
-The JavaScript ecosystem is increasingly moving toward publishing ECMAScript modules (ESM) instead of CommonJS modules; for example, `node-fetch@3` is ESM, but `node-fetch@2` is CommonJS.
+The JavaScript ecosystem is quickly moving toward publishing ECMAScript modules (ESM) instead of CommonJS modules.
+For example, `node-fetch@3` is ESM, but `node-fetch@2` is CommonJS.
 
-If you want to import a pure ESM dependency, see our [Fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample for the necessary configuration changes:
+For more information about importing a pure ESM dependency, see our [Fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample for the necessary configuration changes:
 
 - `package.json` must have include the `"type": "module"` attribute.
 - `tsconfig.json` should output in `esnext` format.

--- a/docs-src/typescript/how-to-import-an-ecmascript-module.md
+++ b/docs-src/typescript/how-to-import-an-ecmascript-module.md
@@ -1,0 +1,16 @@
+---
+id: how-to-import-an-ecmascript-module
+title: How to import an ECMAScript module
+sidebar_label: ECMAScript modules
+description: See our Fetch ESM sample for the necessary configuration changes.
+tags:
+  - guide-context
+---
+
+The JavaScript ecosystem is increasingly moving toward publishing ECMAScript modules (ESM) instead of CommonJS modules; for example, `node-fetch@3` is ESM, but `node-fetch@2` is CommonJS.
+
+If you want to import a pure ESM dependency, see our [Fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample for the necessary configuration changes:
+
+- `package.json` must have include the `"type": "module"` attribute.
+- `tsconfig.json` should output in `esnext` format.
+- Imports must include the `.js` file extension.

--- a/docs/dev-guide/tscript/foundations.md
+++ b/docs/dev-guide/tscript/foundations.md
@@ -530,6 +530,16 @@ async function run() {
 
 <!--SNIPEND-->
 
+### ECMAScript modules
+
+The JavaScript ecosystem is increasingly moving toward publishing ECMAScript modules (ESM) instead of CommonJS modules; for example, `node-fetch@3` is ESM, but `node-fetch@2` is CommonJS.
+
+If you want to import a pure ESM dependency, see our [Fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample for the necessary configuration changes:
+
+- `package.json` must have include the `"type": "module"` attribute.
+- `tsconfig.json` should output in `esnext` format.
+- Imports must include the `.js` file extension.
+
 ### Activity design patterns
 
 The following are some important (and frequently requested) patterns for using our Activities APIs.

--- a/docs/dev-guide/tscript/foundations.md
+++ b/docs/dev-guide/tscript/foundations.md
@@ -532,9 +532,10 @@ async function run() {
 
 ### ECMAScript modules
 
-The JavaScript ecosystem is increasingly moving toward publishing ECMAScript modules (ESM) instead of CommonJS modules; for example, `node-fetch@3` is ESM, but `node-fetch@2` is CommonJS.
+The JavaScript ecosystem is quickly moving toward publishing ECMAScript modules (ESM) instead of CommonJS modules.
+For example, `node-fetch@3` is ESM, but `node-fetch@2` is CommonJS.
 
-If you want to import a pure ESM dependency, see our [Fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample for the necessary configuration changes:
+For more information about importing a pure ESM dependency, see our [Fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample for the necessary configuration changes:
 
 - `package.json` must have include the `"type": "module"` attribute.
 - `tsconfig.json` should output in `esnext` format.

--- a/docs/dev-guide/tscript/foundations.md
+++ b/docs/dev-guide/tscript/foundations.md
@@ -180,6 +180,17 @@ Use the [TypeScript samples library](https://github.com/temporalio/samples-types
 
 [Temporal TypeScript YouTube playlist](https://www.youtube.com/playlist?list=PLl9kRkvFJrlTavecydpk9r6cF7qBmQJvb).
 
+### ECMAScript modules
+
+The JavaScript ecosystem is quickly moving toward publishing ECMAScript modules (ESM) instead of CommonJS modules.
+For example, `node-fetch@3` is ESM, but `node-fetch@2` is CommonJS.
+
+For more information about importing a pure ESM dependency, see our [Fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample for the necessary configuration changes:
+
+- `package.json` must have include the `"type": "module"` attribute.
+- `tsconfig.json` should output in `esnext` format.
+- Imports must include the `.js` file extension.
+
 ## Linting and types
 
 If you started your project with `@temporalio/create`, you already have our recommended TypeScript and ESLint configurations.
@@ -529,17 +540,6 @@ async function run() {
 ```
 
 <!--SNIPEND-->
-
-### ECMAScript modules
-
-The JavaScript ecosystem is quickly moving toward publishing ECMAScript modules (ESM) instead of CommonJS modules.
-For example, `node-fetch@3` is ESM, but `node-fetch@2` is CommonJS.
-
-For more information about importing a pure ESM dependency, see our [Fetch ESM](https://github.com/temporalio/samples-typescript/tree/main/fetch-esm) sample for the necessary configuration changes:
-
-- `package.json` must have include the `"type": "module"` attribute.
-- `tsconfig.json` should output in `esnext` format.
-- Imports must include the `.js` file extension.
 
 ### Activity design patterns
 


### PR DESCRIPTION
## What does this PR do?

Migrates legacy content [Using pure ESM Node Modules](https://legacy-documentation-sdks.temporal.io/typescript/activities#using-pure-esm-node-modules) to the TypeScript SDK developer's guide.

## Notes to reviewers

This PR only migrates content. Reviewing and updating the content is out of scope and can be addressed separately.