### PR TITLE
include JWKS endpoint in docs, as per Jonathan in EDU-1176

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -42,6 +42,7 @@ docs/concepts/temporal.md linguist-generated=true
 docs/concepts/visibility.md linguist-generated=true
 docs/concepts/workflows.md linguist-generated=true
 docs/concepts/workers.md linguist-generated=true
+docs/concepts/dataconversion.md linguist-generated=true
 docs/dev-guide/golang/debugging.md linguist-generated=true
 docs/dev-guide/golang/features.md linguist-generated=true
 docs/dev-guide/golang/foundations.md linguist-generated=true

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday October 05 2023 12:45:57 PM -0400
+Last assembled: Thursday October 05 2023 17:16:26 PM -0500
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly
 
 103 guide configurations found.
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday October 05 2023 17:16:26 PM -0500
+Last assembled: Friday October 06 2023 09:29:43 AM -0500
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docs-src/prod-readiness-context/how-to-set-up-codec-server.md
+++ b/docs-src/prod-readiness-context/how-to-set-up-codec-server.md
@@ -120,10 +120,7 @@ Use the access tokens to validate access and then return decoded payloads from t
 You can enable this by selecting **Pass access token** in your Codec Server endpoint interface where you add your endpoint.
 Enabling this option in the Temporal Cloud UI adds an authorization header to each request sent to the Codec Server endpoint that you set.
 
-In your Codec Server implementation, verify the signature on this access token (in your authorization header) against the JWKS endpoint provided to you.
-
-<!--Update: the JWKS link is provided in the UI onboarding content for now.
-Is this process defined? when a customer signs up for temporal cloud, do we provide them with the JWKS as part of the onboarding process? also the JWKS endpoint is rate-limited - something we should call out when providing the link to users.-->
+In your Codec Server implementation, verify the signature on this access token (in your authorization header) against [our JWKS endpoint](https://login.tmprl.cloud/.well-known/jwks.json).
 
 <!-- Commenting this for now.-->
 <!--If you want to unpack the claims in your token to add additional checks on whether the user has valid access to the Namespace and payloads they are trying to access, you can implement it using Auth0 SDKs, middleware, or one of the third-party libraries at JWT.io.-->

--- a/docs/concepts/dataconversion.md
+++ b/docs/concepts/dataconversion.md
@@ -389,10 +389,7 @@ Use the access tokens to validate access and then return decoded payloads from t
 You can enable this by selecting **Pass access token** in your Codec Server endpoint interface where you add your endpoint.
 Enabling this option in the Temporal Cloud UI adds an authorization header to each request sent to the Codec Server endpoint that you set.
 
-In your Codec Server implementation, verify the signature on this access token (in your authorization header) against the JWKS endpoint provided to you.
-
-<!--Update: the JWKS link is provided in the UI onboarding content for now.
-Is this process defined? when a customer signs up for temporal cloud, do we provide them with the JWKS as part of the onboarding process? also the JWKS endpoint is rate-limited - something we should call out when providing the link to users.-->
+In your Codec Server implementation, verify the signature on this access token (in your authorization header) against [our JWKS endpoint](https://login.tmprl.cloud/.well-known/jwks.json).
 
 <!-- Commenting this for now.-->
 <!--If you want to unpack the claims in your token to add additional checks on whether the user has valid access to the Namespace and payloads they are trying to access, you can implement it using Auth0 SDKs, middleware, or one of the third-party libraries at JWT.io.-->

--- a/docs/production-readiness/develop.md
+++ b/docs/production-readiness/develop.md
@@ -438,10 +438,7 @@ Use the access tokens to validate access and then return decoded payloads from t
 You can enable this by selecting **Pass access token** in your Codec Server endpoint interface where you add your endpoint.
 Enabling this option in the Temporal Cloud UI adds an authorization header to each request sent to the Codec Server endpoint that you set.
 
-In your Codec Server implementation, verify the signature on this access token (in your authorization header) against the JWKS endpoint provided to you.
-
-<!--Update: the JWKS link is provided in the UI onboarding content for now.
-Is this process defined? when a customer signs up for temporal cloud, do we provide them with the JWKS as part of the onboarding process? also the JWKS endpoint is rate-limited - something we should call out when providing the link to users.-->
+In your Codec Server implementation, verify the signature on this access token (in your authorization header) against [our JWKS endpoint](https://login.tmprl.cloud/.well-known/jwks.json).
 
 <!-- Commenting this for now.-->
 <!--If you want to unpack the claims in your token to add additional checks on whether the user has valid access to the Namespace and payloads they are trying to access, you can implement it using Auth0 SDKs, middleware, or one of the third-party libraries at JWT.io.-->


### PR DESCRIPTION
## What does this PR do?

Previously, the JKWS endpoint was provided to individuals during onboarding. As per Jonathan's request in EDU-1176, we will now include it in the documentation. I also removed the comment in the markdown file that asked how the endpoint URL was provided, since this question is no longer relevant as a result of this change.