### PR TITLE
EDU-1088: clarify partial string match information

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Friday August 25 2023 11:29:58 AM -0600
+Last assembled: Friday August 25 2023 15:11:13 PM -0500
 
-Assembly Workflow Id: docs-full-assembly-flossypurse
+Assembly Workflow Id: docs-full-assembly
 
 94 guide configurations found.
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday August 28 2023 10:22:29 AM -0500
+Last assembled: Tuesday August 29 2023 14:20:40 PM -0500
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday August 29 2023 14:20:40 PM -0500
+Last assembled: Tuesday August 29 2023 16:44:25 PM -0500
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Friday August 25 2023 15:11:13 PM -0500
+Last assembled: Monday August 28 2023 10:19:15 AM -0500
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -38,7 +38,7 @@ Custom Search Attributes of the `Text` type cannot be used in **ORDER BY** claus
 ### Partial string match
 
 The `=` operator works like **CONTAINS** to find Workflows with Search Attributes that contain a specific word.
-Partial string match can only be used to find `Text` Search Attributes.
+You can only employ partial string matching to locate Text Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
 

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -38,6 +38,7 @@ Custom Search Attributes of the `Text` type cannot be used in **ORDER BY** claus
 ### Partial string match
 
 The `=` operator works like **CONTAINS** to find Workflows with Search Attributes that contain a specific word.
+Partial string match can only be used to find `Text` Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
 

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -51,7 +51,7 @@ This limitation arises because [Elasticsearch's tokenizer](https://www.elastic.c
 
 If the Advanced List Filter API retrieves a substantial number of Workflow Executions (more than 10,000), the response time might be longer.
 
-Beginning with Temporal Server v1.20 you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/concepts/what-is-a-workflow-execution).
+Beginning with Temporal Server v1.20, you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/concepts/what-is-a-workflow-execution).
 
 To paginate the results using the `ListWorkflow` API, use the page token to retrieve the next page.
 Continue until the page token becomes `null`/`nil`.

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -49,7 +49,7 @@ This limitation arises because [Elasticsearch's tokenizer](https://www.elastic.c
 
 ### Efficient API usage
 
-If the Advanced List Filter API retrieves a substantial number of Workflow Executions (over 10,000), the response time might be longer.
+If the Advanced List Filter API retrieves a substantial number of Workflow Executions (more than 10,000), the response time might be longer.
 
 Starting from Temporal Server v1.20 and later, you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/concepts/what-is-a-workflow-execution).
 

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -10,17 +10,19 @@ tags:
   - visibility
 ---
 
-A List Filter is the SQL-like string that is provided as the parameter to a [Visibility](/concepts/what-is-visibility) List API.
+The [Visibility](/concepts/what-is-visibility) List API requires you to provide a List Filter as an SQL-like string parameter.
 
