### PR TITLE
Note alternative to Sessions

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,7 +1,8 @@
 # Docs Assembly Workflow report
 
+Last assembled: Monday November 13 2023 14:00:51 PM -0500
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly
 
 111 guide configurations found.
 
@@ -419,7 +420,7 @@ concepts/what-is-an-activity-definition -> #activity-definition
 
 concepts/what-is-an-activity-heartbeat -> #activity-heartbeat
 
-go/how-to-develop-an-activity-definition-in-go -> /dev-guide/go/foundations#activity-definition
+go/generated/how-to-develop-an-activity-definition-in-go -> /dev-guide/go/foundations#activity-definition
 
 java/developing-activities -> /dev-guide/java/foundations#develop-activities
 
@@ -529,13 +530,15 @@ python/workflow-retries -> /dev-guide/python/features#workflow-retries
 
 typescript/workflow-retries -> /dev-guide/typescript/features#workflow-retries
 
+concepts/what-is-durable-execution -> #durable-execution
+
 concepts/what-is-a-worker-process -> /workers#worker-process
 
 concepts/what-is-a-temporal-client -> #temporal-client
 
 concepts/what-is-a-worker-program -> /workers#worker-program
 
-go/introduction-to-go-sdk -> /dev-guide/go/introduction#
+go/chapter-introduction/introduction-to-go-sdk -> /dev-guide/go/introduction#
 
 java/introduction-to-java-sdk -> /dev-guide/java/introduction#
 
@@ -561,7 +564,7 @@ typescript/visibility -> /dev-guide/typescript/observability#visibility
 
 concepts/what-is-a-worker-entity -> #worker-entity
 
-go/how-to-develop-a-worker-in-go -> /dev-guide/go/foundations#develop-worker
+go/generated/how-to-develop-a-worker-in-go -> /dev-guide/go/foundations#develop-worker
 
 java/how-to-develop-a-worker-program-in-java -> /dev-guide/java/foundations#run-a-dev-worker
 
@@ -691,6 +694,10 @@ go/updates -> /dev-guide/go/features#updates
 
 java/updates -> /dev-guide/java/features#updates
 
+java/what-is-a-dynamic-handler -> /dev-guide/java/features#dynamic-handler
+
+python/what-is-a-dynamic-handler -> /dev-guide/python/features#dynamic-handler
+
 concepts/what-is-a-parent-close-policy -> #parent-close-policy
 
 go/parent-close-policy -> /dev-guide/go/features#parent-close-policy
@@ -702,8 +709,6 @@ php/parent-close-policy -> /dev-guide/php/features#parent-close-policy
 python/parent-close-policy -> /dev-guide/python/features#parent-close-policy
 
 typescript/parent-close-policy -> /dev-guide/typescript/features#parent-close-policy
-
-concepts/what-is-a-delay-start-workflow-execution -> #delay-workflow-execution
 
 go/cron-jobs -> /dev-guide/go/features#temporal-cron-jobs
 
@@ -1009,6 +1014,8 @@ dev-guide/temporal-application -> #temporal-application
 
 dev-guide/official-sdks -> #official-sdks
 
+go/chapter-durable-execution/durable-execution-intro -> /dev-guide/go/durable-execution#
+
 references/strongly-typed-errors/non-deterministic-error -> /references/errors#non-deterministic-error
 
 typescript/testing -> /dev-guide/typescript/testing#replay
@@ -1095,46 +1102,6 @@ go/tracing -> /dev-guide/go/observability#tracing-and-context-propogation
 
 go/logging -> /dev-guide/go/observability#logging
 
-go/connect-to-a-dev-cluster -> #connect-to-a-dev-cluster
-
-go/how-to-customize-workflow-type-in-go -> #customize-workflow-type
-
-go/how-to-customize-activity-type-in-go -> #customize-activity-type
-
-go/go-dev-guide-structure -> #
-
-go/install-cli -> /dev-guide/go/project-setup#install-cli
-
-go/choose-dev-cluster -> /dev-guide/go/project-setup#choose-dev-cluster
-
-go/project-structure -> /dev-guide/go/project-setup#boilerplate-project
-
-go/backgroundcheck-boilerplate-run-a-dev-server-worker -> /dev-guide/go/project-setup#dev-server-worker
-
-go/backgroundcheck-boilerplate-cloud-worker -> /dev-guide/go/project-setup#cloud-worker
-
-go/self-hosted-worker-docker-network -> /dev-guide/go/project-setup#dockerfile
-
-go/backgroundcheck-boilerplate-start-workflow -> /dev-guide/go/project-setup#local-dev-server
-
-go/backgroundcheck-boilerplate-add-test-framework -> /dev-guide/go/project-setup#test-framework
-
-go/foundations -> /dev-guide/go/foundations#
-
-go/generated/how-to-develop-an-activity-definition-in-go -> /dev-guide/go/foundations#activity-definition
-
-concepts/what-is-durable-execution -> #durable-execution
-
-go/chapter-introduction/introduction-to-go-sdk -> /dev-guide/go/introduction#
-
-go/generated/how-to-develop-a-worker-in-go -> /dev-guide/go/foundations#develop-worker
-
-java/what-is-a-dynamic-handler -> /dev-guide/java/features#dynamic-handler
-
-python/what-is-a-dynamic-handler -> /dev-guide/python/features#dynamic-handler
-
-go/chapter-durable-execution/durable-execution-intro -> /dev-guide/go/durable-execution#
-
 dev-guide/why-use-a-temporal-sdk -> /dev-guide/sdks#replays
 
 go/chapter-project-setup/project-setup-introduction -> /dev-guide/go/project-setup#
