### PR TITLE
EDU-1145: Add sa-east-1 (São Paulo) to list of Temporal Cloud regions

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday September 12 2023 10:17:27 AM -0700
+Last assembled: Friday September 15 2023 16:00:56 PM -0700
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly
 
 94 guide configurations found.
 

--- a/docs-src/cloud/operating-envelope-regions.md
+++ b/docs-src/cloud/operating-envelope-regions.md
@@ -2,14 +2,14 @@
 id: operating-envelope-regions
 title: Where is Temporal Cloud hosted and running?
 sidebar_label: Regions
-description: Temporal Cloud currently runs in 10 regions in AWS.
+description: Temporal Cloud currently runs in multiple regions in AWS.
 tags:
   - operations
   - temporal cloud
   - explanation
 ---
 
-Temporal Cloud currently runs in 11 regions in Amazon Web Services (AWS):
+Temporal Cloud currently runs in the following regions in Amazon Web Services (AWS):
 
 | Area          | Code           | Region            |
 | ------------- | -------------- | ----------------- |
@@ -24,6 +24,7 @@ Temporal Cloud currently runs in 11 regions in Amazon Web Services (AWS):
 | North America | us-east-1      | Northern Virginia |
 | North America | us-east-2      | Ohio              |
 | North America | us-west-2      | Oregon            |
+| South America | sa-east-1      | São Paulo         |
 
 Furthermore, it is compatible with applications deployed in any cloud environment or data center.
 

--- a/docs/cloud/introduction/operating-envelope.md
+++ b/docs/cloud/introduction/operating-envelope.md
@@ -67,7 +67,7 @@ For current system status and information about recent incidents, see [Temporal 
 
 ## Where is Temporal Cloud hosted and running? {#regions}
 
-Temporal Cloud currently runs in 11 regions in Amazon Web Services (AWS):
+Temporal Cloud currently runs in the following regions in Amazon Web Services (AWS):
 
 | Area          | Code           | Region            |
 | ------------- | -------------- | ----------------- |
@@ -82,6 +82,7 @@ Temporal Cloud currently runs in 11 regions in Amazon Web Services (AWS):
 | North America | us-east-1      | Northern Virginia |
 | North America | us-east-2      | Ohio              |
 | North America | us-west-2      | Oregon            |
+| South America | sa-east-1      | São Paulo         |
 
 Furthermore, it is compatible with applications deployed in any cloud environment or data center.
 


### PR DESCRIPTION
## Preview

**https://temporal-documentation-git-edu-1145-region-sa1.preview.thundergun.io/cloud/operating-envelope#regions**

## What does this PR do?

Adds `sa-east-1` to [Where is Temporal Cloud hosted and running?](https://docs.temporal.io/cloud/operating-envelope#regions) (`/docs-src/cloud/operating-envelope-regions.md`).
