### PR TITLE
Re-add info about Google SSO and Google account emails to user invite docs

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Friday October 06 2023 14:51:15 PM -0500
+Last assembled: Friday October 06 2023 15:02:54 PM -0500
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Friday October 06 2023 15:02:54 PM -0500
+Last assembled: Friday October 06 2023 15:05:56 PM -0500
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Friday October 06 2023 09:29:43 AM -0500
+Last assembled: Friday October 06 2023 14:51:15 PM -0500
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docs-src/cloud/users-invite.md
+++ b/docs-src/cloud/users-invite.md
@@ -10,9 +10,15 @@ tags:
   - temporal cloud account
 ---
 
+:::caution
+Access to Temporal Cloud can be authorized via Google OAuth single sign-on or SAML, depending on your account setup.
+
+If you are using Google OAuth for single sign-on and an email address is not associated with a Google Account, the user must follow the instructions in the [Use an existing email address](https://support.google.com/accounts/answer/27441?hl=en#existingemail) section of [Create a Google Account](https://support.google.com/accounts/answer/27441).
+:::
+
 When you create a user in Temporal Cloud, the prospective user receives an email invitation.
-Before accepting the invitation, the user must be logged in to the email address that received the invitation.
-The user must then select **Accept Invite** in the message.
+Before accepting the invitation, the user must be logged in to Google using the email address that received the invitation.
+The user must then click **Accept Invite** in the message.
 Attempting to log in to Temporal Cloud without first accepting the invite doesn't work.
 
 :::info

--- a/docs-src/cloud/users-invite.md
+++ b/docs-src/cloud/users-invite.md
@@ -24,7 +24,6 @@ Attempting to log in to Temporal Cloud without first accepting the invite doesn'
 **Important:** Do _not_ create a Gmail account when creating a Google Account.
 :::info
 
-
 To invite users, a user must have the Global Admin account-level [Role](/cloud/users-account-level-roles).
 
 :::

--- a/docs-src/cloud/users-invite.md
+++ b/docs-src/cloud/users-invite.md
@@ -23,6 +23,8 @@ Attempting to log in to Temporal Cloud without first accepting the invite doesn'
 
 :::info
 
+**Important:** Do _not_ create a Gmail account when creating a Google Account.
+
 To invite users, a user must have the Global Admin account-level [Role](/cloud/users-account-level-roles).
 
 :::

--- a/docs-src/cloud/users-invite.md
+++ b/docs-src/cloud/users-invite.md
@@ -21,9 +21,9 @@ Before accepting the invitation, the user must be logged in to Google using the 
 The user must then click **Accept Invite** in the message.
 Attempting to log in to Temporal Cloud without first accepting the invite doesn't work.
 
+**Important:** Do _not_ create a Gmail account when creating a Google Account.
 :::info
 
-**Important:** Do _not_ create a Gmail account when creating a Google Account.
 
 To invite users, a user must have the Global Admin account-level [Role](/cloud/users-account-level-roles).
 

--- a/docs-src/cloud/users-invite.md
+++ b/docs-src/cloud/users-invite.md
@@ -14,6 +14,8 @@ tags:
 Access to Temporal Cloud can be authorized via Google OAuth single sign-on or SAML, depending on your account setup.
 
 If you are using Google OAuth for single sign-on and an email address is not associated with a Google Account, the user must follow the instructions in the [Use an existing email address](https://support.google.com/accounts/answer/27441?hl=en#existingemail) section of [Create a Google Account](https://support.google.com/accounts/answer/27441).
+
+**Important:** Do _not_ create a Gmail account when creating a Google Account.
 :::
 
 When you create a user in Temporal Cloud, the prospective user receives an email invitation.
@@ -21,7 +23,6 @@ Before accepting the invitation, the user must be logged in to Google using the 
 The user must then click **Accept Invite** in the message.
 Attempting to log in to Temporal Cloud without first accepting the invite doesn't work.
 
-**Important:** Do _not_ create a Gmail account when creating a Google Account.
 :::info
 
 To invite users, a user must have the Global Admin account-level [Role](/cloud/users-account-level-roles).

--- a/docs/cloud/account-setup/users.md
+++ b/docs/cloud/account-setup/users.md
@@ -41,6 +41,8 @@ tags:
 Access to Temporal Cloud can be authorized via Google OAuth single sign-on or SAML, depending on your account setup.
 
 If you are using Google OAuth for single sign-on and an email address is not associated with a Google Account, the user must follow the instructions in the [Use an existing email address](https://support.google.com/accounts/answer/27441?hl=en#existingemail) section of [Create a Google Account](https://support.google.com/accounts/answer/27441).
+
+**Important:** Do _not_ create a Gmail account when creating a Google Account.
 :::
 
 When you create a user in Temporal Cloud, the prospective user receives an email invitation.
@@ -48,7 +50,6 @@ Before accepting the invitation, the user must be logged in to Google using the 
 The user must then click **Accept Invite** in the message.
 Attempting to log in to Temporal Cloud without first accepting the invite doesn't work.
 
-**Important:** Do _not_ create a Gmail account when creating a Google Account.
 :::info
 
 To invite users, a user must have the Global Admin account-level [Role](#account-level-roles).

--- a/docs/cloud/account-setup/users.md
+++ b/docs/cloud/account-setup/users.md
@@ -37,9 +37,15 @@ tags:
 
 ## How to invite users to your Temporal Cloud account {#invite-users}
 
+:::caution
+Access to Temporal Cloud can be authorized via Google OAuth single sign-on or SAML, depending on your account setup.
+
+If you are using Google OAuth for single sign-on and an email address is not associated with a Google Account, the user must follow the instructions in the [Use an existing email address](https://support.google.com/accounts/answer/27441?hl=en#existingemail) section of [Create a Google Account](https://support.google.com/accounts/answer/27441).
+:::
+
 When you create a user in Temporal Cloud, the prospective user receives an email invitation.
-Before accepting the invitation, the user must be logged in to the email address that received the invitation.
-The user must then select **Accept Invite** in the message.
+Before accepting the invitation, the user must be logged in to Google using the email address that received the invitation.
+The user must then click **Accept Invite** in the message.
 Attempting to log in to Temporal Cloud without first accepting the invite doesn't work.
 
 :::info

--- a/docs/cloud/account-setup/users.md
+++ b/docs/cloud/account-setup/users.md
@@ -48,6 +48,7 @@ Before accepting the invitation, the user must be logged in to Google using the 
 The user must then click **Accept Invite** in the message.
 Attempting to log in to Temporal Cloud without first accepting the invite doesn't work.
 
+**Important:** Do _not_ create a Gmail account when creating a Google Account.
 :::info
 
 To invite users, a user must have the Global Admin account-level [Role](#account-level-roles).


### PR DESCRIPTION
## What does this PR do?

As per EDU-1183, this revision updates the "How to invite users to your Temporal Cloud account" page in the documentation to reinstate information that was removed as a result of EDU-201. While Temporal Cloud now supports SAML in addition to SSO through Google, some of the information removed was still relevant, and its removal led to support requests from our customers.