### PR TITLE
Fix admonitions

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday October 26 2023 12:56:28 PM -0700
+Last assembled: Thursday October 26 2023 13:13:04 PM -0700
 
 Assembly Workflow Id: docs-full-assembly-rachfop-123
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday October 26 2023 13:13:04 PM -0700
+Last assembled: Thursday October 26 2023 13:14:57 PM -0700
 
 Assembly Workflow Id: docs-full-assembly-rachfop-123
 

--- a/docs-src/concepts/what-is-an-authorizer-plugin.md
+++ b/docs-src/concepts/what-is-an-authorizer-plugin.md
@@ -24,7 +24,7 @@ The following arguments must be passed to `Authorizer`:
 - `DecisionDeny`: the requested API call is not invoked and an error is returned to the caller.
 - `DecisionAllow`: the requested API call is invoked.
 
-::: caution
+:::caution
 
 `Authorizer` allows all API calls pass by default. Disable the `nopAuthority` authorizer and configure your own to prevent this behavior.
 

--- a/docs-src/concepts/what-is-an-authorizer-plugin.md
+++ b/docs-src/concepts/what-is-an-authorizer-plugin.md
@@ -24,7 +24,7 @@ The following arguments must be passed to `Authorizer`:
 - `DecisionDeny`: the requested API call is not invoked and an error is returned to the caller.
 - `DecisionAllow`: the requested API call is invoked.
 
-:::warning
+::: caution
 
 `Authorizer` allows all API calls pass by default. Disable the `nopAuthority` authorizer and configure your own to prevent this behavior.
 

