### PR TITLE
Adds Windows instructions installing CLI with Scoop

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday October 02 2023 12:10:13 PM +1100
+Last assembled: Thursday October 05 2023 08:58:59 AM -0700
 
-Assembly Workflow Id: docs-full-assembly
+Assembly Workflow Id: docs-full-assembly-rachfop-123
 
 103 guide configurations found.
 

--- a/docs-src/concepts/what-is-the-temporal-cli.md
+++ b/docs-src/concepts/what-is-the-temporal-cli.md
@@ -38,9 +38,15 @@ Run the following command to install Temporal CLI using cURL:
 
 ### Homebrew
 
-Run the following command to install Temporal CLI using Homebrew:
+Run the following command to install Temporal CLI using Homebrew on macOS:
 
 `brew install temporal`
+
+### Scoop
+
+Run the following command to install Temporal CLI using Scoop on Windows:
+
+`scoop install temporal-cli`
 
 ### Manual
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -48,9 +48,15 @@ Run the following command to install Temporal CLI using cURL:
 
 ### Homebrew
 
-Run the following command to install Temporal CLI using Homebrew:
+Run the following command to install Temporal CLI using Homebrew on macOS:
 
 `brew install temporal`
+
+### Scoop
+
+Run the following command to install Temporal CLI using Scoop on Windows:
+
+`scoop install temporal-cli`
 
 ### Manual
 


### PR DESCRIPTION
## What does this PR do?

From this commit:
https://github.com/ScoopInstaller/Main/pull/4805

Users can use Windows CLI.
`scoop install temporal-cli`


## Notes to reviewers

<!-- delete if n/a -->
