### PR TITLE
Clarify User and Namespace Limits in Documentation

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday October 11 2023 09:16:50 AM -0600
+Last assembled: Wednesday October 11 2023 10:00:58 AM -0700
 
-Assembly Workflow Id: docs-full-assembly
+Assembly Workflow Id: docs-full-assembly-rachfop-123
 
 104 guide configurations found.
 

--- a/docs-src/cloud/temporal-cloud-limits-sheet.md
+++ b/docs-src/cloud/temporal-cloud-limits-sheet.md
@@ -57,8 +57,8 @@ These default limits are configurable by creating a [support ticket](/cloud/supp
 
 At the account level, Temporal Cloud sets the following default limits:
 
-- Users: 100
-- Namespaces: 10
+- Users: 300 across all Namespaces. To increase this number, open a [support ticket](/cloud/support#support-ticket).
+- Namespaces: 10. This can be incrementally increased up to 100. To further extend the limit beyond 100, open a [support ticket](/cloud/support#support-ticket).
 
 ### How much data does the Prometheus endpoint retain?
 

--- a/docs/cloud/introduction/operating-envelope.md
+++ b/docs/cloud/introduction/operating-envelope.md
@@ -162,8 +162,8 @@ These default limits are configurable by creating a [support ticket](/cloud/supp
 
 At the account level, Temporal Cloud sets the following default limits:
 
-- Users: 100
-- Namespaces: 10
+- Users: 300 across all Namespaces. To increase this number, open a [support ticket](/cloud/support#support-ticket).
+- Namespaces: 10. This can be incrementally increased up to 100. To further extend the limit beyond 100, open a [support ticket](/cloud/support#support-ticket).
 
 ### How much data does the Prometheus endpoint retain?
 


### PR DESCRIPTION
**Description**:

This PR updates the documentation to provide clearer information about the default limits set by Temporal Cloud at the account level. 

### Changes:

- Specified that the default user limit is 300 users [across all namespaces/per namespace] (based on the actual system behavior or policy).
- Reformatted the list for better readability and emphasis on key points.

### Motivation:

There was potential ambiguity in the original documentation about whether the user limit applied across all namespaces or per namespace. This update seeks to eliminate any confusion for our users, ensuring they have a precise understanding of our default limits.
