### PR TITLE
EDU-839: Migrate TypeScript single-entity pattern to dev guide

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,14 +1,14 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday June 20 2023 13:57:41 PM -0700
+Last assembled: Wednesday June 21 2023 15:46:09 PM -0700
 
-Assembly Workflow Id: docs-full-assembly-flossypurse
+Assembly Workflow Id: docs-full-assembly-dail-macbook
 
 87 guide configurations found.
 
-1462 information nodes found.
+1464 information nodes found.
 
-1221 information nodes are attached to guides.
+1226 information nodes are attached to guides.
 
 The "Link Magic" Activity transformed the following "information node" identifiers into site paths:
 

--- a/assembly/guide-configs/app-dev/typescript/features.json
+++ b/assembly/guide-configs/app-dev/typescript/features.json
@@ -168,7 +168,7 @@
       "id": "typescript/how-to-spawn-a-child-workflow-execution-in-typescript"
     },
     {
-      "type": "h4",
+      "type": "h3",
       "id": "typescript/parent-close-policy"
     },
     {
@@ -182,6 +182,10 @@
     {
       "type": "p",
       "id": "typescript/how-to-continue-as-new-in-typescript"
+    },
+    {
+      "type": "h3",
+      "id": "typescript/single-entity-pattern"
     },
     {
       "type": "h2",

--- a/docs-src/typescript/async-design-patterns.md
+++ b/docs-src/typescript/async-design-patterns.md
@@ -1,7 +1,7 @@
 ---
 id: async-design-patterns
 title: Asynchronous design patterns in TypeScript
-description: TKTKTK.
+description: Examples that demonstrate how to use `sleep` and `condition` to model asynchronous business logic.
 sidebar_label: Asynchronous design patterns
 tags:
   - guide-context

--- a/docs-src/typescript/single-entity-pattern.md
+++ b/docs-src/typescript/single-entity-pattern.md
@@ -1,0 +1,58 @@
+---
+id: single-entity-pattern
+title: Single-entity design pattern in TypeScript
+description: An example that demonstrates how to represent a single entity with a Workflow.
+sidebar_label: Single-entity pattern
+tags:
+  - guide-context
+---
+
+The following is a simple pattern that represents a single entity.
+It tracks the number of iterations regardless of frequency, and calls `continueAsNew` while properly handling pending updates from Signals.
+
+```tsx
+interface Input {
+  /* Define your Workflow input type here */
+}
+interface Update {
+  /* Define your Workflow update type here */
+}
+
+const MAX_ITERATIONS = 1;
+
+export async function entityWorkflow(
+  input: Input,
+  isNew = true,
+): Promise<void> {
+  try {
+    const pendingUpdates = Array<Update>();
+    setHandler(updateSignal, (updateCommand) => {
+      pendingUpdates.push(updateCommand);
+    });
+
+    if (isNew) {
+      await setup(input);
+    }
+
+    for (let iteration = 1; iteration <= MAX_ITERATIONS; ++iteration) {
+      // Ensure that we don't block the Workflow Execution forever waiting
+      // for updates, which means that it will eventually Continue-As-New
+      // even if it does not receive updates.
+      await condition(() => pendingUpdates.length > 0, '1 day');
+
+      while (pendingUpdates.length) {
+        const update = pendingUpdates.shift();
+        await runAnActivityOrChildWorkflow(update);
+      }
+    }
+  } catch (err) {
+    if (isCancellation(err)) {
+      await CancellationScope.nonCancellable(async () => {
+        await cleanup();
+      });
+    }
+    throw err;
+  }
+  await continueAsNew<typeof entityWorkflow>(input, false);
+}
+```


### PR DESCRIPTION
## What does this PR do?

Migrates legacy content single-entity [Example](https://legacy-documentation-sdks.temporal.io/typescript/workflows#example) to the TypeScript SDK developer's guide.

Bonus: Also adds missing `description` metadata to `docs-src/typescript/async-design-patterns.md`. (I missed it in #2116.)

## Notes to reviewers

This PR only migrates content and addresses an earlier oversight. Reviewing and updating the content is out of scope and can be addressed separately.