### PR TITLE
Fix "Query" anchor link

### DIFF
--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -572,7 +572,7 @@ A Signal is an asynchronous request to a [Workflow Execution](/workflows#workflo
 - [How to develop, send, and handle Signals in TypeScript](/dev-guide/typescript/features#signals)
 
 A Signal delivers data to a running Workflow Execution.
-It cannot return data to the caller; to do so, use a [Query](#queries) instead.
+It cannot return data to the caller; to do so, use a [Query](#query) instead.
 The Workflow code that handles a Signal can mutate Workflow state.
 A Signal can be sent from a Temporal Client or a Workflow.
 When a Signal is sent, it is received by the Cluster and recorded as an Event to the Workflow Execution [Event History](#event-history).


### PR DESCRIPTION
## What does this PR do?

Fixes the link to the Query section:

```
## What is a Query? {#query}
```