### PR TITLE
Remove stale blog post link from Typescript observability

### DIFF
--- a/websites/docs.temporal.io/docs/dev-guide/tscript/observability.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/observability.mdx
@@ -70,8 +70,6 @@ Tracing allows you to view the call graph of a Workflow along with its Activitie
 
 Temporal Web's tracing capabilities mainly track Activity Execution within a Temporal context. If you need custom tracing specific for your use case, you should make use of context propagation to add tracing logic accordingly.
 
-For information about Workflow tracing, see [Tracing Temporal Workflows with DataDog](https://spiralscout.com/blog/tracing-temporal-workflow-with-datadog).
-
 For information about how to configure exporters and instrument your code, see [Tracing Temporal Services with OTEL](https://github.com/temporalio/temporal/blob/master/develop/docs/tracing.md).
 
 The [`interceptors-opentelemetry`](https://github.com/temporalio/samples-typescript/tree/main/interceptors-opentelemetry) sample shows how to use the SDK's built-in OpenTelemetry tracing to trace everything from starting a Workflow to Workflow Execution to running an Activity from that Workflow.


### PR DESCRIPTION
## What does this PR do?

Removes a broken link. This blog post has been taken down, and I can't find a replacement URL.

## Notes to reviewers

<!-- delete if n/a -->
