### PR TITLE
EDU-503: Add explanation about notifications of upcoming certificate expirations

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,14 +1,14 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday August 14 2023 13:22:42 PM -0500
+Last assembled: Monday August 14 2023 16:50:29 PM -0700
 
-Assembly Workflow Id: docs-full-assembly
+Assembly Workflow Id: docs-full-assembly-dail-macbook
 
 93 guide configurations found.
 
-1518 information nodes found.
+1519 information nodes found.
 
-1282 information nodes are attached to guides.
+1283 information nodes are attached to guides.
 
 The "Link Magic" Activity transformed the following "information node" identifiers into site paths:
 
@@ -716,6 +716,10 @@ cloud/certificates-filters -> #manage-certificate-filters
 
 cloud/users-namespace-level-permissions -> /cloud/users#namespace-level-permissions
 
+cloud/support-create-ticket -> /cloud/support#support-ticket
+
+cloud/certificates-notifications -> #expiration-notifications
+
 cloud/namespaces-access -> #access-namespaces
 
 cloud/namespaces-manage -> #manage-namespaces
@@ -725,8 +729,6 @@ cloud/namespaces-delete -> #delete-a-namespace
 concepts/what-is-a-cloud-namespace-name -> #temporal-cloud-namespace-name
 
 concepts/what-is-a-cloud-account-id -> #temporal-cloud-account-id
-
-cloud/support-create-ticket -> /cloud/support#support-ticket
 
 concepts/what-is-a-cloud-namespace-id -> #temporal-cloud-namespace-id
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday August 15 2023 09:40:20 AM -0700
+Last assembled: Tuesday August 15 2023 09:47:05 AM -0700
 
 Assembly Workflow Id: docs-full-assembly-dail-macbook
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday August 15 2023 09:47:05 AM -0700
+Last assembled: Tuesday August 15 2023 15:11:36 PM -0700
 
 Assembly Workflow Id: docs-full-assembly-dail-macbook
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday August 14 2023 16:50:29 PM -0700
+Last assembled: Tuesday August 15 2023 09:40:20 AM -0700
 
 Assembly Workflow Id: docs-full-assembly-dail-macbook
 
@@ -711,6 +711,8 @@ go/connect-to-temporal-cloud -> /dev-guide/go/foundations#connect-to-temporal-cl
 python/connect-to-temporal-cloud -> /dev-guide/python/foundations#connect-to-temporal-cloud
 
 typescript/connect-to-temporal-cloud -> /dev-guide/typescript/foundations#connect-to-temporal-cloud
+
+cloud/certificates-namespace -> #manage-certificates
 
 cloud/certificates-filters -> #manage-certificate-filters
 

