### PR TITLE
Shorten anchors

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Friday September 29 2023 01:22:19 AM -0400
+Last assembled: Friday September 29 2023 20:45:01 PM -0400
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docs-src/python/introduction-to-python-sdk.md
+++ b/docs-src/python/introduction-to-python-sdk.md
@@ -18,7 +18,7 @@ Welcome to Temporal Python SDK developer's guide!
 The Temporal Python SDK released on March 18, 2022.
 The Python SDK provides access to the Temporal programming model using idiomatic Python programming paradigms.
 
-### What Python programming skills and experiences are useful when using the Python SDK?
+### What Python programming skills and experiences are useful when using the Python SDK? {#skills}
 
 You can start working with the SDK with only Python knowledge.
 Temporal abstracts much of the complexity of distributed systems, but to unlock its full potential, having a broad base of knowledge will help you design more efficient and resilient systems.
@@ -95,14 +95,14 @@ For complex and large-scale use cases, having some experience with the following
 - Handling PII and sensitive information
 - Encryption and secure coding practices
 
-### Where can I find code samples?
+### Where can I find code samples? {#samples}
 
 Code samples are integrated into this developer’s guide.
 You can find those code samples in the [temporalio/documentation-samples-python](https://github.com/temporalio/documentation-samples-python) repository on GitHub.
 
 Additional Python code samples are in the [temporalio/samples-python](https://github.com/temporalio/samples-python) repository on GitHub.
 
-### What are other resources for learning how to use the Python SDK?
+### What are other resources for learning how to use the Python SDK? {#resources}
 
 - [Temporal 101 with Python](https://learn.temporal.io/courses/temporal_101/python)
 - [Python tutorials](https://learn.temporal.io/tutorials/python/)
@@ -113,21 +113,21 @@ Additional Python code samples are in the [temporalio/samples-python](https://gi
   - [Temporal Python 1.0.0 – A Durable, Distributed Asyncio Event Loop](https://temporal.io/blog/durable-distributed-asyncio-event-loop)
   - [Python SDK: Your first Application](https://temporal.io/blog/python-sdk-your-first-application)
 
-### What are the supported Python versions?
+### What are the supported Python versions? {#python-versions}
 
 - Python 3.7+
 
-## Where can I get help with using the Python SDK?
+## Where can I get help with using the Python SDK? {#help}
 
 - _#python-sdk_ channel in [Temporal Slack](https://t.mp/slack)
 - [Community Forum](https://community.temporal.io/tag/python-sdk)
 
-## How to follow updates to the Python SDK
+## How to follow updates to the Python SDK {#updates}
 
 - The [Temporal newsletter](https://t.mp/news) includes major SDK updates.
 - [GitHub Releases](https://github.com/temporalio/sdk-python/releases) has all SDK releases. It also has a feed that can be added to a feed reader or [converted to emails](https://blogtrottr.com/): `https://github.com/temporalio/sdk-python/releases.atom`.
 
-### How to contribute to the Python SDK
+### How to contribute to the Python SDK {#contribute}
 
 The Temporal Python SDK is MIT licensed, and contributions are welcome.
 Please review our [contribution guidelines](https://github.com/temporalio/sdk-python#development).

--- a/docs-src/typescript/introduction-to-typescript-sdk.md
+++ b/docs-src/typescript/introduction-to-typescript-sdk.md
@@ -17,7 +17,7 @@ Welcome to the Temporal TypeScript SDK developer's guide!
 
 The Temporal TypeScript SDK released on July 26, 2022. The TypeScript SDK provides access to the Temporal programming model using idiomatic JavaScript and TypeScript programming paradigms.
 
-## What programming skills and experiences are useful when using the TypeScript SDK?
+## What programming skills and experiences are useful when using the TypeScript SDK? {#skills}
 
 You can start working with the SDK with only TypeScript knowledge.
 Temporal abstracts much of the complexity of distributed systems, but to unlock its full potential, having a broad base of knowledge will help you design more efficient and resilient systems.
@@ -54,14 +54,14 @@ Temporal abstracts much of the complexity of distributed systems, but to unlock 
     - Event-driven architecture, eventual consistency, partitioning, and replication.
     - Stateful versus stateless processes.
 
-## Where can I find code samples?
+## Where can I find code samples? {#samples}
 
 Code samples are integrated into this developer’s guide.
 You can find those code samples in the [temporalio/documentation-samples-typescript](https://github.com/temporalio/documentation-samples-typescript) repository on GitHub.
 
 Additional TypeScript code samples are in the [temporalio/samples-typescript](https://github.com/temporalio/samples-typescript) repository.
 
-## What are other resources for learning how to use the TypeScript SDK?
+## What are other resources for learning how to use the TypeScript SDK? {#resources}
 
 Further resources for learning how to use the SDK include the following:
 
@@ -80,17 +80,17 @@ Further resources for learning how to use the SDK include the following:
   - [1.0.0 release of the Temporal TypeScript SDK](https://temporal.io/blog/typescript-1-0-0)
   - [How we use V8 isolates to enforce Workflow determinism](https://temporal.io/blog/intro-to-isolated-vm)
 
-## Where can I get help with using the TypeScript SDK?
+## Where can I get help with using the TypeScript SDK? {#help}
 
 - _#typescript-sdk_ channel in [Slack](https://t.mp/slack)
 - [Community Forum](https://community.temporal.io/tag/typescript-sdk)
 
-## How to follow updates to the TypeScript SDK
+## How to follow updates to the TypeScript SDK {#updates}
 
 - The [Temporal newsletter](https://t.mp/news) includes major SDK updates.
 - [GitHub Releases](https://github.com/temporalio/sdk-typescript/releases) has all SDK releases. It also has a feed that can be added to a feed reader or [converted to emails](https://blogtrottr.com/): `https://github.com/temporalio/sdk-typescript/releases.atom`.
 
-## How to contribute to the TypeScript SDK
+## How to contribute to the TypeScript SDK {#contribute}
 
 The Temporal TypeScript SDK is MIT licensed, and contributions are welcome.
 Please review our [contribution guidelines](https://github.com/temporalio/sdk-typescript/blob/main/CONTRIBUTING.md).

--- a/docs/dev-guide/python/introduction.md
+++ b/docs/dev-guide/python/introduction.md
@@ -25,7 +25,7 @@ Welcome to Temporal Python SDK developer's guide!
 The Temporal Python SDK released on March 18, 2022.
 The Python SDK provides access to the Temporal programming model using idiomatic Python programming paradigms.
 
-### What Python programming skills and experiences are useful when using the Python SDK?
+### What Python programming skills and experiences are useful when using the Python SDK? {#skills}
 
 You can start working with the SDK with only Python knowledge.
 Temporal abstracts much of the complexity of distributed systems, but to unlock its full potential, having a broad base of knowledge will help you design more efficient and resilient systems.
@@ -102,14 +102,14 @@ For complex and large-scale use cases, having some experience with the following
 - Handling PII and sensitive information
 - Encryption and secure coding practices
 
-### Where can I find code samples?
+### Where can I find code samples? {#samples}
 
 Code samples are integrated into this developer’s guide.
 You can find those code samples in the [temporalio/documentation-samples-python](https://github.com/temporalio/documentation-samples-python) repository on GitHub.
 
 Additional Python code samples are in the [temporalio/samples-python](https://github.com/temporalio/samples-python) repository on GitHub.
 
-### What are other resources for learning how to use the Python SDK?
+### What are other resources for learning how to use the Python SDK? {#resources}
 
 - [Temporal 101 with Python](https://learn.temporal.io/courses/temporal_101/python)
 - [Python tutorials](https://learn.temporal.io/tutorials/python/)
@@ -120,21 +120,21 @@ Additional Python code samples are in the [temporalio/samples-python](https://gi
   - [Temporal Python 1.0.0 – A Durable, Distributed Asyncio Event Loop](https://temporal.io/blog/durable-distributed-asyncio-event-loop)
   - [Python SDK: Your first Application](https://temporal.io/blog/python-sdk-your-first-application)
 
-### What are the supported Python versions?
+### What are the supported Python versions? {#python-versions}
 
 - Python 3.7+
 
-## Where can I get help with using the Python SDK?
+## Where can I get help with using the Python SDK? {#help}
 
 - _#python-sdk_ channel in [Temporal Slack](https://t.mp/slack)
 - [Community Forum](https://community.temporal.io/tag/python-sdk)
 
-## How to follow updates to the Python SDK
+## How to follow updates to the Python SDK {#updates}
 
 - The [Temporal newsletter](https://t.mp/news) includes major SDK updates.
 - [GitHub Releases](https://github.com/temporalio/sdk-python/releases) has all SDK releases. It also has a feed that can be added to a feed reader or [converted to emails](https://blogtrottr.com/): `https://github.com/temporalio/sdk-python/releases.atom`.
 
-### How to contribute to the Python SDK
+### How to contribute to the Python SDK {#contribute}
 
 The Temporal Python SDK is MIT licensed, and contributions are welcome.
 Please review our [contribution guidelines](https://github.com/temporalio/sdk-python#development).

--- a/docs/dev-guide/tscript/introduction.md
+++ b/docs/dev-guide/tscript/introduction.md
@@ -24,7 +24,7 @@ Welcome to the Temporal TypeScript SDK developer's guide!
 
 The Temporal TypeScript SDK released on July 26, 2022. The TypeScript SDK provides access to the Temporal programming model using idiomatic JavaScript and TypeScript programming paradigms.
 
-## What programming skills and experiences are useful when using the TypeScript SDK?
+## What programming skills and experiences are useful when using the TypeScript SDK? {#skills}
 
 You can start working with the SDK with only TypeScript knowledge.
 Temporal abstracts much of the complexity of distributed systems, but to unlock its full potential, having a broad base of knowledge will help you design more efficient and resilient systems.
@@ -61,14 +61,14 @@ Temporal abstracts much of the complexity of distributed systems, but to unlock 
     - Event-driven architecture, eventual consistency, partitioning, and replication.
     - Stateful versus stateless processes.
 
-## Where can I find code samples?
+## Where can I find code samples? {#samples}
 
 Code samples are integrated into this developer’s guide.
 You can find those code samples in the [temporalio/documentation-samples-typescript](https://github.com/temporalio/documentation-samples-typescript) repository on GitHub.
 
 Additional TypeScript code samples are in the [temporalio/samples-typescript](https://github.com/temporalio/samples-typescript) repository.
 
-## What are other resources for learning how to use the TypeScript SDK?
+## What are other resources for learning how to use the TypeScript SDK? {#resources}
 
 Further resources for learning how to use the SDK include the following:
 
@@ -87,17 +87,17 @@ Further resources for learning how to use the SDK include the following:
   - [1.0.0 release of the Temporal TypeScript SDK](https://temporal.io/blog/typescript-1-0-0)
   - [How we use V8 isolates to enforce Workflow determinism](https://temporal.io/blog/intro-to-isolated-vm)
 
-## Where can I get help with using the TypeScript SDK?
+## Where can I get help with using the TypeScript SDK? {#help}
 
 - _#typescript-sdk_ channel in [Slack](https://t.mp/slack)
 - [Community Forum](https://community.temporal.io/tag/typescript-sdk)
 
-## How to follow updates to the TypeScript SDK
+## How to follow updates to the TypeScript SDK {#updates}
 
 - The [Temporal newsletter](https://t.mp/news) includes major SDK updates.
 - [GitHub Releases](https://github.com/temporalio/sdk-typescript/releases) has all SDK releases. It also has a feed that can be added to a feed reader or [converted to emails](https://blogtrottr.com/): `https://github.com/temporalio/sdk-typescript/releases.atom`.
 
-## How to contribute to the TypeScript SDK
+## How to contribute to the TypeScript SDK {#contribute}
 
 The Temporal TypeScript SDK is MIT licensed, and contributions are welcome.
 Please review our [contribution guidelines](https://github.com/temporalio/sdk-typescript/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
I shared this link and then realized how long it was:


https://docs.temporal.io/dev-guide/typescript/introduction#what-are-other-resources-for-learning-how-to-use-the-typescript-sdk

This shortens it to:


https://docs.temporal.io/dev-guide/typescript/introduction#resources