### PR TITLE
Adds Start Delay to Concept docs

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,14 +1,14 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday October 24 2023 14:14:07 PM -0700
+Last assembled: Tuesday October 24 2023 17:18:43 PM -0700
 
 Assembly Workflow Id: docs-full-assembly-rachfop-123
 
 110 guide configurations found.
 
-1641 information nodes found.
+1642 information nodes found.
 
-1403 information nodes are attached to guides.
+1404 information nodes are attached to guides.
 
 The "Link Magic" Activity transformed the following "information node" identifiers into site paths:
 

--- a/assembly/guide-configs/concepts/workflows.json
+++ b/assembly/guide-configs/concepts/workflows.json
@@ -113,6 +113,10 @@
     },
     {
       "type": "h2",
+      "id": "concepts/what-is-a-delay-start-workflow-execution"
+    },
+    {
+      "type": "h2",
       "id": "concepts/what-is-a-state-transition"
     }
   ]

--- a/docs-src/concepts/what-is-a-delay-start-workflow-execution.md
+++ b/docs-src/concepts/what-is-a-delay-start-workflow-execution.md
@@ -1,0 +1,27 @@
+---
+id: what-is-a-delay-start-workflow-execution
+title: What is a Start Delay?
+description: Start Delay determines the amount of time to wait before initiating a Workflow Execution. If the Workflow receives a Signal during the delay, it dispatches a Workflow Task and the remaining delay is bypassed. Note that Start Delay is incompatible with cron_schedule and is still in the experimental phase.
+sidebar_label: Delay Workflow Execution
+tags:
+    - term
+    - explanation
+    - delay-workflow
+---
+
+Start Delay determines the amount of time to wait before initiating a Workflow Execution.
+
+:::note
+
+You can set either a Delay Start Workflow Execution or a [Schedule](/concepts/what-is-a-schedule), but not both.
+
+This Workflow Option is considered experimental and may change in future releases.
+
+:::
+
+This is useful if you have a Workflow you want to schedule out in the future, but only want it to execute once.
+
+If the Workflow receives a Signal-With-Start during the delay, it dispatches a Workflow Task and the remaining delay is bypassed.
+If the Workflow receives a Signal during the delay that is not a Signal-With-Start, it is ignored and the Workflow continues to be delayed until the delay expires or a Signal-With-Start is received.
+
+You can delay the dispatch of the initial Workflow Execution by setting this option in the Workflow Options field of the SDK of your choice.

--- a/docs/concepts/activities.md
+++ b/docs/concepts/activities.md
@@ -64,7 +64,7 @@ In the context of Temporal, Activities should be designed to be safely executed 
 
 :::info
 
-By design, completed Activities will not re-execute as part of a [Workflow Replay](/workflows#replays). However, Activites won’t record to the [Event History](/retry-policies#event-history) until they return or produce an error. If an Activity fails to report to the server at all, it will be retried. Designing for idempotence, especially if you have a [Global Namespace](/namespaces#global-namespace), will improve reusability and reliability.
+By design, completed Activities will not re-execute as part of a [Workflow Replay](/workflows#replays). However, Activities won’t record to the [Event History](/retry-policies#event-history) until they return or produce an error. If an Activity fails to report to the server at all, it will be retried. Designing for idempotence, especially if you have a [Global Namespace](/namespaces#global-namespace), will improve reusability and reliability.
 
 :::
 

--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -10,6 +10,7 @@ keywords:
 - child-workflow
 - child-workflow-executions
 - continue-as-new
+- delay-workflow
 - explanation
 - queries
 - resets
@@ -21,6 +22,7 @@ tags:
 - child-workflow
 - child-workflow-executions
 - continue-as-new
+- delay-workflow
 - explanation
 - queries
 - resets
@@ -1135,6 +1137,25 @@ A Temporal Cron Job does not stop spawning Runs until it has been Terminated or 
 A Cancellation Request affects only the current Run.
 
 Use the Workflow Id in any requests to Cancel or Terminate.
+
+## What is a Start Delay? {#delay-workflow-execution}
+
+Start Delay determines the amount of time to wait before initiating a Workflow Execution.
+
+:::note
+
+You can set either a Delay Start Workflow Execution or a [Schedule](#schedule), but not both.
+
+This Workflow Option is considered experimental and may change in future releases.
+
+:::
+
+This is useful if you have a Workflow you want to schedule out in the future, but only want it to execute once.
+
+If the Workflow receives a Signal-With-Start during the delay, it dispatches a Workflow Task and the remaining delay is bypassed.
+If the Workflow receives a Signal during the delay that is not a Signal-With-Start, it is ignored and the Workflow continues to be delayed until the delay expires or a Signal-With-Start is received.
+
+You can delay the dispatch of the initial Workflow Execution by setting this option in the Workflow Options field of the SDK of your choice.
 
 ## What is a State Transition? {#state-transition}
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -145,6 +145,12 @@ The default Data Converter is used by the Temporal SDK to convert objects into b
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
 
+#### [Delay Workflow Execution](/workflows#delay-workflow-execution)
+Start Delay determines the amount of time to wait before initiating a Workflow Execution. If the Workflow receives a Signal during the delay, it dispatches a Workflow Task and the remaining delay is bypassed. Note that Start Delay is incompatible with cron_schedule and is still in the experimental phase.
+
+_Tags: [term](/tags/term), [explanation](/tags/explanation), [delay-workflow](/tags/delay-workflow)_
+
+
 #### [Dual Visibility](/visibility#dual-visibility)
 Dual Visibility is a feature that lets you set a secondary Visibility store in your Temporal Cluster to facilitate migrating your Visibility data from one database to another.
 


### PR DESCRIPTION
## What does this PR do?

Adds Start Delay to docs.
This is because users want a one-off scheduled like feature.

Concepts docs first, then code samples.

## Notes to reviewers

### SDKs

* [x] Go - https://github.com/temporalio/sdk-go/issues/1243
* [x] Java - https://github.com/temporalio/sdk-java/issues/1863
* [ ] TypeScript - https://github.com/temporalio/sdk-typescript/issues/1262
* [x] Python - https://github.com/temporalio/sdk-python/issues/404
* [x] .NET - https://github.com/temporalio/sdk-dotnet/issues/145

<!-- delete if n/a -->
