### PR TITLE
EDU-1781: Adds policy details for when ActivityTaskStarted appears in history

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,8 +1,8 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday March 14 2024 11:59:25 AM -0700
+Last assembled: Thursday March 14 2024 16:04:41 PM -0600
 
-Assembly Workflow Id: docs-full-assembly-rachfop-123
+Assembly Workflow Id: docs-full-assembly
 
 147 guide configurations found.
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Friday March 15 2024 10:50:01 AM -0700
+Last assembled: Wednesday March 20 2024 09:52:38 AM -0600
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Thursday March 14 2024 16:04:41 PM -0600
+Last assembled: Friday March 15 2024 10:31:03 AM -0600
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,7 +60,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  The ActivityTaskStarted event is written into the Workflow Event History when your Activity completes or fails after all of its retries.
   It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
   Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -61,7 +61,7 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into the Workflow Event History when your Activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
   Don't be misled into thinking that the Activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -62,7 +62,7 @@ Let's take a closer look:
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into the Workflow Event History when your Activity completes or fails after all of its retries.
   It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the activity is failing to start.
+  Don't be misled into thinking that the Activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,6 +60,9 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -61,7 +61,8 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,10 +60,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into the Workflow Event History when your Activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the Activity is failing to start.
-  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
@@ -70,10 +70,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the activity is failing to start.
-  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
@@ -71,7 +71,8 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
@@ -70,6 +70,9 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
@@ -71,7 +71,7 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
   Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.

--- a/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
@@ -61,7 +61,8 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,10 +60,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the activity is failing to start.
-  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history. 
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,6 +60,9 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,7 +60,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history. 
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
@@ -61,7 +61,7 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
   Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.

--- a/docs-src/references/events.md
+++ b/docs-src/references/events.md
@@ -238,7 +238,7 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 This [Event](/concepts/what-is-an-event) type indicates that an [Activity Task Execution](/concepts/what-is-an-activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/concepts/what-is-an-activity) invocation.
 Note that the ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
 Don't be misled into thinking that the activity is failing to start.
 See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 

--- a/docs-src/references/events.md
+++ b/docs-src/references/events.md
@@ -237,7 +237,9 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 
 This [Event](/concepts/what-is-an-event) type indicates that an [Activity Task Execution](/concepts/what-is-an-activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/concepts/what-is-an-activity) invocation.
-Note, however, that this Event is not written to History until the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)) occurs.
+Note that the ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+This happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)) occurs.
+See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 
 | Field              | Description                                                                                                          |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |

--- a/docs-src/references/events.md
+++ b/docs-src/references/events.md
@@ -237,10 +237,9 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 
 This [Event](/concepts/what-is-an-event) type indicates that an [Activity Task Execution](/concepts/what-is-an-activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/concepts/what-is-an-activity) invocation.
-Note that the ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
 It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
 Don't be misled into thinking that the activity is failing to start.
-See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 
 | Field              | Description                                                                                                          |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |

--- a/docs-src/references/events.md
+++ b/docs-src/references/events.md
@@ -238,7 +238,8 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 This [Event](/concepts/what-is-an-event) type indicates that an [Activity Task Execution](/concepts/what-is-an-activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/concepts/what-is-an-activity) invocation.
 Note that the ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-This happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)) occurs.
+It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+Don't be misled into thinking that the activity is failing to start.
 See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 
 | Field              | Description                                                                                                          |

--- a/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
@@ -61,7 +61,7 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
   Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.

--- a/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,10 +60,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the activity is failing to start.
-  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,6 +60,9 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
@@ -61,7 +61,8 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
@@ -391,10 +391,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the activity is failing to start.
-  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
@@ -391,6 +391,9 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
@@ -392,7 +392,8 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
@@ -311,10 +311,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the activity is failing to start.
-  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
@@ -312,7 +312,8 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
@@ -311,6 +311,9 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
@@ -285,7 +285,8 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
@@ -284,10 +284,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the activity is failing to start.
-  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history. 
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
@@ -284,6 +284,9 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
@@ -489,7 +489,8 @@ Let's take a closer look:
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
   The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+  Don't be misled into thinking that the activity is failing to start.
   See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
@@ -488,6 +488,9 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+  This happens after the terminal Event (like ActivityTaskCompleted or ActivityTaskFailed) occurs.
+  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
@@ -488,10 +488,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-  It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-  Don't be misled into thinking that the activity is failing to start.
-  See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/references/events.mdx
+++ b/websites/docs.temporal.io/docs/references/events.mdx
@@ -242,10 +242,9 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 
 This [Event](/workflows#event) type indicates that an [Activity Task Execution](/workers#activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/activities) invocation.
-Note that the ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](#activitytaskcompleted) or [ActivityTaskFailed](#activitytaskfailed)).
+The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](#activitytaskcompleted) or [ActivityTaskFailed](#activitytaskfailed)).
 Don't be misled into thinking that the activity is failing to start.
-See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
 
 | Field              | Description                                                                                                          |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |

--- a/websites/docs.temporal.io/docs/references/events.mdx
+++ b/websites/docs.temporal.io/docs/references/events.mdx
@@ -243,9 +243,9 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 This [Event](/workflows#event) type indicates that an [Activity Task Execution](/workers#activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/activities) invocation.
 Note that the ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
-This happens after the terminal Event (like [ActivityTaskCompleted](#activitytaskcompleted) or [ActivityTaskFailed](#activitytaskfailed)) occurs.
+It may be counter-intuitive that this happens after the terminal Event (like [ActivityTaskCompleted](#activitytaskcompleted) or [ActivityTaskFailed](#activitytaskfailed)).
+Don't be misled into thinking that the activity is failing to start.
 See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
-
 
 | Field              | Description                                                                                                          |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |

--- a/websites/docs.temporal.io/docs/references/events.mdx
+++ b/websites/docs.temporal.io/docs/references/events.mdx
@@ -242,7 +242,10 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 
 This [Event](/workflows#event) type indicates that an [Activity Task Execution](/workers#activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/activities) invocation.
-Note, however, that this Event is not written to History until the terminal Event (like [ActivityTaskCompleted](#activitytaskcompleted) or [ActivityTaskFailed](#activitytaskfailed)) occurs.
+Note that the ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+This happens after the terminal Event (like [ActivityTaskCompleted](#activitytaskcompleted) or [ActivityTaskFailed](#activitytaskfailed)) occurs.
+See [When does Temporal write the ActivityTaskStarted event into Workflow history?](https://community.temporal.io/t/when-does-temporal-write-the-activitytaskstarted-event-into-workflow-history/6162) for more details.
+
 
 | Field              | Description                                                                                                          |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
Adds policy details for when ActivityTaskStarted appears in history

Incorporates forum information and URL requested in ticket comments in both the updated material and the Events reference.
    
