### PR TITLE
EDU-1065: Add redirect for Temporal Cloud pricing page

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1826,6 +1826,10 @@
       "destination": "cloud/operating-envelope:path*"
     },
     {
+      "source": "/cloud/introduction/pricing:path*",
+      "destination": "/cloud/pricing:path*"
+    },
+    {
       "source": "/cloud/introduction/support:path*",
       "destination": "/cloud/support:path*"
     },


### PR DESCRIPTION
## What does this PR do?

Adds a redirect from `/cloud/introduction/pricing` to [/cloud/pricing](https://docs.temporal.io/cloud/pricing).