--- a/docs-src/typescript/async-design-patterns.md
+++ b/docs-src/typescript/async-design-patterns.md
@@ -64,7 +64,7 @@ export async function yourWorkflow(userId: string) {
 
 You can invert this to create a reminder pattern where the promise resolves _if_ no Signal is received.
 
-:::warning Antipattern: Racing sleep.then
+::: caution Antipattern: Racing sleep.then
 
 Be careful when racing a chained `sleep`.
 This might cause bugs because the chained `.then` will still continue to execute.

--- a/docs-src/typescript/async-design-patterns.md
+++ b/docs-src/typescript/async-design-patterns.md
@@ -64,7 +64,7 @@ export async function yourWorkflow(userId: string) {
 
 You can invert this to create a reminder pattern where the promise resolves _if_ no Signal is received.
 
-::: caution Antipattern: Racing sleep.then
+:::caution Antipattern: Racing sleep.then
 
 Be careful when racing a chained `sleep`.
 This might cause bugs because the chained `.then` will still continue to execute.

--- a/docs-src/typescript/workflows.md
+++ b/docs-src/typescript/workflows.md
@@ -692,7 +692,7 @@ export async function OneClickBuy(itemId: string) {
 
 </details>
 
-:::warning `condition` Antipatterns
+::: caution `condition` Antipatterns
 
 - No time based condition functions are allowed in your function as this is very error prone.
   Use the optional `timeout` arg or a `sleep` timer.
@@ -762,7 +762,7 @@ export async function yourWorkflow(userId: string) {
 
 You can invert this to create a Reminder pattern where the promise resolves IF no Signal is received.
 
-:::warning Antipattern: Racing sleep.then
+::: caution Antipattern: Racing sleep.then
 
 Be careful when racing a chained `sleep`. This may cause bugs because the chained `.then` will still continue to execute.
 

--- a/docs-src/typescript/workflows.md
+++ b/docs-src/typescript/workflows.md
@@ -692,7 +692,7 @@ export async function OneClickBuy(itemId: string) {
 
 </details>
 
-::: caution `condition` Antipatterns
+:::caution `condition` Antipatterns
 
 - No time based condition functions are allowed in your function as this is very error prone.
   Use the optional `timeout` arg or a `sleep` timer.
@@ -762,7 +762,7 @@ export async function yourWorkflow(userId: string) {
 
 You can invert this to create a Reminder pattern where the promise resolves IF no Signal is received.
 
-::: caution Antipattern: Racing sleep.then
+:::caution Antipattern: Racing sleep.then
 
 Be careful when racing a chained `sleep`. This may cause bugs because the chained `.then` will still continue to execute.
 

--- a/docs/dev-guide/tscript/features.md
+++ b/docs/dev-guide/tscript/features.md
@@ -971,7 +971,7 @@ export async function yourWorkflow(userId: string) {
 
 You can invert this to create a reminder pattern where the promise resolves _if_ no Signal is received.
 
-::: caution Antipattern: Racing sleep.then
+:::caution Antipattern: Racing sleep.then
 
 Be careful when racing a chained `sleep`.
 This might cause bugs because the chained `.then` will still continue to execute.

--- a/docs/dev-guide/tscript/features.md
+++ b/docs/dev-guide/tscript/features.md
@@ -971,7 +971,7 @@ export async function yourWorkflow(userId: string) {
 
 You can invert this to create a reminder pattern where the promise resolves _if_ no Signal is received.
 
-:::warning Antipattern: Racing sleep.then
+::: caution Antipattern: Racing sleep.then
 
 Be careful when racing a chained `sleep`.
 This might cause bugs because the chained `.then` will still continue to execute.

--- a/docs/security.md
+++ b/docs/security.md
@@ -249,7 +249,7 @@ The following arguments must be passed to `Authorizer`:
 - `DecisionDeny`: the requested API call is not invoked and an error is returned to the caller.
 - `DecisionAllow`: the requested API call is invoked.
 
-:::warning
+::: caution
 
 `Authorizer` allows all API calls pass by default. Disable the `nopAuthority` authorizer and configure your own to prevent this behavior.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -249,7 +249,7 @@ The following arguments must be passed to `Authorizer`:
 - `DecisionDeny`: the requested API call is not invoked and an error is returned to the caller.
 - `DecisionAllow`: the requested API call is invoked.
 
-::: caution
+:::caution
 
 `Authorizer` allows all API calls pass by default. Disable the `nopAuthority` authorizer and configure your own to prevent this behavior.
 

--- a/kb/production-deploy.md
+++ b/kb/production-deploy.md
@@ -58,7 +58,7 @@ At minimum, the `development.yaml` file needs to have the [`global`](/references
 
 The [Server configuration reference](/references/configuration) has a more complete list of possible parameters.
 
-::: caution Before you deploy: Reminder on shard count
+:::caution Before you deploy: Reminder on shard count
 
 A huge part of production deploy is understanding current and future scale - the **number of shards can't be changed after the cluster is in use** so this decision needs to be upfront. Shard count determines scaling to improve concurrency if you start getting lots of lock contention.
 The default `numHistoryShards` is 4; deployments at scale can go up to 500-2000 shards.
@@ -188,7 +188,7 @@ Temporal Web's tracing capabilities mainly track activity execution within a Tem
 
 ## Further things to consider
 
-::: caution
+:::caution
 
 This document is still being written, and we would welcome your questions and contributions.
 

--- a/kb/production-deploy.md
+++ b/kb/production-deploy.md
@@ -58,7 +58,7 @@ At minimum, the `development.yaml` file needs to have the [`global`](/references
 
 The [Server configuration reference](/references/configuration) has a more complete list of possible parameters.
 
-:::warning Before you deploy: Reminder on shard count
+::: caution Before you deploy: Reminder on shard count
 
 A huge part of production deploy is understanding current and future scale - the **number of shards can't be changed after the cluster is in use** so this decision needs to be upfront. Shard count determines scaling to improve concurrency if you start getting lots of lock contention.
 The default `numHistoryShards` is 4; deployments at scale can go up to 500-2000 shards.
@@ -188,7 +188,7 @@ Temporal Web's tracing capabilities mainly track activity execution within a Tem
 
 ## Further things to consider
 
-:::warning
+::: caution
 
 This document is still being written, and we would welcome your questions and contributions.
 


### PR DESCRIPTION
## What does this PR do?

`:::warning` is not a valid note.
https://docusaurus.io/docs/markdown-features/admonitions

Replaced with `:::caution`.

## Notes to reviewers

<!-- delete if n/a -->
