### PR TITLE
include go get command for installing the SDK

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday October 16 2023 13:36:19 PM -0700
+Last assembled: Wednesday October 18 2023 09:34:22 AM -0700
 
 Assembly Workflow Id: docs-full-assembly
 
@@ -53,8 +53,6 @@ concepts/what-is-a-global-namespace -> /namespaces#global-namespace
 concepts/what-is-the-temporal-server -> /clusters#temporal-server
 
 concepts/what-is-multi-cluster-replication -> /clusters#multi-cluster-replication
-
-cloud/security-cloud-intro -> #
 
 references/server-options -> /references/server-options#withconfig
 
@@ -1081,5 +1079,7 @@ cli/server/start-dev -> /cli/server#start-dev
 cli/operator/namespace/create -> /cli/operator#create
 
 cli/workflow/start -> /cli/workflow#start
+
+cloud/security-cloud-intro -> #
 
 

--- a/docs-src/go/project-structure.md
+++ b/docs-src/go/project-structure.md
@@ -72,12 +72,16 @@ If you are following along with this guide, your project will look like this:
 
 ### Initialize Go project dependency framework
 
-If you have created a similar project structure as noted earlier, run `go mod init` to create a new Go module for this project.
+If you have created a similar project structure as noted earlier, run `go mod init` to create a new Go module for this project. The module name will be something like `<your_name>/backgroundcheck`:
 
-```bash
+```shell
 mkdir backgroundcheck
 cd backgroundcheck
-go mod init
+go mod init github.com/your_name/backgroundcheck
 ```
 
-The module name will be something like `<repo>/backgroundcheck` .
+Then, use `go get` to install the Temporal Go SDK:
+
+```shell
+go get go.temporal.io/sdk
+```

--- a/docs/dev-guide/golang/project-setup.md
+++ b/docs/dev-guide/golang/project-setup.md
@@ -339,15 +339,19 @@ If you are following along with this guide, your project will look like this:
 
 ### Initialize Go project dependency framework
 
-If you have created a similar project structure as noted earlier, run `go mod init` to create a new Go module for this project.
+If you have created a similar project structure as noted earlier, run `go mod init` to create a new Go module for this project. The module name will be something like `<your_name>/backgroundcheck`:
 
-```bash
+```shell
 mkdir backgroundcheck
 cd backgroundcheck
-go mod init
+go mod init github.com/your_name/backgroundcheck
 ```
 
-The module name will be something like `<repo>/backgroundcheck` .
+Then, use `go get` to install the Temporal Go SDK:
+
+```shell
+go get go.temporal.io/sdk
+```
 
 ### Boilerplate Workflow code {#workflow-code}
 


### PR DESCRIPTION
from just chatting with @MasonEgger while he was working on the Java page -- we're kind of skipping over actually retrieving the SDK module in the current Go docs, this fixes it.