### PR TITLE
Delete docs changelog and redirect users to temporal.io/change-log

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Welcome to Temporal's documentation repository!
   - [/docs-src information nodes](#docs-src-information-nodes)
   - [/docs generated files for Docusaurus](#docs-generated-files-for-docusaurus)
   - [/assembly Assembly Workflow](#assembly-assembly-workflow)
-  - [/changelog Docs site changelog](#changelog-docs-site-changelog)
   - [Snipsync code synchronization tooling](#snipsync-code-synchronization-tooling)
 - [How to get approval to create a pull request](#how-to-get-approval-to-create-a-pull-request)
 - [How to fix a typo](#how-to-fix-a-typo)
@@ -100,12 +99,6 @@ See [How to run the Assembly Workflow](#how-to-run-the-assembly-workflow) for mo
 
 Beyond creating generated files, the Assembly Workflow can generate information nodes for documentation code-sample repositories.
 For more information, see [How to use DACX](#how-to-use-dacx).
-
-### `/changelog` Docs site changelog
-
-This directory contains logs of major changes to the documentation.
-
-The information at [docs.temporal.io](http://docs.temporal.io) changes frequently, but bigger and more notable changes are captured in the changelog.
 
 ### Snipsync code synchronization tooling
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -89,12 +89,6 @@ module.exports = {
           position: "left",
         },
         {
-          label: "Docs changelog",
-          to: "/changelog",
-          activeBasePath: "changelog",
-          position: "left",
-        },
-        {
           label: "Learn Temporal",
           href: "https://learn.temporal.io",
           right: "left",
@@ -343,34 +337,6 @@ module.exports = {
         },
       };
     },
-    [
-      "@docusaurus/plugin-content-blog",
-      {
-        /**
-         * Required for any multi-instance plugin
-         */
-        id: "changelog",
-        /**
-         * URL route for the blog section of your site.
-         * *DO NOT* include a trailing slash.
-         */
-        routeBasePath: "changelog",
-        /**
-         * Path to data on filesystem relative to site dir.
-         */
-        blogTitle: "Temporal documentation changelog",
-        blogSidebarTitle: "Docs changelog",
-        path: "changelog",
-        routeBasePath: "changelog",
-        blogSidebarCount: "ALL",
-        blogDescription: "A log of changes to this site's content.",
-        showReadingTime: false, // Show estimated reading time for the blog post.
-        feedOptions: {
-          type: "all",
-          copyright: `Copyright © ${new Date().getFullYear()} Temporal Technologies Inc.  All rights reserved. Copyright © 2020 Uber Technologies, Inc.`,
-        },
-      },
-    ],
     [
       "@docusaurus/plugin-content-blog",
       {

--- a/src/pages/changelog.js
+++ b/src/pages/changelog.js
@@ -5,7 +5,7 @@ function ChangelogRedirect() {
         window.location.href = "https://temporal.io/change-log";
     }, []);
 
-    return null;  // Return null since we don't need any actual rendering here.
+    return null;
 }
 
 export default ChangelogRedirect;

--- a/src/pages/changelog.js
+++ b/src/pages/changelog.js
@@ -1,0 +1,11 @@
+import React, { useEffect } from 'react';
+
+function ChangelogRedirect() {
+    useEffect(() => {
+        window.location.href = "https://temporal.io/change-log";
+    }, []);
+
+    return null;  // Return null since we don't need any actual rendering here.
+}
+
+export default ChangelogRedirect;

--- a/vercel.json
+++ b/vercel.json
@@ -378,8 +378,8 @@
       "destination": "/dev-guide/go/versioning:path*"
     },
     {
-      "source": "/change-log",
-      "destination": "/changelog"
+      "source": "/changelog",
+      "destination": "https://temporal.io/change-log"
     },
     {
       "source": "/blog/how-datadog-ensures-database-reliability-with-temporal",


### PR DESCRIPTION
This PR deletes the changelog config and redirects them instead to temporal.io/change-log, so that if a user goes to "https://docs.temporal.io/changelog", they will now be directed to "temporal.io/change-log". See screen record of new changes:


https://github.com/temporalio/documentation/assets/141692465/49d7e154-e3e5-4ded-bec8-260f06e9cdf5

