### PR TITLE
Document WorkflowIdConflictPolicy

### DIFF
--- a/docs-src/concepts/what-is-a-workflow-id-conflict-policy.md
+++ b/docs-src/concepts/what-is-a-workflow-id-conflict-policy.md
@@ -1,0 +1,30 @@
+---
+id: what-is-a-workflow-id-conflict-policy
+title: What is a Workflow Id Conflict Policy?
+sidebar_label: Workflow Id Conflict Policy
+description: A Workflow Id Conflict Policy determines how to resolve the conflict when spawning a new Workflow Execution with a particular Workflow Id that is used by an Open Workflow Execution already.
+tags:
+  - term
+  - explanation
+---
+
+A Workflow Id Conflict Policy determines how to resolve the conflict when spawning a new Workflow Execution with a particular Workflow Id that is used by an Open Workflow Execution already.
+See [Workflow Id Reuse Policy](/concepts/what-is-a-workflow-id-reuse-policy) for managing the reuse of a Workflow Id of a Close Workflow.
+
+By default, this results in a `Workflow execution already started` error.
+
+:::note
+
+The default [StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#StartWorkflowOptions) behavior in the Go SDK is to not return an error when a new Workflow Execution is attempted with the same Workflow Id as an open Workflow Execution.
+Instead, it returns a WorkflowRun instance representing the current or last run of the open Workflow Execution.
+
+To return the `Workflow execution already started` error, set `WorkflowExecutionErrorWhenAlreadyStarted` to `true`.
+
+:::
+
+The Workflow Id Conflict Policy can have one of the following values:
+
+- **Fail:** The Workflow Execution is prevented from spawning and a `Workflow execution already started` error is returned.
+  **This is the default policy, if one is not specified.**
+- **Use Existing:** The Workflow Execution is prevented from spawning and a successful response with the Open Workflow Execution's Run Id is returned.
+- **Terminate Existing:** The Open Workflow Execution is terminated first and then the new the Workflow Execution with the same Workflow Id is spawned.

--- a/docs-src/concepts/what-is-a-workflow-id-reuse-policy.md
+++ b/docs-src/concepts/what-is-a-workflow-id-reuse-policy.md
@@ -11,16 +11,7 @@ tags:
 A Workflow Id Reuse Policy determines whether a Workflow Execution is allowed to spawn with a particular Workflow Id, if that Workflow Id has been used with a previous, and now Closed, Workflow Execution.
 
 It is not possible for a new Workflow Execution to spawn with the same Workflow Id as another Open Workflow Execution, regardless of the Workflow Id Reuse Policy.
-In some cases, an attempt to spawn a Workflow Execution with a Workflow Id that is the same as the Id of a currently Open Workflow Execution results in a `Workflow execution already started` error.
-
-:::note
-
-The default [StartWorkflowOptions](https://pkg.go.dev/go.temporal.io/sdk/internal#StartWorkflowOptions) behavior in the Go SDK is to not return an error when a new Workflow Execution is attempted with the same Workflow Id as an open Workflow Execution.
-Instead, it returns a WorkflowRun instance representing the current or last run of the open Workflow Execution.
-
-To return the `Workflow execution already started` error, set `WorkflowExecutionErrorWhenAlreadyStarted` to `true`.
-
-:::
+See [Workflow Id Conflict Policy](/concepts/what-is-a-workflow-id-conflict-policy) for resolving a Workflow Id conflict.
 
 The Workflow Id Reuse Policy can have one of the following values:
 
@@ -38,4 +29,4 @@ For example, the Temporal Service can only check the Workflow Id of the spawning
 The fourth value of the Workflow Id Reuse Policy, Terminate if Running, only applies to a Workflow Execution that is currently open within the Namespace.
 For Terminate if Running, the Retention Period is not a consideration for this policy.
 
-If there is an attempt to spawn a Workflow Execution with a Workflow Id Reuse Policy that won't allow it the Server will prevent the Workflow Execution from spawning.
+If there is an attempt to spawn a Workflow Execution with a Workflow Id Reuse Policy that won't allow it, the Server will prevent the Workflow Execution from spawning.

--- a/docs-src/concepts/what-is-a-workflow-id.md
+++ b/docs-src/concepts/what-is-a-workflow-id.md
@@ -14,7 +14,9 @@ A Workflow Id is a customizable, application-level identifier for a [Workflow Ex
 
 A Workflow Id is meant to be a business-process identifier such as customer identifier or order identifier.
 
-A [Workflow Id Reuse Policy](/concepts/what-is-a-workflow-id-reuse-policy) can be used to manage whether a Workflow Id can be re-used.
 The Temporal Platform guarantees uniqueness of the Workflow Id within a [Namespace](/concepts/what-is-a-namespace) based on the Workflow Id Reuse Policy.
+
+A [Workflow Id Reuse Policy](/concepts/what-is-a-workflow-id-reuse-policy) can be used to manage whether a Workflow Id from a Closed Workflow can be re-used.
+A [Workflow Id Conflict Policy](/concepts/what-is-a-workflow-id-conflict-policy) can be used to decide how to resolve a Workflow Id conflict with a Running Workflow.
 
 A Workflow Execution can be uniquely identified across all Namespaces by its [Namespace](/concepts/what-is-a-namespace), Workflow Id, and [Run Id](/concepts/what-is-a-run-id).


### PR DESCRIPTION
## What does this PR do?

Documents https://github.com/temporalio/api/pull/359

## Notes to reviewers

I haven't generated any of the docs yet to keep the PR simple while we wordsmith it.

⚠️ I suppose this should only be merged once the SDKs support this new policy. This is tracked here: https://github.com/temporalio/features/issues/437