### PR TITLE
EDU-1020 and EDU-1049: Refactor table of Temporal Cloud regions; add redirect

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday August 14 2023 13:22:42 PM -0500
+Last assembled: Monday August 14 2023 17:47:44 PM -0700
 
-Assembly Workflow Id: docs-full-assembly
+Assembly Workflow Id: docs-full-assembly-dail-macbook
 
 93 guide configurations found.
 

--- a/docs-src/cloud/operating-envelope-regions.md
+++ b/docs-src/cloud/operating-envelope-regions.md
@@ -11,18 +11,18 @@ tags:
 
 Temporal Cloud currently runs in 10 regions in Amazon Web Services (AWS):
 
-| Code           | Region                   |
-| -------------- | ------------------------ |
-| ap-northeast-1 | Asia Pacific (Tokyo)     |
-| ap-southeast-1 | Asia Pacific (Singapore) |
-| ap-southeast-2 | Asia Pacific (Sydney)    |
-| ca-central-1   | Canada (Central)         |
-| eu-central-1   | EU (Frankfurt)           |
-| eu-west-1      | EU (Ireland)             |
-| eu-west-2      | EU (London)              |
-| us-east-1      | US East (N. Virginia)    |
-| us-east-2      | US East (Ohio)           |
-| us-west-2      | US West (Oregon)         |
+| Area          | Code           | Region            |
+| ------------- | -------------- | ----------------- |
+| Asia Pacific  | ap-northeast-1 | Tokyo             |
+| Asia Pacific  | ap-southeast-1 | Singapore         |
+| Asia Pacific  | ap-southeast-2 | Sydney            |
+| Europe        | eu-central-1   | Frankfurt         |
+| Europe        | eu-west-1      | Ireland           |
+| Europe        | eu-west-2      | London            |
+| North America | ca-central-1   | Central Canada    |
+| North America | us-east-1      | Northern Virginia |
+| North America | us-east-2      | Ohio              |
+| North America | us-west-2      | Oregon            |
 
 Furthermore, it is compatible with applications deployed in any cloud environment or data center.
 

--- a/docs/cloud/introduction/operating-envelope.md
+++ b/docs/cloud/introduction/operating-envelope.md
@@ -63,18 +63,18 @@ For current system status and information about recent incidents, see [Temporal 
 
 Temporal Cloud currently runs in 10 regions in Amazon Web Services (AWS):
 
-| Code           | Region                   |
-| -------------- | ------------------------ |
-| ap-northeast-1 | Asia Pacific (Tokyo)     |
-| ap-southeast-1 | Asia Pacific (Singapore) |
-| ap-southeast-2 | Asia Pacific (Sydney)    |
-| ca-central-1   | Canada (Central)         |
-| eu-central-1   | EU (Frankfurt)           |
-| eu-west-1      | EU (Ireland)             |
-| eu-west-2      | EU (London)              |
-| us-east-1      | US East (N. Virginia)    |
-| us-east-2      | US East (Ohio)           |
-| us-west-2      | US West (Oregon)         |
+| Area          | Code           | Region            |
+| ------------- | -------------- | ----------------- |
+| Asia Pacific  | ap-northeast-1 | Tokyo             |
+| Asia Pacific  | ap-southeast-1 | Singapore         |
+| Asia Pacific  | ap-southeast-2 | Sydney            |
+| Europe        | eu-central-1   | Frankfurt         |
+| Europe        | eu-west-1      | Ireland           |
+| Europe        | eu-west-2      | London            |
+| North America | ca-central-1   | Central Canada    |
+| North America | us-east-1      | Northern Virginia |
+| North America | us-east-2      | Ohio              |
+| North America | us-west-2      | Oregon            |
 
 Furthermore, it is compatible with applications deployed in any cloud environment or data center.
 

--- a/vercel.json
+++ b/vercel.json
@@ -1338,6 +1338,10 @@
       "destination": "/workflows#continue-as-new"
     },
     {
+      "source": "/concepts/what-is-a-cloud-namespace-name",
+      "destination": "/cloud/namespaces#temporal-cloud-namespace-name"
+    },
+    {
       "source": "/concepts/what-is-a-data-converter",
       "destination": "/security#data-converter"
     },


### PR DESCRIPTION
## Preview

**https://temporal-documentation-git-edu-1042-region-table.preview.thundergun.io/cloud/operating-envelope#regions**

## What does this PR do?

- Makes the table in [Where is Temporal Cloud hosted and running?](https://temporal-documentation-git-edu-1042-region-table.preview.thundergun.io/cloud/operating-envelope#regions) easier to read.
- Adds a redirect from `/concepts/what-is-a-cloud-namespace-name` to [/cloud/namespaces#temporal-cloud-namespace-name](https://docs.temporal.io/cloud/namespaces#temporal-cloud-namespace-name).
