### PR TITLE
remove metric temporal_cloud_v0_frontend_service_pending_requests

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Friday July 07 2023 13:24:03 PM -0600
+Last assembled: Saturday July 08 2023 20:56:58 PM +0200
 
-Assembly Workflow Id: docs-full-assembly-flossypurse
+Assembly Workflow Id: docs-full-assembly
 
 88 guide configurations found.
 

--- a/docs-src/cloud-context/how-to-monitor-temporal-cloud-metrics.md
+++ b/docs-src/cloud-context/how-to-monitor-temporal-cloud-metrics.md
@@ -85,7 +85,6 @@ To disable a metrics endpoint, use [`tcld account metrics disable`](/cloud/tcld/
 Temporal tracks the following metrics for your various Namespaces.
 
 - temporal_cloud_v0_frontend_service_error_count
-- temporal_cloud_v0_frontend_service_pending_requests
 - temporal_cloud_v0_frontend_service_request_count
 - temporal_cloud_v0_poll_success_count
 - temporal_cloud_v0_poll_success_sync_count


### PR DESCRIPTION
## What does this PR do?

Remove metric temporal_cloud_v0_frontend_service_pending_requests, added by mistake, please see https://github.com/temporalio/documentation/pull/2189 


## Notes to reviewers

<!-- delete if n/a -->
