### PR TITLE
Remove how-to-use-a-prebuilt-workflow-bundle-in-typescript from Found…

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday February 13 2024 13:23:53 PM -0600
+Last assembled: Tuesday February 13 2024 15:11:27 PM -0700
 
 Assembly Workflow Id: docs-full-assembly
 
@@ -8,7 +8,7 @@ Assembly Workflow Id: docs-full-assembly
 
 1755 information nodes found.
 
-1515 information nodes are attached to guides.
+1514 information nodes are attached to guides.
 
 The "Link Magic" Activity transformed the following "information node" identifiers into site paths:
 
@@ -1163,8 +1163,6 @@ typescript/how-to-implement-interceptors-in-typescript -> /dev-guide/typescript/
 typescript/add-sdk -> /dev-guide/typescript/foundations#install-a-temporal-sdk
 
 typescript/linting-and-types -> /dev-guide/typescript/foundations#linting-and-types
-
-typescript/how-to-use-a-prebuilt-workflow-bundle-in-typescript -> /dev-guide/typescript/foundations#prebuilt-workflow-bundles
 
 typescript/how-to-shut-down-a-worker -> /dev-guide/typescript/foundations#shut-down-a-worker
 

--- a/docs-src/typescript/landing-page/typescript-dev-guide-structure.md
+++ b/docs-src/typescript/landing-page/typescript-dev-guide-structure.md
@@ -67,7 +67,6 @@ The Foundations section of the Temporal Developer's guide covers the minimum set
 - [How to run Worker Processes](/typescript/run-a-dev-worker): The Worker Process is where Workflow Functions and Activity Functions are executed.
 - [How to run a Worker on Docker in TypeScript](/typescript/how-to-run-a-worker-on-docker): Workers based on the TypeScript SDK can be deployed and run as Docker containers.
 - [How to run a Temporal Cloud Worker](/typescript/run-a-temporal-cloud-worker): The Worker Process is where Workflow Functions and Activity Functions are executed.
-- [How to use a prebuilt Workflow bundle in TypeScript](/typescript/how-to-use-a-prebuilt-workflow-bundle-in-typescript): Pass a prebuilt bundle instead of `workflowsPath`. or use the `bundleWorkflowCode` helper.
 - [How to shut down a Worker and track its state](/typescript/how-to-shut-down-a-worker): To shut down a Worker, send a shutdown Signal to the Worker or call `Worker.shutdown()`.
 - [How to start a Workflow Execution](/typescript/spawning-workflows): Workflow Execution semantics rely on several parameters—that is, to start a Workflow Execution you must supply a Task Queue that will be used for the Tasks (one that a Worker is polling), the Workflow Type, language-specific contextual data, and Workflow Function parameters.
 - [Cancellation scopes in Typescript](/typescript/cancellation-scopes):

