### PR TITLE
EDU-1646: remove obsolete information about execution limit

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday January 17 2024 12:10:27 PM -0800
+Last assembled: Monday January 22 2024 13:34:14 PM -0600
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly
 
 137 guide configurations found.
 
@@ -803,8 +803,6 @@ cloud/certificates-requirements -> /cloud/certificates#certificate-requirements
 cloud/certificates-issue -> /cloud/certificates#issue-certificates
 
 go/connect-to-temporal-cloud -> /dev-guide/go/foundations#connect-to-temporal-cloud
-
-java/connect-to-temporal-cloud -> /dev-guide/java/foundations#connect-to-temporal-cloud
 
 python/connect-to-temporal-cloud -> /dev-guide/python/foundations#connect-to-temporal-cloud
 

--- a/docs-src/concepts/what-is-a-schedule-to-close-timeout.md
+++ b/docs-src/concepts/what-is-a-schedule-to-close-timeout.md
@@ -26,7 +26,6 @@ Example Schedule-To-Close Timeout period for an Activity Execution that has a ch
 **The default Schedule-To-Close Timeout is ∞ (infinity).**
 
 An Activity Execution must have either this timeout (Schedule-To-Close) or [Start-To-Close](/concepts/what-is-a-start-to-close-timeout) set.
-By default, an Activity Execution Retry Policy dictates that retries occur for up to 10 years.
 This timeout can be used to control the overall duration of an Activity Execution in the face of failures (repeated Activity Task Executions), without altering the Maximum Attempts field of the Retry Policy.
 
 :::tip

--- a/docs-src/java/testing-activities.md
+++ b/docs-src/java/testing-activities.md
@@ -7,7 +7,7 @@ tags:
   - guide-context
 ---
 
-Mocking isolates code undergoing testing so the focus remains on the code, and not on external dependencies or other state. You can test activities using a mocked Activity environment.
+Mocking isolates code undergoing testing so the focus remains on the code, and not on external dependencies or other state. You can test Activities using a mocked Activity environment.
 
 This approach offers a way to mock the Activity context, listen to Heartbeats, and cancel the Activity. You test the Activity in isolation, calling it directly without needing to create a Worker to run it.
 

--- a/docs-src/java/testing-activities.md
+++ b/docs-src/java/testing-activities.md
@@ -7,7 +7,7 @@ tags:
   - guide-context
 ---
 
-Mocking isolates code undergoing testing so the focus remains on the code, and not on external dependencies or other state. You can test activities using a mocked Activity environment. 
+Mocking isolates code undergoing testing so the focus remains on the code, and not on external dependencies or other state. You can test activities using a mocked Activity environment.
 
 This approach offers a way to mock the Activity context, listen to Heartbeats, and cancel the Activity. You test the Activity in isolation, calling it directly without needing to create a Worker to run it.
 

--- a/websites/docs.temporal.io/docs/concepts/activities.mdx
+++ b/websites/docs.temporal.io/docs/concepts/activities.mdx
@@ -262,7 +262,6 @@ Example Schedule-To-Close Timeout period for an Activity Execution that has a ch
 **The default Schedule-To-Close Timeout is ∞ (infinity).**
 
 An Activity Execution must have either this timeout (Schedule-To-Close) or [Start-To-Close](#start-to-close-timeout) set.
-By default, an Activity Execution Retry Policy dictates that retries occur for up to 10 years.
 This timeout can be used to control the overall duration of an Activity Execution in the face of failures (repeated Activity Task Executions), without altering the Maximum Attempts field of the Retry Policy.
 
 :::tip

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/testing.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/testing.mdx
@@ -239,8 +239,18 @@ You can find all unit tests for the [Temporal Java samples](https://github.com/t
 
 ## Testing Activities {#test-activities}
 
-An Activity can be tested with a mock Activity environment, which provides a way to mock the Activity context, listen to Heartbeats, and cancel the Activity.
-This behavior allows you to test the Activity in isolation by calling it directly, without needing to create a Worker to run the Activity.
+Mocking isolates code undergoing testing so the focus remains on the code, and not on external dependencies or other state. You can test activities using a mocked Activity environment.
+
+This approach offers a way to mock the Activity context, listen to Heartbeats, and cancel the Activity. You test the Activity in isolation, calling it directly without needing to create a Worker to run it.
+
+Temporal provides the `TestActivityEnvironment` and `TestActivityExtension` classes for testing Activities outside the scope of a Workflow. Testing
+Activities are similar to testing non-Temporal Java code.
+
+For example, you can test an Activity for:
+
+- Exceptions thrown when invoking the Activity Execution.
+- Exceptions thrown when checking for the result of the Activity Execution.
+- Activity return values. Check that the return value matches the expected value.
 
 ### Run an Activity {#run-an-activity}
 


### PR DESCRIPTION
## What does this PR do?

Corrects the documentation by removing obsolete information about a limit that no longer exists in Temporal.

## Notes to reviewers 

See EDU-1646 for more information and confirmation from Maxim that this limit was removed some time ago.