--- a/assembly/guide-configs/cloud/manage-certificates.json
+++ b/assembly/guide-configs/cloud/manage-certificates.json
@@ -29,6 +29,10 @@
     },
     {
       "type": "h2",
+      "id": "cloud/certificates-notifications"
+    },
+    {
+      "type": "h2",
       "id": "cloud/certificates-namespace"
     },
     {

--- a/docs-src/cloud/certificates-intro.md
+++ b/docs-src/cloud/certificates-intro.md
@@ -13,12 +13,13 @@ tags:
 
 Temporal Cloud access is secured by the mutual Transport Layer Security (mTLS) protocol, which requires a CA certificate from the user.
 
-[Worker Processes](/concepts/what-is-a-worker-process) require CA certificates and private keys to connect to Temporal Cloud.
+A [Worker Process](/concepts/what-is-a-worker-process) requires a CA certificate and private key to connect to Temporal Cloud.
 Temporal Cloud does not require an exchange of secrets; only the certificates produced by private keys are used for verification.
 
 :::caution Don't let your certificates expire
 
 An expired root CA certificate invalidates all downstream certificates.
+
 An expired end-entity certificate prevents a [Temporal Client](/concepts/what-is-a-temporal-client) from connecting to a Namespace or starting a Workflow Execution.
 If the client is on a Worker, any current Workflow Executions that are processed by that Worker either run indefinitely without making progress until the Worker resumes or fail because of timeouts.
 

--- a/docs-src/cloud/certificates-intro.md
+++ b/docs-src/cloud/certificates-intro.md
@@ -13,7 +13,17 @@ tags:
 
 Temporal Cloud access is secured by the mutual Transport Layer Security (mTLS) protocol, which requires a CA certificate from the user.
 
-[Worker Processes](/workers/#worker-process) require CA certificates and private keys to connect to Temporal Cloud.
+[Worker Processes](/concepts/what-is-a-worker-process) require CA certificates and private keys to connect to Temporal Cloud.
 Temporal Cloud does not require an exchange of secrets; only the certificates produced by private keys are used for verification.
+
+:::caution Don't let your certificates expire
+
+An expired root CA certificate invalidates all downstream certificates.
+An expired end-entity certificate prevents a [Temporal Client](/concepts/what-is-a-temporal-client) from connecting to a Namespace or starting a Workflow Execution.
+If the client is on a Worker, any current Workflow Executions that are processed by that Worker either run indefinitely without making progress until the Worker resumes or fail because of timeouts.
+
+To update certificates, see [How to add, update, and remove certificates in a Temporal Cloud Namespace](/cloud/certificates-namespace).
+
+:::
 
 All certificates used by Temporal Cloud must meet the following requirements.

--- a/docs-src/cloud/certificates-namespace.md
+++ b/docs-src/cloud/certificates-namespace.md
@@ -19,8 +19,10 @@ To manage certificates for Temporal Cloud Namespaces, use the **Namespaces** pag
 
 Don't let your certificates expire!
 Add reminders to your calendar to issue new CA certificates well before the expiration dates of the existing ones.
+Temporal Cloud begins sending notifications 15 days before expiration.
+For details, see the previous section ([How to receive notifications about certificate expiration](/cloud/certificates-notifications)).
 
-When updating CA certificates, it's important to follow a rollover process.
+When updating CA certificates, it's important to follow a rollover process (sometimes referred to as "certificatev rotation").
 Doing so enables your Namespace to serve both CA certificates for a period of time until traffic to your old CA certificate ceases.
 
 Be aware that the subject of the existing certificate and the subject of the new certificate must not be identical.

--- a/docs-src/cloud/certificates-namespace.md
+++ b/docs-src/cloud/certificates-namespace.md
@@ -22,7 +22,7 @@ Add reminders to your calendar to issue new CA certificates well before the expi
 Temporal Cloud begins sending notifications 15 days before expiration.
 For details, see the previous section ([How to receive notifications about certificate expiration](/cloud/certificates-notifications)).
 
-When updating CA certificates, it's important to follow a rollover process (sometimes referred to as "certificatev rotation").
+When updating CA certificates, it's important to follow a rollover process (sometimes referred to as "certificate rotation").
 Doing so enables your Namespace to serve both CA certificates for a period of time until traffic to your old CA certificate ceases.
 
 Be aware that the subject of the existing certificate and the subject of the new certificate must not be identical.

--- a/docs-src/cloud/certificates-notifications.md
+++ b/docs-src/cloud/certificates-notifications.md
@@ -19,4 +19,4 @@ To ensure that you receive email notifications, configure your junk-email filter
 
 After a support ticket is created, admins should expect a follow-up from the Temporal Developer Success team.
 
-To change who receives certificate notifications for a Namespace (or to provide feedback about notifications), [create a support ticket](/cloud/support-create-ticket).
+To change who receives certificate-expiration notifications for a Namespace (or to provide feedback about such notifications), [create a support ticket](/cloud/support-create-ticket).

--- a/docs-src/cloud/certificates-notifications.md
+++ b/docs-src/cloud/certificates-notifications.md
@@ -13,8 +13,10 @@ To keep your Namespace secure and online, you must update the CA certificate for
 
 To help you remember to do so, Temporal Cloud sends email notifications to users who have the Global Admin [Role](/cloud/users-account-level-roles) or the Namespace Admin [permission](/cloud/users-namespace-level-permissions) 15 days before expiration and, if necessary, 10 days before expiration.
 
-If the certificate is not updated, 5 days before expiration Temporal Cloud creates a [support ticket](/cloud/support-create-ticket) on behalf of the Global Admins and Namespace Admins.
+If the certificate is not updated, 5 days before expiration Temporal Cloud creates a support ticket on behalf of the Global Admins and Namespace Admins.
 
 To ensure that you receive email notifications, configure your junk-email filters to permit email from `noreply@temporal.io`.
 
 After a support ticket is created, admins should expect a follow-up from the Temporal Developer Success team.
+
+To change who receives certificate notifications for a Namespace (or to provide feedback about notifications), [create a support ticket](/cloud/support-create-ticket).

--- a/docs-src/cloud/certificates-notifications.md
+++ b/docs-src/cloud/certificates-notifications.md
@@ -1,0 +1,20 @@
+---
+id: certificates-notifications
+title: How to receive notifications about certificate expiration
+sidebar_label: Expiration notifications
+description: Temporal Cloud sends notifications when a certificate is close to expiration.
+tags:
+  - how-to
+  - temporal cloud
+  - certificates
+---
+
+To keep your Namespace secure and online, you must update the CA certificate for the Namespace _before_ the certificate expires.
+
+To help you remember to do so, Temporal Cloud sends email notifications to users who have the Global Admin [Role](/cloud/users-account-level-roles) or the Namespace Admin [permission](/cloud/users-namespace-level-permissions) 15 days before expiration and, if necessary, 10 days before expiration.
+
+If the certificate is not updated, 5 days before expiration Temporal Cloud creates a [support ticket](/cloud/support-create-ticket) on behalf of the Global Admins and Namespace Admins.
+
+To ensure that you receive email notifications, configure your junk-email filters to permit email from `noreply@temporal.io`.
+
+After a support ticket is created, admins should expect a follow-up from the Temporal Developer Success team.

--- a/docs/cloud/account-setup/certificates.md
+++ b/docs/cloud/account-setup/certificates.md
@@ -26,8 +26,18 @@ tags:
 
 Temporal Cloud access is secured by the mutual Transport Layer Security (mTLS) protocol, which requires a CA certificate from the user.
 
-[Worker Processes](/workers/#worker-process) require CA certificates and private keys to connect to Temporal Cloud.
+<a class="tdlp" href="/workers#worker-process">Worker Processes<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What is a Worker Process?</span><br /><br /><span class="tdlppd">A Worker Process is responsible for polling a Task Queue, dequeueing a Task, executing your code in response to a Task, and responding to the Temporal Server with the results.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/workers#worker-process">Learn more</a></span></span></a> require CA certificates and private keys to connect to Temporal Cloud.
 Temporal Cloud does not require an exchange of secrets; only the certificates produced by private keys are used for verification.
+
+:::caution Don't let your certificates expire
+
+An expired root CA certificate invalidates all downstream certificates.
+An expired end-entity certificate prevents a <a class="tdlp" href="/temporal#temporal-client">Temporal Client<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What is a Temporal Client?</span><br /><br /><span class="tdlppd">A Temporal Client, provided by a Temporal SDK, provides a set of APIs to communicate with a Temporal Cluster.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/temporal#temporal-client">Learn more</a></span></span></a> from connecting to a Namespace or starting a Workflow Execution.
+If the client is on a Worker, any current Workflow Executions that are processed by that Worker either run indefinitely without making progress until the Worker resumes or fail because of timeouts.
+
+To update certificates, see <a class="tdlp" href="#manage-certificates">How to add, update, and remove certificates in a Temporal Cloud Namespace<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to add, update, and remove certificates in a Temporal Cloud Namespace</span><br /><br /><span class="tdlppd">To manage certificates for Temporal Cloud Namespaces, use the `tcld namespace accepted-client-ca` commands.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#manage-certificates">Learn more</a></span></span></a>.
+
+:::
 
 All certificates used by Temporal Cloud must meet the following requirements.
 
@@ -186,11 +196,13 @@ To keep your Namespace secure and online, you must update the CA certificate for
 
 To help you remember to do so, Temporal Cloud sends email notifications to users who have the Global Admin <a class="tdlp" href="/cloud/users#account-level-roles">Role<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What are the account-level Roles for users in Temporal Cloud?</span><br /><br /><span class="tdlppd">Account-level Roles are Global Admin, Developer, and Read-Only.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/users#account-level-roles">Learn more</a></span></span></a> or the Namespace Admin <a class="tdlp" href="/cloud/users#namespace-level-permissions">permission<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What are the Namespace-level permissions for users in Temporal Cloud?</span><br /><br /><span class="tdlppd">Namespace-level permissions are Namespace Admin, Write, and Read-Only.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/users#namespace-level-permissions">Learn more</a></span></span></a> 15 days before expiration and, if necessary, 10 days before expiration.
 
-If the certificate is not updated, 5 days before expiration Temporal Cloud creates a <a class="tdlp" href="/cloud/support#support-ticket">support ticket<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to create a ticket for Temporal Support</span><br /><br /><span class="tdlppd">To request assistance from Temporal Support, create a ticket in Zendesk.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/support#support-ticket">Learn more</a></span></span></a> on behalf of the Global Admins and Namespace Admins.
+If the certificate is not updated, 5 days before expiration Temporal Cloud creates a support ticket on behalf of the Global Admins and Namespace Admins.
 
 To ensure that you receive email notifications, configure your junk-email filters to permit email from `noreply@temporal.io`.
 
 After a support ticket is created, admins should expect a follow-up from the Temporal Developer Success team.
+
+To change who receives certificate notifications for a Namespace (or to provide feedback about notifications), <a class="tdlp" href="/cloud/support#support-ticket">create a support ticket<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to create a ticket for Temporal Support</span><br /><br /><span class="tdlppd">To request assistance from Temporal Support, create a ticket in Zendesk.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/support#support-ticket">Learn more</a></span></span></a>.
 
 ## How to add, update, and remove certificates in a Temporal Cloud Namespace {#manage-certificates}
 

--- a/docs/cloud/account-setup/certificates.md
+++ b/docs/cloud/account-setup/certificates.md
@@ -203,7 +203,7 @@ To ensure that you receive email notifications, configure your junk-email filter
 
 After a support ticket is created, admins should expect a follow-up from the Temporal Developer Success team.
 
-To change who receives certificate notifications for a Namespace (or to provide feedback about notifications), <a class="tdlp" href="/cloud/support#support-ticket">create a support ticket<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to create a ticket for Temporal Support</span><br /><br /><span class="tdlppd">To request assistance from Temporal Support, create a ticket in Zendesk.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/support#support-ticket">Learn more</a></span></span></a>.
+To change who receives certificate-expiration notifications for a Namespace (or to provide feedback about such notifications), <a class="tdlp" href="/cloud/support#support-ticket">create a support ticket<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to create a ticket for Temporal Support</span><br /><br /><span class="tdlppd">To request assistance from Temporal Support, create a ticket in Zendesk.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/support#support-ticket">Learn more</a></span></span></a>.
 
 ## How to add, update, and remove certificates in a Temporal Cloud Namespace {#manage-certificates}
 
@@ -220,7 +220,7 @@ Add reminders to your calendar to issue new CA certificates well before the expi
 Temporal Cloud begins sending notifications 15 days before expiration.
 For details, see the previous section (<a class="tdlp" href="#expiration-notifications">How to receive notifications about certificate expiration<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to receive notifications about certificate expiration</span><br /><br /><span class="tdlppd">Temporal Cloud sends notifications when a certificate is close to expiration.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#expiration-notifications">Learn more</a></span></span></a>).
 
-When updating CA certificates, it's important to follow a rollover process (sometimes referred to as "certificatev rotation").
+When updating CA certificates, it's important to follow a rollover process (sometimes referred to as "certificate rotation").
 Doing so enables your Namespace to serve both CA certificates for a period of time until traffic to your old CA certificate ceases.
 
 Be aware that the subject of the existing certificate and the subject of the new certificate must not be identical.

--- a/docs/cloud/account-setup/certificates.md
+++ b/docs/cloud/account-setup/certificates.md
@@ -26,12 +26,13 @@ tags:
 
 Temporal Cloud access is secured by the mutual Transport Layer Security (mTLS) protocol, which requires a CA certificate from the user.
 
-<a class="tdlp" href="/workers#worker-process">Worker Processes<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What is a Worker Process?</span><br /><br /><span class="tdlppd">A Worker Process is responsible for polling a Task Queue, dequeueing a Task, executing your code in response to a Task, and responding to the Temporal Server with the results.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/workers#worker-process">Learn more</a></span></span></a> require CA certificates and private keys to connect to Temporal Cloud.
+A <a class="tdlp" href="/workers#worker-process">Worker Process<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What is a Worker Process?</span><br /><br /><span class="tdlppd">A Worker Process is responsible for polling a Task Queue, dequeueing a Task, executing your code in response to a Task, and responding to the Temporal Server with the results.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/workers#worker-process">Learn more</a></span></span></a> requires a CA certificate and private key to connect to Temporal Cloud.
 Temporal Cloud does not require an exchange of secrets; only the certificates produced by private keys are used for verification.
 
 :::caution Don't let your certificates expire
 
 An expired root CA certificate invalidates all downstream certificates.
+
 An expired end-entity certificate prevents a <a class="tdlp" href="/temporal#temporal-client">Temporal Client<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What is a Temporal Client?</span><br /><br /><span class="tdlppd">A Temporal Client, provided by a Temporal SDK, provides a set of APIs to communicate with a Temporal Cluster.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/temporal#temporal-client">Learn more</a></span></span></a> from connecting to a Namespace or starting a Workflow Execution.
 If the client is on a Worker, any current Workflow Executions that are processed by that Worker either run indefinitely without making progress until the Worker resumes or fail because of timeouts.
 

--- a/docs/cloud/account-setup/certificates.md
+++ b/docs/cloud/account-setup/certificates.md
@@ -180,6 +180,18 @@ Temporal uses the root CA certificate as the trusted authority for access to you
 
 <a class="tdlp" href="#manage-certificate-filters">How to manage certificate filters in Temporal Cloud<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to manage certificate filters in Temporal Cloud</span><br /><br /><span class="tdlppd">To limit access to specific CA certificates, you can create certificate filters.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#manage-certificate-filters">Learn more</a></span></span></a>
 
+## How to receive notifications about certificate expiration {#expiration-notifications}
+
+To keep your Namespace secure and online, you must update the CA certificate for the Namespace _before_ the certificate expires.
+
+To help you remember to do so, Temporal Cloud sends email notifications to users who have the Global Admin <a class="tdlp" href="/cloud/users#account-level-roles">Role<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What are the account-level Roles for users in Temporal Cloud?</span><br /><br /><span class="tdlppd">Account-level Roles are Global Admin, Developer, and Read-Only.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/users#account-level-roles">Learn more</a></span></span></a> or the Namespace Admin <a class="tdlp" href="/cloud/users#namespace-level-permissions">permission<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">What are the Namespace-level permissions for users in Temporal Cloud?</span><br /><br /><span class="tdlppd">Namespace-level permissions are Namespace Admin, Write, and Read-Only.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/users#namespace-level-permissions">Learn more</a></span></span></a> 15 days before expiration and, if necessary, 10 days before expiration.
+
+If the certificate is not updated, 5 days before expiration Temporal Cloud creates a <a class="tdlp" href="/cloud/support#support-ticket">support ticket<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to create a ticket for Temporal Support</span><br /><br /><span class="tdlppd">To request assistance from Temporal Support, create a ticket in Zendesk.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="/cloud/support#support-ticket">Learn more</a></span></span></a> on behalf of the Global Admins and Namespace Admins.
+
+To ensure that you receive email notifications, configure your junk-email filters to permit email from `noreply@temporal.io`.
+
+After a support ticket is created, admins should expect a follow-up from the Temporal Developer Success team.
+
 ## How to add, update, and remove certificates in a Temporal Cloud Namespace {#manage-certificates}
 
 :::note
@@ -192,8 +204,10 @@ To manage certificates for Temporal Cloud Namespaces, use the **Namespaces** pag
 
 Don't let your certificates expire!
 Add reminders to your calendar to issue new CA certificates well before the expiration dates of the existing ones.
+Temporal Cloud begins sending notifications 15 days before expiration.
+For details, see the previous section (<a class="tdlp" href="#expiration-notifications">How to receive notifications about certificate expiration<span class="tdlpiw"><img src="/img/link-preview-icon.svg" alt="Link preview icon" /></span><span class="tdlpc"><span class="tdlppt">How to receive notifications about certificate expiration</span><br /><br /><span class="tdlppd">Temporal Cloud sends notifications when a certificate is close to expiration.</span><span class="tdlplm"><br /><br /><a class="tdlplma" href="#expiration-notifications">Learn more</a></span></span></a>).
 
-When updating CA certificates, it's important to follow a rollover process.
+When updating CA certificates, it's important to follow a rollover process (sometimes referred to as "certificatev rotation").
 Doing so enables your Namespace to serve both CA certificates for a period of time until traffic to your old CA certificate ceases.
 
 Be aware that the subject of the existing certificate and the subject of the new certificate must not be identical.


### PR DESCRIPTION
## Preview

**https://temporal-documentation-git-edu-503-cert-notifications.preview.thundergun.io/cloud/certificates#expiration-notifications**

## What does this PR do?

Adds a section to [How to manage certificates in Temporal Cloud](https://docs.temporal.io/cloud/certificates) about notifications generated by Temporal Cloud when a CA certificate is near expiration.