--- a/guide-configs/app-dev/typescript/foundations.json
+++ b/guide-configs/app-dev/typescript/foundations.json
@@ -181,10 +181,6 @@
     },
     {
       "type": "h2",
-      "id": "typescript/how-to-use-a-prebuilt-workflow-bundle-in-typescript"
-    },
-    {
-      "type": "h2",
       "id": "typescript/how-to-shut-down-a-worker"
     },
     {

--- a/websites/docs.temporal.io/docs/dev-guide/tscript/foundations.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/foundations.mdx
@@ -968,32 +968,6 @@ async function run() {
 
 <!--SNIPEND-->
 
-## How to use a prebuilt Workflow bundle in TypeScript {#prebuilt-workflow-bundles}
-
-If you're an advanced user, you can pass a prebuilt bundle instead of `workflowsPath`, or you can use the `bundleWorkflowCode` helper:
-
-```ts
-import { bundleWorkflowCode, Worker } from '@temporalio/worker';
-
-// Option 1: passing path to prebuilt bundle
-const worker = await Worker.create({
-  taskQueue,
-  workflowBundle: {
-    codePath: './path-to-bundle.js',
-    sourceMapPath: './path-to-bundle.js.map',
-  },
-});
-
-// Option 2: bundling code using Temporal's bundler settings
-const workflowBundle = await bundleWorkflowCode({
-  workflowsPath: require.resolve('./path-to-your-workflows'),
-});
-const worker = await Worker.create({
-  taskQueue,
-  workflowBundle,
-});
-```
-
 ## How to shut down a Worker and track its state {#shut-down-a-worker}
 
 Workers shut down if they receive any of the Signals enumerated in [shutdownSignals](https://typescript.temporal.io/api/interfaces/worker.RuntimeOptions#shutdownsignals): `'SIGINT'`, `'SIGTERM'`, `'SIGQUIT'`, and `'SIGUSR2'`.

--- a/websites/docs.temporal.io/docs/dev-guide/tscript/index.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/index.mdx
@@ -75,7 +75,7 @@ The Foundations section of the Temporal Developer's guide covers the minimum set
 - [How to run Worker Processes](/dev-guide/typescript/foundations#run-a-dev-worker): The Worker Process is where Workflow Functions and Activity Functions are executed.
 - [How to run a Worker on Docker in TypeScript](/dev-guide/typescript/foundations#run-a-worker-on-docker): Workers based on the TypeScript SDK can be deployed and run as Docker containers.
 - [How to run a Temporal Cloud Worker](/dev-guide/typescript/foundations#run-a-temporal-cloud-worker): The Worker Process is where Workflow Functions and Activity Functions are executed.
-- [How to use a prebuilt Workflow bundle in TypeScript](/dev-guide/typescript/foundations#prebuilt-workflow-bundles): Pass a prebuilt bundle instead of `workflowsPath`. or use the `bundleWorkflowCode` helper.
+- [How to use a prebuilt Workflow bundle in TypeScript](/typescript/how-to-use-a-prebuilt-workflow-bundle-in-typescript): Pass a prebuilt bundle instead of `workflowsPath`. or use the `bundleWorkflowCode` helper.
 - [How to shut down a Worker and track its state](/dev-guide/typescript/foundations#shut-down-a-worker): To shut down a Worker, send a shutdown Signal to the Worker or call `Worker.shutdown()`.
 - [How to start a Workflow Execution](/dev-guide/typescript/foundations#start-workflow-execution): Workflow Execution semantics rely on several parameters—that is, to start a Workflow Execution you must supply a Task Queue that will be used for the Tasks (one that a Worker is polling), the Workflow Type, language-specific contextual data, and Workflow Function parameters.
 - [Cancellation scopes in Typescript](/dev-guide/typescript/foundations#cancellation-scopes):

--- a/websites/docs.temporal.io/docs/production-deployment/cloud/account-setup/namespaces.mdx
+++ b/websites/docs.temporal.io/docs/production-deployment/cloud/account-setup/namespaces.mdx
@@ -79,7 +79,7 @@ To create a Namespace, a user must have the Developer or Global Admin account-le
 
 :::tip
 
-By default, each account is provisioned with ten Namespaces. 
+By default, each account is provisioned with ten Namespaces.
 As you create and use your Namespaces, for example by scheduling Workflows, Temporal Cloud automatically raises your limit.
 Our service identifies your usage patterns.
 It responds by slowly increasing your allowance, up to 100 Namespaces.
@@ -135,7 +135,7 @@ Customers should consider not only a Namespace naming convention but also how to
 
 Before considering an appropriate Namespace configuration, you should be aware of the following constraints:
 
-- By default, each account is provisioned with ten Namespaces. 
+- By default, each account is provisioned with ten Namespaces.
   As you create and use your Namespaces, for example by scheduling Workflows, Temporal Cloud automatically raises your limit.
   Our service identifies your usage patterns.
   It responds by slowly increasing your allowance, up to 100 Namespaces.

--- a/websites/docs.temporal.io/docs/production-deployment/cloud/introduction/limits.mdx
+++ b/websites/docs.temporal.io/docs/production-deployment/cloud/introduction/limits.mdx
@@ -45,7 +45,7 @@ The following aspects apply at the Temporal Cloud Account level (per account).
 
 **How many namespaces can I create?​**
 
-By default, each account is provisioned with ten Namespaces. 
+By default, each account is provisioned with ten Namespaces.
 As you create and use your Namespaces, for example by scheduling Workflows, Temporal Cloud automatically raises your limit.
 Our service identifies your usage patterns.
 It responds by slowly increasing your allowance, up to 100 Namespaces.


### PR DESCRIPTION
Trying to get this built and merged again. Last time it errored.

Removing how-to-use-a-prebuilt-workflow-bundle-in-typescript from Foundations in Typescript.