### PR TITLE
Make assemble and worker to read server address from environment. 

### DIFF
--- a/assemble.js
+++ b/assemble.js
@@ -77,7 +77,9 @@ async function useCloud(params) {
 }
 
 async function useLocal(params) {
-  const connection = await Connection.connect({});
+  const connection = await Connection.connect(
+      (process.env.TEMPORAL_SERVER_ADDRESS)?{address: process.env.TEMPORAL_SERVER_ADDRESS}:{}
+  );
   const client = new WorkflowClient({
     connection,
   });

--- a/assembly/worker.js
+++ b/assembly/worker.js
@@ -39,7 +39,11 @@ async function run() {
   }
 
   async function useLocal() {
+    const connection = await NativeConnection.connect(
+        (process.env.TEMPORAL_SERVER_ADDRESS) ? {address: process.env.TEMPORAL_SERVER_ADDRESS} : {}
+    );
     const worker = await Worker.create({
+	    connection,
       workflowsPath: path.resolve("./workflows/fullAssembly.js"),
       activities,
       taskQueue: `docs-assembly`,


### PR DESCRIPTION
## What does this PR do?
Enhance worker.js and assemble.js to allow them to run on a remote machine. Temporal server address can be specified through TEMPORAL_SERVER_ADDRESS environment variable.

## Notes to reviewers
I dockerized node and yarn. I also created a script which performs both the `yarn install`. This will allow to setup environment with a single docker compose command. To run the environment inside docker, I need to be able to specify the address for the worker to connect. This is the reason for this pull request.

