### PR TITLE
Expanding testing activity for Run-an-Activity

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday January 17 2024 12:10:27 PM -0800
+Last assembled: Monday January 22 2024 10:28:29 AM -0700
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly
 
 137 guide configurations found.
 
@@ -803,8 +803,6 @@ cloud/certificates-requirements -> /cloud/certificates#certificate-requirements
 cloud/certificates-issue -> /cloud/certificates#issue-certificates
 
 go/connect-to-temporal-cloud -> /dev-guide/go/foundations#connect-to-temporal-cloud
-
-java/connect-to-temporal-cloud -> /dev-guide/java/foundations#connect-to-temporal-cloud
 
 python/connect-to-temporal-cloud -> /dev-guide/python/foundations#connect-to-temporal-cloud
 

--- a/docs-src/java/run-an-activity.md
+++ b/docs-src/java/run-an-activity.md
@@ -1,10 +1,10 @@
 ---
 id: run-an-activity
-title: Run an Activity
+title: Running an Activity
 description: If an Activity references its context, you need to mock that context when testing in isolation.
-sidebar_label: Run an Activity
+sidebar_label: Running an Activity
 tags:
   - guide-context
 ---
 
-If an Activity references its context, you need to mock that context when testing in isolation.
+During isolation testing, if an Activity references its context, you'll need to mock that context. Mocked information stands in for the context, allowing you to focus your testing on the Activity's code.

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/testing.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/testing.mdx
@@ -242,9 +242,9 @@ You can find all unit tests for the [Temporal Java samples](https://github.com/t
 An Activity can be tested with a mock Activity environment, which provides a way to mock the Activity context, listen to Heartbeats, and cancel the Activity.
 This behavior allows you to test the Activity in isolation by calling it directly, without needing to create a Worker to run the Activity.
 
-### Run an Activity {#run-an-activity}
+### Running an Activity {#running-an-activity}
 
-If an Activity references its context, you need to mock that context when testing in isolation.
+During isolation testing, if an Activity references its context, you'll need to mock that context. Mocked information stands in for the context, allowing you to focus your testing on the Activity's code.
 
 ### Listen to Heartbeats {#listen-to-heartbeats}
 


### PR DESCRIPTION
## What does this PR do?

### This patch:

- Expands the skeletal Development > Java SDK > Testing > Testing Activities > Cancelling an Activity section, adding more context and content.
- Updates wording to remove Vale complaints.

### Checks 

✅ All Vale complaints resolved
✅ Builds and renders

## Notes to reviewers

This is the fourth of several patches to expand the [**Testing Activities**](https://docs.temporal.io/dev-guide/java/testing#test-activities) section, which is currently skeletal. This work is under the guidance of @MasonEgger.
