### PR TITLE
clarify that updates are synchronous replacements for queries and signals

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday October 03 2023 18:17:01 PM -0400
+Last assembled: Thursday October 05 2023 12:45:57 PM -0400
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docs-src/concepts/what-is-an-update.md
+++ b/docs-src/concepts/what-is-an-update.md
@@ -17,6 +17,12 @@ An Update is a request to and a response from a Temporal Client to a [Workflow E
 
 - [How to develop, send, and handle Updates in Go](/go/updates)
 
+You can think of an Update as a synchronous, blocking call that could replace both a Signal and a Query. An update is:
+
+- A Signal with a response
+- A Query that can change state
+- The logical model of a Signal with the overhead and latency of a Query
+
 The Workflow must have a function to handle the Update.
 Unlike a [Signal](/concepts/what-is-a-signal) handler, the Update handler function can mutate the state of the Workflow while also returning a value to the caller.
 The Update handler listens for Updates by the Update's name.
@@ -30,16 +36,16 @@ An Update has four phases.
    See the [Temporal Platform limits sheet](/kb/temporal-platform-limits-sheet) for more details.
    When this phase is complete, the Platform changes the status of the Update to **Admitted**.
    At this stage, the Platform hasn't yet persisted the Update to the Workflow Execution's Event History or sent it to a Worker.
-1. **Validation.** An optional developer provided function that performs request validation.
+2. **Validation.** An optional developer provided function that performs request validation.
    This validation code, similar to a [Query](/concepts/what-is-a-query) handler, can observe but not change the Workflow state.
    This means that the validation of an Update request may depend on the Workflow state at runtime.
    If an Update request doesn't pass validation at this stage, the system rejects the request and doesn't record anything in the Workflow Event History to indicate that the Update ever happened.
    The Update processing doesn't proceed to later phases.
    When the Update completes the validation stage, the Platform changes its state to **Accepted**.
    A [WorkflowExecutionUpdateAcceptedEvent](/references/events#workflowexecutionupdateacceptedevent) Event in the Workflow Execution [Event History](#event-history) denotes the acceptance of an Update.
-1. **Execution.** Accepted Update requests move to the execution phase.
+3. **Execution.** Accepted Update requests move to the execution phase.
    In this phase, the Worker delivers the request to the Update handler.
    Like every bit of code in a Workflow, Update handlers must be [deterministic](/concepts/what-is-a-workflow-definition#deterministic-constraints).
-1. **Completion.** The Update handler can return a result or a language-appropriate error/exception to indicate its completion.
+4. **Completion.** The Update handler can return a result or a language-appropriate error/exception to indicate its completion.
    The Platform sends the Update outcome back to the original invoking entity as an Update response.
    A [WorkflowExecutionUpdateCompletedEvent](/references/events#workflowexecutionupdatecompletedevent) Event in the Workflow Execution Event History denotes the completion of an Update.

--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -667,6 +667,12 @@ An Update is a request to and a response from a Temporal Client to a [Workflow E
 
 - [How to develop, send, and handle Updates in Go](/dev-guide/go/features#updates)
 
+You can think of an Update as a synchronous, blocking call that could replace both a Signal and a Query. An update is:
+
+- A Signal with a response
+- A Query that can change state
+- The logical model of a Signal with the overhead and latency of a Query
+
 The Workflow must have a function to handle the Update.
 Unlike a [Signal](#signal) handler, the Update handler function can mutate the state of the Workflow while also returning a value to the caller.
 The Update handler listens for Updates by the Update's name.
@@ -680,17 +686,17 @@ An Update has four phases.
    See the [Temporal Platform limits sheet](/kb/temporal-platform-limits-sheet) for more details.
    When this phase is complete, the Platform changes the status of the Update to **Admitted**.
    At this stage, the Platform hasn't yet persisted the Update to the Workflow Execution's Event History or sent it to a Worker.
-1. **Validation.** An optional developer provided function that performs request validation.
+2. **Validation.** An optional developer provided function that performs request validation.
    This validation code, similar to a [Query](#query) handler, can observe but not change the Workflow state.
    This means that the validation of an Update request may depend on the Workflow state at runtime.
    If an Update request doesn't pass validation at this stage, the system rejects the request and doesn't record anything in the Workflow Event History to indicate that the Update ever happened.
    The Update processing doesn't proceed to later phases.
    When the Update completes the validation stage, the Platform changes its state to **Accepted**.
    A [WorkflowExecutionUpdateAcceptedEvent](/references/events#workflowexecutionupdateacceptedevent) Event in the Workflow Execution [Event History](#event-history) denotes the acceptance of an Update.
-1. **Execution.** Accepted Update requests move to the execution phase.
+3. **Execution.** Accepted Update requests move to the execution phase.
    In this phase, the Worker delivers the request to the Update handler.
    Like every bit of code in a Workflow, Update handlers must be [deterministic](#deterministic-constraints).
-1. **Completion.** The Update handler can return a result or a language-appropriate error/exception to indicate its completion.
+4. **Completion.** The Update handler can return a result or a language-appropriate error/exception to indicate its completion.
    The Platform sends the Update outcome back to the original invoking entity as an Update response.
    A [WorkflowExecutionUpdateCompletedEvent](/references/events#workflowexecutionupdatecompletedevent) Event in the Workflow Execution Event History denotes the completion of an Update.
 


### PR DESCRIPTION
Adds some introductory text around updates to make the same connections as at Replay 2023 — they are a synchronous implementation of query/signal 