### PR TITLE
EDU-1096: Site docs.temporal.io Has Incorrect Meetups Link

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday August 29 2023 16:44:25 PM -0500
+Last assembled: Tuesday August 29 2023 17:35:14 PM -0500
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -139,7 +139,7 @@ module.exports = {
             },
             {
               label: "Meetups",
-              href: "https://lu.ma/temporal",
+              href: "https://temporal.io/community#events",
             },
             {
               label: "Workshops",


### PR DESCRIPTION
## What does this PR do?

## Notes to reviewers

The page footer of [https://docs.temporal.io/](https://docs.temporal.io/) has an outdated link for Meetups. We migrated away from [lu.ma](http://lu.ma/) earlier this year. Our home page now uses [https://temporal.io/community#events](https://temporal.io/community#events) as the link target, so the docs sub-site should mirror that. This PR provides that correction.
