### PR TITLE
go SDK - Instead of nil activity, use method expression

### DIFF
--- a/docs-src/go/generated/how-to-spawn-an-activity-execution-in-go.md
+++ b/docs-src/go/generated/how-to-spawn-an-activity-execution-in-go.md
@@ -34,11 +34,10 @@ func YourWorkflowDefinition(ctx workflow.Context, param YourWorkflowParam) (*You
 		ActivityParamX: param.WorkflowParamX,
 		ActivityParamY: param.WorkflowParamY,
 	}
-	// Use a nil struct pointer to call Activities that are part of a struct.
-	var a *YourActivityObject
 	// Execute the Activity and wait for the result.
 	var activityResult YourActivityResultObject
-	err := workflow.ExecuteActivity(ctx, a.YourActivityDefinition, activityParam).Get(ctx, &activityResult)
+	// Use method expression to call Activities that are part of a struct.
+	err := workflow.ExecuteActivity(ctx, (*YourActivityObject).YourActivityDefinition, activityParam).Get(ctx, &activityResult)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/dev-guide/golang/foundations.md
+++ b/docs/dev-guide/golang/foundations.md
@@ -756,11 +756,10 @@ func YourWorkflowDefinition(ctx workflow.Context, param YourWorkflowParam) (*You
 		ActivityParamX: param.WorkflowParamX,
 		ActivityParamY: param.WorkflowParamY,
 	}
-	// Use a nil struct pointer to call Activities that are part of a struct.
-	var a *YourActivityObject
 	// Execute the Activity and wait for the result.
 	var activityResult YourActivityResultObject
-	err := workflow.ExecuteActivity(ctx, a.YourActivityDefinition, activityParam).Get(ctx, &activityResult)
+	// Use method expression to call Activities that are part of a struct.
+	err := workflow.ExecuteActivity(ctx, (*YourActivityObject).YourActivityDefinition, activityParam).Get(ctx, &activityResult)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Method expressions are nicer and get rid of the nil object.

They are not that widely known feature of go - they basically de-curry a method and make it a function where the first parameter is the receiver - https://go.dev/ref/spec#Method_expressions.

As Temporal SDK doesn't really care about the implementation and just looks at the method name through runtime and reflection, this still works, and one gets rid of the "nil object" pattern.