### PR TITLE
change typescript link title for consistency

### DIFF
--- a/docs-src/concepts/what-is-a-temporal-sdk.md
+++ b/docs-src/concepts/what-is-a-temporal-sdk.md
@@ -22,7 +22,7 @@ Temporal currently offers the following SDKs:
 - [Get started with the Java SDK](/java/introduction-to-java-sdk)
 - [Get started with the PHP SDK](/dev-guide/php)
 - [Get started with the Python SDK](/python/introduction-to-python-sdk)
-- [How to use the TypeScript SDK](/typescript/introduction-to-typescript-sdk)
+- [Get started with the TypeScript SDK](/typescript/introduction-to-typescript-sdk)
 
 Each SDK emits metrics which can be ingested into monitoring platforms.
 See the [SDK metrics reference](/references/sdk-metrics) for a complete list.

--- a/docs/concepts/temporal.md
+++ b/docs/concepts/temporal.md
@@ -81,7 +81,7 @@ Temporal currently offers the following SDKs:
 - [Get started with the Java SDK](/dev-guide/java/introduction#)
 - [Get started with the PHP SDK](/dev-guide/php)
 - [Get started with the Python SDK](/dev-guide/python/introduction#)
-- [How to use the TypeScript SDK](/dev-guide/typescript/introduction#)
+- [Get started with the TypeScript SDK](/dev-guide/typescript/introduction#)
 
 Each SDK emits metrics which can be ingested into monitoring platforms.
 See the [SDK metrics reference](/references/sdk-metrics#) for a complete list.


### PR DESCRIPTION
## What does this PR do?

Fixes a tiny nit with https://docs.temporal.io/temporal

When linking to the various SDKs, the typescript link has a different format than the other languages.
