### PR TITLE
Adds notes on PrivateLinkV2

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday November 08 2023 12:18:48 PM -0700
+Last assembled: Wednesday November 08 2023 12:36:05 PM -0800
 
-Assembly Workflow Id: docs-full-assembly-flossypurse
+Assembly Workflow Id: docs-full-assembly-rachfop-123
 
 111 guide configurations found.
 
@@ -420,7 +420,7 @@ concepts/what-is-an-activity-definition -> #activity-definition
 
 concepts/what-is-an-activity-heartbeat -> #activity-heartbeat
 
-go/generated/how-to-develop-an-activity-definition-in-go -> /dev-guide/go/foundations#activity-definition
+go/how-to-develop-an-activity-definition-in-go -> /dev-guide/go/foundations#activity-definition
 
 java/developing-activities -> /dev-guide/java/foundations#develop-activities
 
@@ -530,15 +530,13 @@ python/workflow-retries -> /dev-guide/python/features#workflow-retries
 
 typescript/workflow-retries -> /dev-guide/typescript/features#workflow-retries
 
-concepts/what-is-durable-execution -> #durable-execution
-
 concepts/what-is-a-worker-process -> /workers#worker-process
 
 concepts/what-is-a-temporal-client -> #temporal-client
 
 concepts/what-is-a-worker-program -> /workers#worker-program
 
-go/chapter-introduction/introduction-to-go-sdk -> /dev-guide/go/introduction#
+go/introduction-to-go-sdk -> /dev-guide/go/introduction#
 
 java/introduction-to-java-sdk -> /dev-guide/java/introduction#
 
@@ -564,7 +562,7 @@ typescript/visibility -> /dev-guide/typescript/observability#visibility
 
 concepts/what-is-a-worker-entity -> #worker-entity
 
-go/generated/how-to-develop-a-worker-in-go -> /dev-guide/go/foundations#develop-worker
+go/how-to-develop-a-worker-in-go -> /dev-guide/go/foundations#develop-worker
 
 java/how-to-develop-a-worker-program-in-java -> /dev-guide/java/foundations#run-a-dev-worker
 
@@ -694,10 +692,6 @@ go/updates -> /dev-guide/go/features#updates
 
 java/updates -> /dev-guide/java/features#updates
 
-java/what-is-a-dynamic-handler -> /dev-guide/java/features#dynamic-handler
-
-python/what-is-a-dynamic-handler -> /dev-guide/python/features#dynamic-handler
-
 concepts/what-is-a-parent-close-policy -> #parent-close-policy
 
 go/parent-close-policy -> /dev-guide/go/features#parent-close-policy
@@ -709,6 +703,8 @@ php/parent-close-policy -> /dev-guide/php/features#parent-close-policy
 python/parent-close-policy -> /dev-guide/python/features#parent-close-policy
 
 typescript/parent-close-policy -> /dev-guide/typescript/features#parent-close-policy
+
+concepts/what-is-a-delay-start-workflow-execution -> #delay-workflow-execution
 
 go/cron-jobs -> /dev-guide/go/features#temporal-cron-jobs
 
@@ -1014,8 +1010,6 @@ dev-guide/temporal-application -> #temporal-application
 
 dev-guide/official-sdks -> #official-sdks
 
-go/chapter-durable-execution/durable-execution-intro -> /dev-guide/go/durable-execution#
-
 references/strongly-typed-errors/non-deterministic-error -> /references/errors#non-deterministic-error
 
 typescript/testing -> /dev-guide/typescript/testing#replay
@@ -1102,6 +1096,46 @@ go/tracing -> /dev-guide/go/observability#tracing-and-context-propogation
 
 go/logging -> /dev-guide/go/observability#logging
 
