### PR TITLE
EDU-958: fix cluster default limits

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday July 20 2023 14:34:56 PM -0500
+Last assembled: Friday July 21 2023 13:51:38 PM +0200
 
 Assembly Workflow Id: docs-full-assembly
 
@@ -702,6 +702,8 @@ python/connect-to-temporal-cloud -> /dev-guide/python/foundations#connect-to-tem
 
 typescript/connect-to-temporal-cloud -> /dev-guide/typescript/foundations#connect-to-temporal-cloud
 
+cloud-context/certificates-filters -> #manage-certificate-filters
+
 concepts/what-is-a-cloud-namespace-id -> /cloud/index#temporal-cloud-namespace-id
 
 cli/cmd-options/activity-id -> /cli/cmd-options#activity-id
@@ -957,7 +959,5 @@ go/selectors -> /dev-guide/go/features#selectors
 go/how-to-customize-workflow-type-in-go -> #customize-workflow-type
 
 go/how-to-customize-activity-type-in-go -> #customize-activity-type
-
-cloud-context/certificates-filters -> #manage-certificate-filters
 
 

--- a/kb/temporal-platform-limits-sheet.md
+++ b/kb/temporal-platform-limits-sheet.md
@@ -41,7 +41,7 @@ Warnings are soft limits that produce a warning log on the server side.
     - `SignalExternalWorkflowExecution`
     - `RequestCancelExternalWorkflowExecution`
     - `StartChildWorkflowExecution`
-  - The open source Temporal Cluster has a default limit of 2,000 pending Activities, Child Workflows, Signals, or Workflow cancellation requests, but you can override the limits in the dynamic configuration using these variables:
+  - As of v1.21, the open source Temporal Cluster has a default limit of 2,000 pending Activities, Child Workflows, Signals, or Workflow cancellation requests, but you can override the limits in the dynamic configuration using these variables:
     - `limit.numPendingActivities.error`
     - `limit.numPendingSignals.error`
     - `limit.numPendingCancelRequests.error`

--- a/kb/temporal-platform-limits-sheet.md
+++ b/kb/temporal-platform-limits-sheet.md
@@ -41,7 +41,7 @@ Warnings are soft limits that produce a warning log on the server side.
     - `SignalExternalWorkflowExecution`
     - `RequestCancelExternalWorkflowExecution`
     - `StartChildWorkflowExecution`
-  - The open source Temporal Cluster has a default limit of 50,000 pending Activities, Child Workflows, Signals, or Workflow cancellation requests, but you can override the limits in the dynamic configuration using these variables:
+  - The open source Temporal Cluster has a default limit of 2,000 pending Activities, Child Workflows, Signals, or Workflow cancellation requests, but you can override the limits in the dynamic configuration using these variables:
     - `limit.numPendingActivities.error`
     - `limit.numPendingSignals.error`
     - `limit.numPendingCancelRequests.error`


### PR DESCRIPTION
## What does this PR do?

I think cluster default limits is 2000 for pending activities, child workflows ... . Please see https://github.com/temporalio/temporal/blob/00587f605637703d13ba6191486d054ef5a1ef1c/service/history/configs/config.go#L461 

## Notes to reviewers

[added by Dail]  Code change occurred in https://github.com/temporalio/temporal/pull/4326.
