### PR TITLE
fix search highlight color

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1010,12 +1010,6 @@ h1 {
   text-decoration: none;
 }
 
-.DocSearch-Hit-title,
-.DocSearch-Hit-icon,
-.DocSearch-Hit-action {
-  --docsearch-hit-active-color: black;
-}
-
 .announcementBar_node_modules-\@docusaurus-theme-classic-lib-next-theme-AnnouncementBar-styles-module {
   --docusaurus-announcement-bar-height: 4rem;
   font-size: 24px;


### PR DESCRIPTION
## What does this PR do?

Fix the search highlight color:

| Before | After |
|--------|--------|
| <img width="566" alt="Screenshot 2023-11-30 at 8 12 49 AM" src="https://github.com/temporalio/documentation/assets/159852/55b8d040-7965-4918-985f-96bc2ce82823"> | <img width="565" alt="Screenshot 2023-11-30 at 8 12 54 AM" src="https://github.com/temporalio/documentation/assets/159852/7cfb0d7a-8f8a-4dd6-928a-a12d26a60e2c"> |

## Notes to reviewers

<!-- delete if n/a -->
