### PR TITLE
Adds context to Testing Activities introduction

### DIFF
--- a/docs-src/java/testing-activities.md
+++ b/docs-src/java/testing-activities.md
@@ -7,5 +7,15 @@ tags:
   - guide-context
 ---
 
-An Activity can be tested with a mock Activity environment, which provides a way to mock the Activity context, listen to Heartbeats, and cancel the Activity.
-This behavior allows you to test the Activity in isolation by calling it directly, without needing to create a Worker to run the Activity.
+Mocking isolates code undergoing testing so the focus remains on the code, and not on external dependencies or other state. You can test activities using a mocked Activity environment. 
+
+This approach offers a way to mock the Activity context, listen to Heartbeats, and cancel the Activity. You test the Activity in isolation, calling it directly without needing to create a Worker to run it.
+
+Temporal provides the `TestActivityEnvironment` and `TestActivityExtension` classes for testing Activities outside the scope of a Workflow. Testing
+Activities are similar to testing non-Temporal Java code.
+
+For example, you can test an Activity for:
+
+- Exceptions thrown when invoking the Activity Execution.
+- Exceptions thrown when checking for the result of the Activity Execution.
+- Activity return values. Check that the return value matches the expected value.


### PR DESCRIPTION
## What does this PR do?

### This patch:

- Incorporates the introduction from [**Project Setup**-test framework]( https://docs.temporal.io/dev-guide/java/project-setup#test-framework) and repurposes it to expand the skeletal [**Testing Activities**](https://docs.temporal.io/dev-guide/java/testing#test-activities) section.
- Updates wording so Vale complaints removed

### This patch does not:

- Include the sample from the  Java project-setup

### Checks 

✅ No Vale complaints
✅ Builds and renders

## Notes to reviewers

This is the first of several patches to expand the [**Testing Activities**](https://docs.temporal.io/dev-guide/java/testing#test-activities) section, which is currently skeletal under the guidance of @MasonEgger.

Content source pulled from:

- https://docs.temporal.io/dev-guide/java/project-setup#test-framework
- https://github.com/temporalio/edu-102-java-content/tree/main/testing-application-code

Checking material for Vale compliance and rewording as needed.
