### PR TITLE
Extends 'Listening to Heartbeats' content

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday January 17 2024 12:10:27 PM -0800
+Last assembled: Friday January 19 2024 15:39:30 PM -0700
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly
 
 137 guide configurations found.
 
@@ -803,8 +803,6 @@ cloud/certificates-requirements -> /cloud/certificates#certificate-requirements
 cloud/certificates-issue -> /cloud/certificates#issue-certificates
 
 go/connect-to-temporal-cloud -> /dev-guide/go/foundations#connect-to-temporal-cloud
-
-java/connect-to-temporal-cloud -> /dev-guide/java/foundations#connect-to-temporal-cloud
 
 python/connect-to-temporal-cloud -> /dev-guide/python/foundations#connect-to-temporal-cloud
 

--- a/docs-src/java/listen-to-heartbeats.md
+++ b/docs-src/java/listen-to-heartbeats.md
@@ -1,10 +1,12 @@
 ---
 id: listen-to-heartbeats
-title: Listen to Heartbeats
+title: Listening to Heartbeats
 description: When an Activity sends a Heartbeat, be sure that you can see the Heartbeats in your test code so that you can verify them.
-sidebar_label: Listen to Heartbeats
+sidebar_label: Listening to Heartbeats
 tags:
   - guide-context
 ---
 
-When an Activity sends a Heartbeat, be sure that you can see the Heartbeats in your test code so that you can verify them.
+Activities usually issue periodic Heartbeats, a feature that broadcasts recurring proof-of-life updates. Each ping shows that an Activity is making progress and the Worker hasn't crashed. Heartbeats may include details that report task progress in the event an Activity Worker crashes.
+
+When testing Activities that support Heartbeats, make sure you can see those Heartbeats in your test code. Provide appropriate test coverage. This enables you to verify both the Heartbeat's content and behavior.

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/testing.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/testing.mdx
@@ -246,9 +246,11 @@ This behavior allows you to test the Activity in isolation by calling it directl
 
 If an Activity references its context, you need to mock that context when testing in isolation.
 
-### Listen to Heartbeats {#listen-to-heartbeats}
+### Listening to Heartbeats {#listening-to-heartbeats}
 
-When an Activity sends a Heartbeat, be sure that you can see the Heartbeats in your test code so that you can verify them.
+Activities usually issue periodic Heartbeats, a feature that broadcasts recurring proof-of-life updates. Each ping shows that an Activity is making progress and the Worker hasn't crashed. Heartbeats may include details that report task progress in the event an Activity Worker crashes.
+
+When testing Activities that support Heartbeats, make sure you can see those Heartbeats in your test code. Provide appropriate test coverage. This enables you to verify both the Heartbeat's content and behavior.
 
 ### Cancel an Activity {#cancel-an-activity}
 


### PR DESCRIPTION
## What does this PR do?

### This patch:

- Expands the skeletal Development > Java SDK > Testing > Testing Activities > Listen(ing) to Heartbeats section, adding more context and content.
- Some content sourced from activity-heartbeats.md
- Updates wording to remove Vale complaints.

### Checks 

✅ All Vale complaints resolved
✅ Builds and renders

## Notes to reviewers

This is the second of several patches to expand the [**Testing Activities**](https://docs.temporal.io/dev-guide/java/testing#test-activities) section, which is currently skeletal. This work is under the guidance of @MasonEgger.
