### PR TITLE
Point out that ActivityTaskStarted will not appear until Activity completed

### DIFF
--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday March 20 2024 12:43:07 PM -0600
+Last assembled: Wednesday March 20 2024 12:54:27 PM -0600
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Tuesday March 19 2024 14:43:56 PM -0600
+Last assembled: Wednesday March 20 2024 12:43:07 PM -0600
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/ASSEMBLY_REPORT.md
+++ b/ASSEMBLY_REPORT.md
@@ -1,6 +1,6 @@
 # Docs Assembly Workflow report
 
-Last assembled: Wednesday March 20 2024 12:54:27 PM -0600
+Last assembled: Wednesday March 20 2024 13:21:58 PM -0600
 
 Assembly Workflow Id: docs-full-assembly
 

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,6 +60,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,7 +60,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/go/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,7 +60,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events#ActivityTaskStarted) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
@@ -70,7 +70,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
@@ -70,7 +70,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events#ActivityTaskStarted) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/java/chapter-durable-execution/non-deterministic-code-changes.md
@@ -70,6 +70,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,7 +60,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events#ActivityTaskStarted) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,7 +60,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/python/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,6 +60,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/references/events.md
+++ b/docs-src/references/events.md
@@ -237,7 +237,7 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 
 This [Event](/concepts/what-is-an-event) type indicates that an [Activity Task Execution](/concepts/what-is-an-activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/concepts/what-is-an-activity) invocation.
-The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+The ActivityTaskStarted event is written into Workflow Event History when the Activity completes or fails after all of its retries.
 It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
 Don't be misled into thinking that the activity is failing.
 

--- a/docs-src/references/events.md
+++ b/docs-src/references/events.md
@@ -237,7 +237,9 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 
 This [Event](/concepts/what-is-an-event) type indicates that an [Activity Task Execution](/concepts/what-is-an-activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/concepts/what-is-an-activity) invocation.
-Note, however, that this Event is not written to History until the terminal Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)) occurs.
+The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
+Don't be misled into thinking that the activity is failing.
 
 | Field              | Description                                                                                                          |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |

--- a/docs-src/references/events.md
+++ b/docs-src/references/events.md
@@ -239,7 +239,7 @@ This [Event](/concepts/what-is-an-event) type indicates that an [Activity Task E
 The SDK Worker picked up the Activity Task and started processing the [Activity](/concepts/what-is-an-activity) invocation.
 The ActivityTaskStarted event is written into Workflow Event History when the Activity completes or fails after all of its retries.
 It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](/references/events#activitytaskcompleted) or [ActivityTaskFailed](/references/events#activitytaskfailed)).
-Don't be misled into thinking that the activity is failing.
+Don't be misled into thinking that the Activity did not start if you don't see this Event in the History.
 
 | Field              | Description                                                                                                          |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |

--- a/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,6 +60,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,7 +60,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
+++ b/docs-src/typescript/chapter-durable-execution/non-deterministic-code-changes.md
@@ -60,7 +60,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events#ActivityTaskStarted) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
@@ -391,7 +391,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events#ActivityTaskStarted) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
@@ -391,6 +391,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/golang/durable-execution.mdx
@@ -391,7 +391,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
@@ -311,7 +311,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
@@ -311,6 +311,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
+++ b/websites/docs.temporal.io/docs/dev-guide/javalang/durable-execution.mdx
@@ -311,7 +311,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: The Workflow progresses until it reaches a line that issues a Command to the Temporal Cluster. The Workflow suspends execution as it made as much progress as it could.
 - `ActivityTaskScheduled`: This Event indicates that a request to execute an Activity was made, in this instance a call to the `SSNTraceActivity`, and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events#ActivityTaskStarted) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
@@ -284,6 +284,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
@@ -284,7 +284,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/python/durable-execution.md
@@ -284,7 +284,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events#ActivityTaskStarted) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
@@ -488,7 +488,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
@@ -488,6 +488,8 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
+  Visit the [Events](references/events.md) page to learn how and when this event is written into Workflow history.
+  The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.
 

--- a/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
+++ b/websites/docs.temporal.io/docs/dev-guide/tscript/durable-execution.md
@@ -488,7 +488,7 @@ Let's take a closer look:
 - `WorkflowTaskCompleted`: This Event indicates that the Worker suspended execution and made as much progress that it could.
 - `ActivityTaskScheduled`: This Event indicates that the ExecuteActivity API was called and the Worker sent the [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) Command to the Server.
 - `ActivityTaskStarted`: This Event indicates that the Worker successfully polled the Activity Task and started evaluating Activity code.
-  Visit the [Events](/references/events.md) page to learn how and when this event is written into Workflow history.
+  Visit the [Events](/references/events#ActivityTaskStarted) page to learn how and when this event is written into Workflow history.
   The process can be counter-intuitive.
 - `ActivityTaskCompleted`: This Event indicates that the Worker completed evaluation of the Activity code and returned any results to the Server.
   In response, the Server schedules another Workflow Task to finish evaluating the Workflow code resulting in the remaining Events, `WorkflowTaskScheduled`.`WorkflowTaskStarted`, `WorkflowTaskCompleted`, `WorkflowExecutionCompleted`.

--- a/websites/docs.temporal.io/docs/references/events.mdx
+++ b/websites/docs.temporal.io/docs/references/events.mdx
@@ -242,7 +242,9 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 
 This [Event](/workflows#event) type indicates that an [Activity Task Execution](/workers#activity-task-execution) was started.
 The SDK Worker picked up the Activity Task and started processing the [Activity](/activities) invocation.
-Note, however, that this Event is not written to History until the terminal Event (like [ActivityTaskCompleted](#activitytaskcompleted) or [ActivityTaskFailed](#activitytaskfailed)) occurs.
+The ActivityTaskStarted event is written into Workflow history when your activity completes or fails after all of its retries.
+It may be counter-intuitive that this happens after the final Activity Event (like [ActivityTaskCompleted](#activitytaskcompleted) or [ActivityTaskFailed](#activitytaskfailed)).
+Don't be misled into thinking that the activity is failing.
 
 | Field              | Description                                                                                                          |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
The old branch seemed corrupted, so I'm starting another. 

Clarifies that against common-sense, the ActivityTaskStarted state does not appear in history until the Activity has completed.

This version is pulled back and uses minimal incursions, redirecting to the events page instead.

JIRA: EDU-1781 https://temporalio.atlassian.net/browse/EDU-1781

## What does this PR do?

## Notes to reviewers

<!-- delete if n/a -->
