### PR TITLE
Expanding testing activity for Cancel-an-Activity

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday January 17 2024 12:10:27 PM -0800
+Last assembled: Monday January 22 2024 10:32:53 AM -0700
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly
 
 137 guide configurations found.
 
@@ -803,8 +803,6 @@ cloud/certificates-requirements -> /cloud/certificates#certificate-requirements
 cloud/certificates-issue -> /cloud/certificates#issue-certificates
 
 go/connect-to-temporal-cloud -> /dev-guide/go/foundations#connect-to-temporal-cloud
-
-java/connect-to-temporal-cloud -> /dev-guide/java/foundations#connect-to-temporal-cloud
 
 python/connect-to-temporal-cloud -> /dev-guide/python/foundations#connect-to-temporal-cloud
 

--- a/docs-src/java/cancel-an-activity.md
+++ b/docs-src/java/cancel-an-activity.md
@@ -1,10 +1,10 @@
 ---
 id: cancel-an-activity
-title: Cancel an Activity
-description: If an Activity is supposed to react to Cancellation, you can test whether it reacts correctly by canceling it.
-sidebar_label: Cancel an Activity
+title: Cancelling an Activity
+description: If an Activity should to react to Cancellation, you can test whether it reacts correctly by canceling it.
+sidebar_label: Cancelling an Activity
 tags:
   - guide-context
 ---
 
-If an Activity is supposed to react to a Cancellation, you can test whether it reacts correctly by canceling it.
+Activity Cancellation lets Activities know they don't need to continue work and gives time for the Activity to clean up any resources it's created. You can cancel Java-based activities if they emit Heartbeats. To test an Activity that reacts to Cancellations, make sure that the Activity reacts correctly and cancels.

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/testing.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/testing.mdx
@@ -250,9 +250,9 @@ If an Activity references its context, you need to mock that context when testin
 
 When an Activity sends a Heartbeat, be sure that you can see the Heartbeats in your test code so that you can verify them.
 
-### Cancel an Activity {#cancel-an-activity}
+### Cancelling an Activity {#cancelling-an-activity}
 
-If an Activity is supposed to react to a Cancellation, you can test whether it reacts correctly by canceling it.
+Activity Cancellation lets Activities know they don't need to continue work and gives time for the Activity to clean up any resources it's created. You can cancel Java-based activities if they emit Heartbeats. To test an Activity that reacts to Cancellations, make sure that the Activity reacts correctly and cancels.
 
 ## Testing Workflows {#test-workflows}
 


### PR DESCRIPTION
PR: Run Activity Tests

## What does this PR do?

### This patch:

- Expands the skeletal Development > Java SDK > Testing > Testing Activities > Run(ning) an Activity section, adding more context and content.
- Updates wording to remove Vale complaints.

### Checks 

✅ All Vale complaints resolved
✅ Builds and renders

## Notes to reviewers

This is the third of several patches to expand the [**Testing Activities**](https://docs.temporal.io/dev-guide/java/testing#test-activities) section, which is currently skeletal. This work is under the guidance of @MasonEgger.