+go/connect-to-a-dev-cluster -> #connect-to-a-dev-cluster
+
+go/how-to-customize-workflow-type-in-go -> #customize-workflow-type
+
+go/how-to-customize-activity-type-in-go -> #customize-activity-type
+
+go/go-dev-guide-structure -> #
+
+go/install-cli -> /dev-guide/go/project-setup#install-cli
+
+go/choose-dev-cluster -> /dev-guide/go/project-setup#choose-dev-cluster
+
+go/project-structure -> /dev-guide/go/project-setup#boilerplate-project
+
+go/backgroundcheck-boilerplate-run-a-dev-server-worker -> /dev-guide/go/project-setup#dev-server-worker
+
+go/backgroundcheck-boilerplate-cloud-worker -> /dev-guide/go/project-setup#cloud-worker
+
+go/self-hosted-worker-docker-network -> /dev-guide/go/project-setup#dockerfile
+
+go/backgroundcheck-boilerplate-start-workflow -> /dev-guide/go/project-setup#local-dev-server
+
+go/backgroundcheck-boilerplate-add-test-framework -> /dev-guide/go/project-setup#test-framework
+
+go/foundations -> /dev-guide/go/foundations#
+
+go/generated/how-to-develop-an-activity-definition-in-go -> /dev-guide/go/foundations#activity-definition
+
+concepts/what-is-durable-execution -> #durable-execution
+
+go/chapter-introduction/introduction-to-go-sdk -> /dev-guide/go/introduction#
+
+go/generated/how-to-develop-a-worker-in-go -> /dev-guide/go/foundations#develop-worker
+
+java/what-is-a-dynamic-handler -> /dev-guide/java/features#dynamic-handler
+
+python/what-is-a-dynamic-handler -> /dev-guide/python/features#dynamic-handler
+
+go/chapter-durable-execution/durable-execution-intro -> /dev-guide/go/durable-execution#
+
 dev-guide/why-use-a-temporal-sdk -> /dev-guide/sdks#replays
 
 go/chapter-project-setup/project-setup-introduction -> /dev-guide/go/project-setup#
@@ -1113,8 +1147,6 @@ go/chapter-durable-execution/non-deterministic-code-changes -> #durability-throu
 go/chapter-project-setup/backgroundcheck-boilerplate-start-workflow -> /dev-guide/go/project-setup#start-workflow
 
 go/chapter-durable-execution/retrieve-event-history -> #retrieve-event-history
-
-go/connect-to-a-dev-cluster -> #connect-to-a-dev-cluster
 
 go/generated/how-to-customize-workflow-type-in-go -> #customize-workflow-type
 
@@ -1129,7 +1161,5 @@ go/chapter-project-setup/project-structure -> /dev-guide/go/project-setup#boiler
 go/generated/backgroundcheck-boilerplate-run-a-dev-server-worker -> /dev-guide/go/project-setup#dev-server-worker
 
 go/generated/backgroundcheck-boilerplate-add-test-framework -> /dev-guide/go/project-setup#test-framework
-
-go/foundations -> /dev-guide/go/foundations#
 
 

--- a/docs-src/cloud/security-cloud-platform.md
+++ b/docs-src/cloud/security-cloud-platform.md
@@ -18,6 +18,16 @@ A Namespace (regardless of account) cannot interact with other Namespaces.
 Each Namespace is available through a secure gRPC (mTLS) endpoint and an HTTPS (TLS) endpoint.
 You can make these endpoints more secure by routing all communication through AWS PrivateLink.
 
+:::note
+
+If you are interested in leveraging AWS PrivateLink in your Namespaces, [create a support ticket](/cloud/support#support-ticket) that includes the following information:
+
+- AWS Region: The Region in which your connection will go through.
+- AWS Account Id: The account which contains the permissions to enable AWS PrivateLink.
+- Temporal Cloud Namespace names: The name of the Namespaces you want to enable AWS PrivateLink with.
+
+:::
+
 Temporal Cloud is a multi-tenant service.
 Namespaces in the same environment are logically segregated.
 Namespaces do not share data processing or data storage across regional boundaries.

--- a/docs/cloud/introduction/security.md
+++ b/docs/cloud/introduction/security.md
@@ -60,6 +60,16 @@ A Namespace (regardless of account) cannot interact with other Namespaces.
 Each Namespace is available through a secure gRPC (mTLS) endpoint and an HTTPS (TLS) endpoint.
 You can make these endpoints more secure by routing all communication through AWS PrivateLink.
 
+:::note
+
+If you are interested in leveraging AWS PrivateLink in your Namespaces, [create a support ticket](/cloud/support#support-ticket) that includes the following information:
+
+- AWS Region: The Region in which your connection will go through.
+- AWS Account Id: The account which contains the permissions to enable AWS PrivateLink.
+- Temporal Cloud Namespace names: The name of the Namespaces you want to enable AWS PrivateLink with.
+
+:::
+
 Temporal Cloud is a multi-tenant service.
 Namespaces in the same environment are logically segregated.
 Namespaces do not share data processing or data storage across regional boundaries.


### PR DESCRIPTION
## What does this PR do?

[Preview](https://temporal-documentation-9kwpms5xb.preview.thundergun.io/cloud/security#namespace-isolation)

This lets customers know that PrivateLink can be enabled per namespace and the information needed in their support ticket.

I want to follow up with a larger tutorial, but don't want to hold it up as users need this information. 

## Notes to reviewers

<!-- delete if n/a -->
