### PR TITLE
Improve readability of links

### DIFF
--- a/websites/docs.temporal.io/src/css/custom.css
+++ b/websites/docs.temporal.io/src/css/custom.css
@@ -82,7 +82,8 @@ html[data-theme="light"] {
 
 a,
 a:hover {
-  text-decoration: underline;
+  text-decoration: underline 1px;
+  text-underline-offset: 2px;
 }
 
 .alert {


### PR DESCRIPTION
before & after:

<img width="729" alt="image" src="https://github.com/temporalio/documentation/assets/251288/4b3c1501-2cd4-4fe6-966b-19589aa5725c">

<img width="796" alt="image" src="https://github.com/temporalio/documentation/assets/251288/d7cbe352-dbc6-467f-8f08-c56ed63400ae">
