### PR TITLE
Rewords namespace limit information for clarity and accuracy.

### DIFF
--- a/docs-src/cloud/limits.md
+++ b/docs-src/cloud/limits.md
@@ -34,9 +34,7 @@ The following aspects apply at the Temporal Cloud Account level (per account).
 
 **How many namespaces can I create?​**
 
-The initial limit is 10 Namespaces.
-
-As Namespaces get created and start being used (Workflows get created in them), this limit gets automatically and incrementally raised up to 100.
+By default, each account is provisioned with a starting quota of ten Namespaces. As you create and use your Namespaces, for example by scheduling Workflows, Temporal Cloud automatically raises your limit towards 100. Our service identifies your usage patterns and responds by slowly increasing your account's Namespace allowance towards the hard limit of 100.
 
 ### Retained Prometheus endpoint data
 

--- a/docs-src/cloud/namespaces-create.md
+++ b/docs-src/cloud/namespaces-create.md
@@ -19,8 +19,7 @@ To create a Namespace, a user must have the Developer or Global Admin account-le
 
 :::tip
 
-By default, each account has a quota of 10 Namespaces.
-If you want to increase this limit, open a [support ticket](/cloud/support-create-ticket).
+By default, each account is provisioned with a starting quota of ten Namespaces. As you create and use your Namespaces, for example by scheduling Workflows, Temporal Cloud automatically raises your limit towards 100. Our service identifies your usage patterns and responds by slowly increasing your account's Namespace allowance towards the hard limit of 100.
 
 :::
 


### PR DESCRIPTION
This PR clarifies and corrects wording about Namespace limits in Temporal Cloud.

## Notes to reviewers

I changed the wording in both limits.md and namespaces-create.md to be accurate and better reflect our mission of clarity.