### PR TITLE
move namespace param from Worker to Client -  project-setup.mdx

### DIFF
--- a/docs-src/python/generated/backgroundcheck-boilerplate-run-a-dev-server-worker.md
+++ b/docs-src/python/generated/backgroundcheck-boilerplate-run-a-dev-server-worker.md
@@ -35,11 +35,10 @@ from workflows.backgroundcheck_dacx import BackgroundCheck
 
 
 async def main():
-    client = await Client.connect("localhost:7233")
+    client = await Client.connect("localhost:7233", namespace="backgroundcheck_namespace",)
 
     worker = Worker(
         client,
-        namespace="backgroundcheck_namespace",
         task_queue="backgroundcheck-boilerplate-task-queue",
         workflows=[BackgroundCheck],
         activities=[ssn_trace_activity],

--- a/websites/docs.temporal.io/docs/dev-guide/python/project-setup.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/python/project-setup.mdx
@@ -475,11 +475,10 @@ from workflows.backgroundcheck_dacx import BackgroundCheck
 
 
 async def main():
-    client = await Client.connect("localhost:7233")
+    client = await Client.connect("localhost:7233", namespace="backgroundcheck_namespace")
 
     worker = Worker(
-        client,
-        namespace="backgroundcheck_namespace",
+        client,        
         task_queue="backgroundcheck-boilerplate-task-queue",
         workflows=[BackgroundCheck],
         activities=[ssn_trace_activity],


### PR DESCRIPTION
`Worker()` does not accept namespace, it must be passed to `Client.connect()` instead.

Since namespaces are introduced later in this document, a better fix might be to simply eliminate the namespace parameter from this example, rather than moving it to `Client.connect()`. 

