### PR TITLE
clarify use of task queue variable in python worker versioning

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Monday December 04 2023 09:47:03 AM -0800
+Last assembled: Monday December 04 2023 13:13:29 PM -0800
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docs-src/python/how-to-use-worker-versioning-in-python.md
+++ b/docs-src/python/how-to-use-worker-versioning-in-python.md
@@ -41,7 +41,7 @@ You might want to do this as part of your CI deployment process.
 ```python
 # ...
 await client.update_worker_build_id_compatibility(
-    task_queue, BuildIdOpAddNewDefault("deadbeef")
+    "your_task_queue_name", BuildIdOpAddNewDefault("deadbeef")
 )
 ```
 

--- a/docs/dev-guide/python/versioning.md
+++ b/docs/dev-guide/python/versioning.md
@@ -84,7 +84,7 @@ You might want to do this as part of your CI deployment process.
 ```python
 # ...
 await client.update_worker_build_id_compatibility(
-    task_queue, BuildIdOpAddNewDefault("deadbeef")
+    "your_task_queue_name", BuildIdOpAddNewDefault("deadbeef")
 )
 ```
 


### PR DESCRIPTION
Noticed this is unclear right now on https://docs.temporal.io/dev-guide/python/versioning#tell-the-task-queue-about-your-workers-build-id — this example uses `task_queue`, the others use "your_task_queue_name".