-A List Filter contains [Search Attribute](/concepts/what-is-a-search-attribute) names, Search Attribute values, and [operators](#supported-operators) to pull a filtered list of Workflow Executions from the Visibility store.
 
-List Filter [Search Attribute](/concepts/what-is-a-search-attribute) names are case sensitive, and each List Filter is scoped by a single [Namespace](/concepts/what-is-a-namespace).
+A List Filter includes [Search Attribute](/concepts/what-is-a-search-attribute) names, Search Attribute values, and [operators](#supported-operators) that allow it to retrieve a filtered list of Workflow Executions from the Visibility Store.
 
-A List Filter that uses a time range has a resolution of 1 ns on [Elasticsearch](/clusters/how-to-integrate-elasticsearch-into-a-temporal-cluster) and 1 µs for [SQL databases](/clusters/how-to-set-up-visibility-in-a-temporal-cluster).
+List Filter [Search Attribute](/concepts/what-is-a-search-attribute) names are case sensitive.
+A single [Namespace](/concepts/what-is-a-namespace) scopes each List Filter.
+
+A List Filter using a time range provides a resolution of 1 ns on [Elasticsearch](/clusters/how-to-integrate-elasticsearch-into-a-temporal-cluster) and 1 µs for [SQL databases](/clusters/how-to-set-up-visibility-in-a-temporal-cluster).
 
 ### Supported operators
 
-A List Filter contains [Search Attribute](/concepts/what-is-a-search-attribute) names, Search Attribute values, and the following supported operators:
+List Filters support the following operators:
 
 - **=, !=, >, >=, <, <=**
 - **AND, OR, ()**
@@ -37,38 +39,39 @@ Custom Search Attributes of the `Text` type cannot be used in **ORDER BY** claus
 
 ### Partial string match
 
-The `=` operator works like **CONTAINS** to find Workflows with Search Attributes that contain a specific word.
-You can only employ partial string matching to locate Text Search Attributes.
+The `=` operator functions similarly to **CONTAINS**, helping to find Workflows with Search Attributes containing a specific word.
+Partial string matching only applies to locating Text Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
 
-For example, if you have a custom Search Attribute named `Description` of `Text` type with the value of "The quick brown fox jumps over the lazy dog", searching for `Description='quick'` or `Description='fox'` will successfully return the Workflow.
-However, partial word searches such as `Description='qui'` or `Description='laz'` will not return the Workflow.
-This is because [Elasticsearch's tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) is configured to return complete words as tokens.
+For instance, if you have a custom Search Attribute named `Description` of `Text` type with the value "The quick brown fox jumps over the lazy dog", a search for `Description='quick'` or `Description='fox'` will successfully return the Workflow.
+However, searches for partial words like `Description='qui'` or `Description='laz'` won't return the Workflow.
+This limitation arises because [Elasticsearch's tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) is configured to return complete words as tokens.
 
 ### Efficient API usage
 
-An Advanced List Filter API may take longer to respond if it is retrieving a large number of Workflow Executions (over 10,000).
+If the Advanced List Filter API retrieves a substantial number of Workflow Executions (over 10,000), the response time might be longer.
 
-With Temporal Server v1.20 and later, you can use the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/concepts/what-is-a-workflow-execution).
+Starting from Temporal Server v1.20 and later, you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/concepts/what-is-a-workflow-execution).
 
-Paginate the results with the `ListWorkflow` API by using the page token to retrieve the next page; continue until the page token is `null`/`nil`.
+To paginate the results using the `ListWorkflow` API, use the page token to retrieve the next page. 
+Continue until the page token becomes `null`/`nil`.
 
 #### List Filter examples
 
-The following is a List Filter set with [`tctl`](/tctl-v1/workflow/list):
+Here are examples of List Filters set with [`tctl`](/tctl-v1/workflow/list):
 
 ```
 WorkflowType = "main.YourWorkflowDefinition" and ExecutionStatus != "Running" and (StartTime > "2021-06-07T16:46:34.236-08:00" or CloseTime > "2021-06-07T16:46:34-08:00")
 ```
 
-When used, a list of Workflows that meet the following conditions are returned:
+When used, you will receive a list of Workflows fulfilling the following criteria:
 
-- The Workflow Type is set to `main.YourWorkflowDefinition`.
-- The Workflow isn't running.
-- The Workflow either started after "2021-06-07T16:46:34.236-08:00" or closed after "2021-06-07T16:46:34-08:00".
+- Workflow Type is `main.YourWorkflowDefinition`.
+- Workflow isn't in a running state.
+- Workflow either started after "2021-06-07T16:46:34.236-08:00" or closed after "2021-06-07T16:46:34-08:00".
 
-More List Filter examples have been provided below.
+Additional examples of List Filters are provided below.
 
 ```sql
 WorkflowId = '<workflow-id>'

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -64,7 +64,7 @@ Here are examples of List Filters set with [`tctl`](/tctl-v1/workflow/list):
 WorkflowType = "main.YourWorkflowDefinition" and ExecutionStatus != "Running" and (StartTime > "2021-06-07T16:46:34.236-08:00" or CloseTime > "2021-06-07T16:46:34-08:00")
 ```
 
-When used, you will receive a list of Workflows fulfilling the following criteria:
+When you use the preceding example, you receive a list of Workflows fulfilling the following criteria:
 
 - Workflow Type is `main.YourWorkflowDefinition`.
 - Workflow isn't in a running state.

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -12,7 +12,6 @@ tags:
 
 The [Visibility](/concepts/what-is-visibility) List API requires you to provide a List Filter as an SQL-like string parameter.
 
-
 A List Filter includes [Search Attribute](/concepts/what-is-a-search-attribute) names, Search Attribute values, and [operators](#supported-operators) that allow it to retrieve a filtered list of Workflow Executions from the Visibility Store.
 
 List Filter [Search Attribute](/concepts/what-is-a-search-attribute) names are case sensitive.
@@ -54,7 +53,7 @@ If the Advanced List Filter API retrieves a substantial number of Workflow Execu
 
 Starting from Temporal Server v1.20 and later, you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/concepts/what-is-a-workflow-execution).
 
-To paginate the results using the `ListWorkflow` API, use the page token to retrieve the next page. 
+To paginate the results using the `ListWorkflow` API, use the page token to retrieve the next page.
 Continue until the page token becomes `null`/`nil`.
 
 #### List Filter examples

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -38,7 +38,7 @@ Custom Search Attributes of the `Text` type cannot be used in **ORDER BY** claus
 
 ### Partial string match
 
-The `=` operator functions similarly to **CONTAINS**, helping to find Workflows with Search Attributes containing a specific word.
+The `=` operator works similarly to **CONTAINS**, helping to find Workflows with Search Attributes containing a specific word.
 Partial string matching applies only to locating Text Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
@@ -51,7 +51,7 @@ This limitation arises because [Elasticsearch's tokenizer](https://www.elastic.c
 
 If the Advanced List Filter API retrieves a substantial number of Workflow Executions (more than 10,000), the response time might be longer.
 
-Starting from Temporal Server v1.20 and later, you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/concepts/what-is-a-workflow-execution).
+Beginning with Temporal Server v1.20 you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/concepts/what-is-a-workflow-execution).
 
 To paginate the results using the `ListWorkflow` API, use the page token to retrieve the next page.
 Continue until the page token becomes `null`/`nil`.

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -70,7 +70,7 @@ When you use the preceding example, you receive a list of Workflows fulfilling t
 - Workflow isn't in a running state.
 - Workflow either started after "2021-06-07T16:46:34.236-08:00" or closed after "2021-06-07T16:46:34-08:00".
 
-Additional examples of List Filters are provided below.
+The following are additional examples of List Filters.
 
 ```sql
 WorkflowId = '<workflow-id>'

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -43,7 +43,7 @@ Partial string matching applies only to locating Text Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
 
-For instance, if you have a custom Search Attribute named `Description` of `Text` type with the value "The quick brown fox jumps over the lazy dog", a search for `Description='quick'` or `Description='fox'` will successfully return the Workflow.
+For example, if you have a custom Search Attribute named `Description` of `Text` type with the value "The quick brown fox jumps over the lazy dog", a search for `Description='quick'` or `Description='fox'` successfully returns the Workflow.
 However, searches for partial words like `Description='qui'` or `Description='laz'` won't return the Workflow.
 This limitation arises because [Elasticsearch's tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) is configured to return complete words as tokens.
 

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -12,7 +12,7 @@ tags:
 
 The [Visibility](/concepts/what-is-visibility) List API requires you to provide a List Filter as an SQL-like string parameter.
 
-A List Filter includes [Search Attribute](/concepts/what-is-a-search-attribute) names, Search Attribute values, and [operators](#supported-operators) that allow it to retrieve a filtered list of Workflow Executions from the Visibility Store.
+A List Filter includes [Search Attribute](/concepts/what-is-a-search-attribute) names, Search Attribute values, and [operators](#supported-operators) so that it can retrieve a filtered list of Workflow Executions from the Visibility Store.
 
 List Filter [Search Attribute](/concepts/what-is-a-search-attribute) names are case sensitive.
 A single [Namespace](/concepts/what-is-a-namespace) scopes each List Filter.

--- a/docs-src/concepts/what-is-a-list-filter.md
+++ b/docs-src/concepts/what-is-a-list-filter.md
@@ -39,7 +39,7 @@ Custom Search Attributes of the `Text` type cannot be used in **ORDER BY** claus
 ### Partial string match
 
 The `=` operator functions similarly to **CONTAINS**, helping to find Workflows with Search Attributes containing a specific word.
-Partial string matching only applies to locating Text Search Attributes.
+Partial string matching applies only to locating Text Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
 

--- a/docs/cli/server.md
+++ b/docs/cli/server.md
@@ -31,7 +31,7 @@ Currently, `cli` server functionality extends to starting the Server.
 
 The `temporal server start-dev` command starts a local [Temporal Server](/clusters#temporal-server).
 You can access the Web UI at http://localhost:8233.
-The default Frontend Server gRPC port used as a target endpoint for client calls is 7233.
+The default Frontend Service gRPC port used as a target endpoint for client calls is 7233.
 
 Use the following options to change the behavior of this command.
 

--- a/docs/concepts/visibility.md
+++ b/docs/concepts/visibility.md
@@ -124,6 +124,7 @@ Custom Search Attributes of the `Text` type cannot be used in **ORDER BY** claus
 ### Partial string match
 
 The `=` operator works like **CONTAINS** to find Workflows with Search Attributes that contain a specific word.
+Partial string match can only be used to find `Text` Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
 

--- a/docs/concepts/visibility.md
+++ b/docs/concepts/visibility.md
@@ -96,17 +96,18 @@ For details on migrating your Visibility store databases, see [Dual Visibility](
 
 ## What is a List Filter? {#list-filter}
 
-A List Filter is the SQL-like string that is provided as the parameter to a [Visibility](/clusters#visibility) List API.
+The [Visibility](/clusters#visibility) List API requires you to provide a List Filter as an SQL-like string parameter.
 
-A List Filter contains [Search Attribute](#search-attribute) names, Search Attribute values, and [operators](#supported-operators) to pull a filtered list of Workflow Executions from the Visibility store.
+A List Filter includes [Search Attribute](#search-attribute) names, Search Attribute values, and [operators](#supported-operators) that allow it to retrieve a filtered list of Workflow Executions from the Visibility Store.
 
-List Filter [Search Attribute](#search-attribute) names are case sensitive, and each List Filter is scoped by a single [Namespace](/namespaces#).
+List Filter [Search Attribute](#search-attribute) names are case sensitive.
+A single [Namespace](/namespaces#) scopes each List Filter.
 
-A List Filter that uses a time range has a resolution of 1 ns on [Elasticsearch](/cluster-deployment-guide#elasticsearch) and 1 µs for [SQL databases](/cluster-deployment-guide#visibility-store).
+A List Filter using a time range provides a resolution of 1 ns on [Elasticsearch](/cluster-deployment-guide#elasticsearch) and 1 µs for [SQL databases](/cluster-deployment-guide#visibility-store).
 
 ### Supported operators
 
-A List Filter contains [Search Attribute](#search-attribute) names, Search Attribute values, and the following supported operators:
+List Filters support the following operators:
 
 - **=, !=, >, >=, <, <=**
 - **AND, OR, ()**
@@ -123,38 +124,39 @@ Custom Search Attributes of the `Text` type cannot be used in **ORDER BY** claus
 
 ### Partial string match
 
-The `=` operator works like **CONTAINS** to find Workflows with Search Attributes that contain a specific word.
-Partial string match can only be used to find `Text` Search Attributes.
+The `=` operator functions similarly to **CONTAINS**, helping to find Workflows with Search Attributes containing a specific word.
+Partial string matching only applies to locating Text Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
 
-For example, if you have a custom Search Attribute named `Description` of `Text` type with the value of "The quick brown fox jumps over the lazy dog", searching for `Description='quick'` or `Description='fox'` will successfully return the Workflow.
-However, partial word searches such as `Description='qui'` or `Description='laz'` will not return the Workflow.
-This is because [Elasticsearch's tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) is configured to return complete words as tokens.
+For instance, if you have a custom Search Attribute named `Description` of `Text` type with the value "The quick brown fox jumps over the lazy dog", a search for `Description='quick'` or `Description='fox'` will successfully return the Workflow.
+However, searches for partial words like `Description='qui'` or `Description='laz'` won't return the Workflow.
+This limitation arises because [Elasticsearch's tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) is configured to return complete words as tokens.
 
 ### Efficient API usage
 
-An Advanced List Filter API may take longer to respond if it is retrieving a large number of Workflow Executions (over 10,000).
+If the Advanced List Filter API retrieves a substantial number of Workflow Executions (over 10,000), the response time might be longer.
 
-With Temporal Server v1.20 and later, you can use the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/workflows#workflow-execution).
+Starting from Temporal Server v1.20 and later, you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/workflows#workflow-execution).
 
-Paginate the results with the `ListWorkflow` API by using the page token to retrieve the next page; continue until the page token is `null`/`nil`.
+To paginate the results using the `ListWorkflow` API, use the page token to retrieve the next page.
+Continue until the page token becomes `null`/`nil`.
 
 #### List Filter examples
 
-The following is a List Filter set with [`tctl`](/tctl-v1/workflow#list):
+Here are examples of List Filters set with [`tctl`](/tctl-v1/workflow#list):
 
 ```
 WorkflowType = "main.YourWorkflowDefinition" and ExecutionStatus != "Running" and (StartTime > "2021-06-07T16:46:34.236-08:00" or CloseTime > "2021-06-07T16:46:34-08:00")
 ```
 
-When used, a list of Workflows that meet the following conditions are returned:
+When used, you will receive a list of Workflows fulfilling the following criteria:
 
-- The Workflow Type is set to `main.YourWorkflowDefinition`.
-- The Workflow isn't running.
-- The Workflow either started after "2021-06-07T16:46:34.236-08:00" or closed after "2021-06-07T16:46:34-08:00".
+- Workflow Type is `main.YourWorkflowDefinition`.
+- Workflow isn't in a running state.
+- Workflow either started after "2021-06-07T16:46:34.236-08:00" or closed after "2021-06-07T16:46:34-08:00".
 
-More List Filter examples have been provided below.
+Additional examples of List Filters are provided below.
 
 ```sql
 WorkflowId = '<workflow-id>'

--- a/docs/concepts/visibility.md
+++ b/docs/concepts/visibility.md
@@ -137,7 +137,7 @@ This limitation arises because [Elasticsearch's tokenizer](https://www.elastic.c
 
 If the Advanced List Filter API retrieves a substantial number of Workflow Executions (more than 10,000), the response time might be longer.
 
-Beginning with Temporal Server v1.20 you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/workflows#workflow-execution).
+Beginning with Temporal Server v1.20, you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/workflows#workflow-execution).
 
 To paginate the results using the `ListWorkflow` API, use the page token to retrieve the next page.
 Continue until the page token becomes `null`/`nil`.

--- a/docs/concepts/visibility.md
+++ b/docs/concepts/visibility.md
@@ -98,7 +98,7 @@ For details on migrating your Visibility store databases, see [Dual Visibility](
 
 The [Visibility](/clusters#visibility) List API requires you to provide a List Filter as an SQL-like string parameter.
 
-A List Filter includes [Search Attribute](#search-attribute) names, Search Attribute values, and [operators](#supported-operators) that allow it to retrieve a filtered list of Workflow Executions from the Visibility Store.
+A List Filter includes [Search Attribute](#search-attribute) names, Search Attribute values, and [operators](#supported-operators) so that it can retrieve a filtered list of Workflow Executions from the Visibility Store.
 
 List Filter [Search Attribute](#search-attribute) names are case sensitive.
 A single [Namespace](/namespaces#) scopes each List Filter.
@@ -124,20 +124,20 @@ Custom Search Attributes of the `Text` type cannot be used in **ORDER BY** claus
 
 ### Partial string match
 
-The `=` operator functions similarly to **CONTAINS**, helping to find Workflows with Search Attributes containing a specific word.
-Partial string matching only applies to locating Text Search Attributes.
+The `=` operator works similarly to **CONTAINS**, helping to find Workflows with Search Attributes containing a specific word.
+Partial string matching applies only to locating Text Search Attributes.
 
 <!-- note: advanced vis features will be supported in SQL upon the release of v1.20.-->
 
-For instance, if you have a custom Search Attribute named `Description` of `Text` type with the value "The quick brown fox jumps over the lazy dog", a search for `Description='quick'` or `Description='fox'` will successfully return the Workflow.
+For example, if you have a custom Search Attribute named `Description` of `Text` type with the value "The quick brown fox jumps over the lazy dog", a search for `Description='quick'` or `Description='fox'` successfully returns the Workflow.
 However, searches for partial words like `Description='qui'` or `Description='laz'` won't return the Workflow.
 This limitation arises because [Elasticsearch's tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) is configured to return complete words as tokens.
 
 ### Efficient API usage
 
-If the Advanced List Filter API retrieves a substantial number of Workflow Executions (over 10,000), the response time might be longer.
+If the Advanced List Filter API retrieves a substantial number of Workflow Executions (more than 10,000), the response time might be longer.
 
-Starting from Temporal Server v1.20 and later, you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/workflows#workflow-execution).
+Beginning with Temporal Server v1.20 you can employ the `CountWorkflow` API to efficiently count the number of [Workflow Executions](/workflows#workflow-execution).
 
 To paginate the results using the `ListWorkflow` API, use the page token to retrieve the next page.
 Continue until the page token becomes `null`/`nil`.
@@ -150,13 +150,13 @@ Here are examples of List Filters set with [`tctl`](/tctl-v1/workflow#list):
 WorkflowType = "main.YourWorkflowDefinition" and ExecutionStatus != "Running" and (StartTime > "2021-06-07T16:46:34.236-08:00" or CloseTime > "2021-06-07T16:46:34-08:00")
 ```
 
-When used, you will receive a list of Workflows fulfilling the following criteria:
+When you use the preceding example, you receive a list of Workflows fulfilling the following criteria:
 
 - Workflow Type is `main.YourWorkflowDefinition`.
 - Workflow isn't in a running state.
 - Workflow either started after "2021-06-07T16:46:34.236-08:00" or closed after "2021-06-07T16:46:34-08:00".
 
-Additional examples of List Filters are provided below.
+The following are additional examples of List Filters.
 
 ```sql
 WorkflowId = '<workflow-id>'


### PR DESCRIPTION
## What does this PR do?
This PR adds a note that clarifies that partial string match can only be used on `Text` Search Attributes.