@@ -1146,6 +1113,8 @@ go/chapter-durable-execution/non-deterministic-code-changes -> #durability-throu
 go/chapter-project-setup/backgroundcheck-boilerplate-start-workflow -> /dev-guide/go/project-setup#start-workflow
 
 go/chapter-durable-execution/retrieve-event-history -> #retrieve-event-history
+
+go/connect-to-a-dev-cluster -> #connect-to-a-dev-cluster
 
 go/generated/how-to-customize-workflow-type-in-go -> #customize-workflow-type
 
@@ -1160,5 +1129,7 @@ go/chapter-project-setup/project-structure -> /dev-guide/go/project-setup#boiler
 go/generated/backgroundcheck-boilerplate-run-a-dev-server-worker -> /dev-guide/go/project-setup#dev-server-worker
 
 go/generated/backgroundcheck-boilerplate-add-test-framework -> /dev-guide/go/project-setup#test-framework
+
+go/foundations -> /dev-guide/go/foundations#
 
 

--- a/docs-src/go/worker-sessions.md
+++ b/docs-src/go/worker-sessions.md
@@ -10,7 +10,7 @@ tags:
   - workers
   - go sdk
 ssdi:
-  - This feature is currently available only in the Go SDK.
+  - This feature is only available in the Go SDK.
   - For other SDKs, use Worker-specific Task Queues. See samples in [TypeScript](https://github.com/temporalio/samples-typescript/tree/main/worker-specific-task-queues), [Python](https://github.com/temporalio/samples-python/tree/main/worker_specific_task_queues), [.NET](https://github.com/temporalio/samples-dotnet/tree/main/src/WorkerSpecificTaskQueues), and [Java](https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/fileprocessing).
 ---
 

--- a/docs-src/go/worker-sessions.md
+++ b/docs-src/go/worker-sessions.md
@@ -11,6 +11,7 @@ tags:
   - go sdk
 ssdi:
   - This feature is currently available only in the Go SDK.
+  - For other SDKs, use Worker-specific Task Queues. See samples in [TypeScript](https://github.com/temporalio/samples-typescript/tree/main/worker-specific-task-queues), [Python](https://github.com/temporalio/samples-python/tree/main/worker_specific_task_queues), [.NET](https://github.com/temporalio/samples-dotnet/tree/main/src/WorkerSpecificTaskQueues), and [Java](https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/fileprocessing).
 ---
 
 A Worker Session is a feature that provides a straightforward API for [Task Routing](/concepts/what-is-task-routing) to ensure that Activity Tasks are executed with the same Worker without requiring you to manually specify Task Queue names.

--- a/docs/dev-guide/golang/features.md
+++ b/docs/dev-guide/golang/features.md
@@ -1520,7 +1520,7 @@ To set your custom Payload Converter, use [`NewCompositeDataConverter`](https://
 
 :::tip Support, stability, and dependency info
 
-- This feature is currently available only in the Go SDK.
+- This feature is only available in the Go SDK.
 - For other SDKs, use Worker-specific Task Queues. See samples in [TypeScript](https://github.com/temporalio/samples-typescript/tree/main/worker-specific-task-queues), [Python](https://github.com/temporalio/samples-python/tree/main/worker_specific_task_queues), [.NET](https://github.com/temporalio/samples-dotnet/tree/main/src/WorkerSpecificTaskQueues), and [Java](https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/fileprocessing).
 
 :::

--- a/docs/dev-guide/golang/features.md
+++ b/docs/dev-guide/golang/features.md
@@ -1521,6 +1521,7 @@ To set your custom Payload Converter, use [`NewCompositeDataConverter`](https://
 :::tip Support, stability, and dependency info
 
 - This feature is currently available only in the Go SDK.
+- For other SDKs, use Worker-specific Task Queues. See samples in [TypeScript](https://github.com/temporalio/samples-typescript/tree/main/worker-specific-task-queues), [Python](https://github.com/temporalio/samples-python/tree/main/worker_specific_task_queues), [.NET](https://github.com/temporalio/samples-dotnet/tree/main/src/WorkerSpecificTaskQueues), and [Java](https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/fileprocessing).
 
 :::
 


### PR DESCRIPTION
A common question is whether/when other SDKs will support Sessions. The answer is they don't and don't plan to, because the Worker-specific Task Queue pattern provides a good solution. 