### PR TITLE
DO NOT MERGE: EDU-2387 Adds glossary definition for Multi-region Namespace

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -279,7 +279,7 @@ _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
 A Multi-region Namespace (MRN) is a [Temporal Cloud](#temporal-cloud) Namespace that is configured to work across an active [region](/cloud/service-availability#regions) and a standby region located within the same continent.
 Each region is hosted on a separate Temporal Cloud [Cluster](#temporal-cluster). 
-Temporal Cloud automatically replicates Workflow Executions and metadata from the active to the standby region using [Multi-Cluster Replication](#multi-cluster-replication).
+Temporal Cloud automatically replicates Workflow Executions and metadata from the active to the standby region.
 MRNs are designed to respond to service issues like network congestion.
 When service to the primary Cluster is compromised, a [failover](#failover) transfers control from the active to the standby Cluster.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -182,7 +182,7 @@ _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 <span style={{ backgroundColor: 'rgb(255, 255, 102)', fontWeight: 'bold' }}>When MRN goes live update this link from self-hosted-guide/multi-cluster-replication to cloud/multi-region</span>
 #### [Failover](/self-hosted-guide/multi-cluster-replication) <!--[Failover](/cloud/multi-region)-->
 
-A failover shifts Workflow Execution processing from an active Cluster to a standby [Cluster](#temporal-cluster) during outages or other incidents.
+A Failover shifts Workflow Execution processing from an active Temporal Service to a standby Temporal Service during outages or other incidents.
 Standby Clusters use [Multi-Cluster Replication](#multi-cluster-replication) to duplicate data and prevent data loss during failover.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -183,7 +183,7 @@ _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 #### [Failover](/self-hosted-guide/multi-cluster-replication) <!--[Failover](/cloud/multi-region)-->
 
 A Failover shifts Workflow Execution processing from an active Temporal Service to a standby Temporal Service during outages or other incidents.
-Standby Clusters use [Multi-Cluster Replication](#multi-cluster-replication) to duplicate data and prevent data loss during failover.
+Standby Namespaces use replication to duplicate data and prevent data loss during Failover.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
@@ -221,7 +221,7 @@ _Tags: [product-release-stages](/tags/product-release-stages), [term](/tags/term
 
 A Global Namespace is a Namespace that duplicates data from an active [Cluster](#temporal-cluster) to a standby Cluster using [Multi-Cluster Replication](#multi-cluster-replication), keeping both Namespaces in sync.
 Global Namespaces are designed to respond to service issues like network congestion.
-When service to the primary Cluster is compromised, a [failover](#failover) transfers control from the active to the standby cluster.
+When service to the primary Cluster is compromised, a [Failover](#failover) transfers control from the active to the standby cluster.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
@@ -278,10 +278,10 @@ _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 #### [Multi-region Namespace](/cloud)<!--/multi-region)-->
 
 A Multi-region Namespace (MRN) is a [Temporal Cloud](#temporal-cloud) Namespace that is configured to work across an active [region](/cloud/service-availability#regions) and a standby region located within the same continent.
-Each region is hosted on a separate Temporal Cloud [Cluster](#temporal-cluster). 
+Each Region corresponds to a dedicated Temporal Cloud Service. 
 Temporal Cloud automatically replicates Workflow Executions and metadata from the active to the standby region.
 MRNs are designed to respond to service issues like network congestion.
-When service to the primary Cluster is compromised, a [failover](#failover) transfers control from the active to the standby Cluster.
+In the event that the primary Service's performance is compromised, a [Failover](#failover) transfers control from the active to the standby Service.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -182,7 +182,7 @@ _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 <span style={{ backgroundColor: 'rgb(255, 255, 102)', fontWeight: 'bold' }}>When MRN goes live update this link from self-hosted-guide/multi-cluster-replication to cloud/multi-region</span>
 #### [Failover](/self-hosted-guide/multi-cluster-replication) <!--[Failover](/cloud/multi-region)-->
 
-A Failover shifts Workflow Execution processing from an active Temporal Service to a standby Temporal Service during outages or other incidents.
+A Failover shifts Workflow Execution processing from an active Temporal Namespace to a standby Temporal Namespace during outages or other incidents.
 Standby Namespaces use replication to duplicate data and prevent data loss during Failover.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
@@ -219,7 +219,7 @@ _Tags: [product-release-stages](/tags/product-release-stages), [term](/tags/term
 
 #### [Global Namespace](/namespaces#global-namespace)
 
-A Global Namespace is a Namespace that duplicates data from an active [Cluster](#temporal-cluster) to a standby Cluster using [Multi-Cluster Replication](#multi-cluster-replication), keeping both Namespaces in sync.
+A Global Namespace is a Namespace that duplicates data from an active [Temporal Service](#temporal-cluster) to a standby Service using the replication to keep both Namespaces in sync.
 Global Namespaces are designed to respond to service issues like network congestion.
 When service to the primary Cluster is compromised, a [Failover](#failover) transfers control from the active to the standby cluster.
 
@@ -277,11 +277,11 @@ _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 <span style={{ backgroundColor: 'rgb(255, 255, 102)', fontWeight: 'bold' }}>When MRN goes live update this link from cloud to cloud/multi-region</span>
 #### [Multi-region Namespace](/cloud)<!--/multi-region)-->
 
-A Multi-region Namespace (MRN) is a [Temporal Cloud](#temporal-cloud) Namespace that is configured to work across an active [region](/cloud/service-availability#regions) and a standby region located within the same continent.
-Each Region corresponds to a dedicated Temporal Cloud Service. 
+A Multi-region Namespace (MRN) is a [Temporal Cloud](#temporal-cloud) Namespace that is configured to work across an active [region](/cloud/service-availability#regions) and a standby region.
+Each region corresponds to a dedicated Temporal Cloud Service. 
 Temporal Cloud automatically replicates Workflow Executions and metadata from the active to the standby region.
-MRNs are designed to respond to service issues like network congestion.
-In the event that the primary Service's performance is compromised, a [Failover](#failover) transfers control from the active to the standby Service.
+MRNs are designed to respond to service issues that may arise.
+In the event that the Namespace's performance is compromised, a [Failover](#failover) transfers control from the active to the standby region.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -179,8 +179,7 @@ An append-only log of Events that represents the full state a Workflow Execution
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
-<span style={{ backgroundColor: 'rgb(255, 255, 102)', fontWeight: 'bold' }}>When MRN goes live update this link from self-hosted-guide/multi-cluster-replication to cloud/multi-region</span>
-#### [Failover](/self-hosted-guide/multi-cluster-replication) <!--[Failover](/cloud/multi-region)-->
+#### [Failover](/cloud/multi-region)
 
 A Failover shifts Workflow Execution processing from an active Temporal Namespace to a standby Temporal Namespace during outages or other incidents.
 Standby Namespaces use replication to duplicate data and prevent data loss during Failover.
@@ -274,8 +273,7 @@ The replicated data is used for backup and state reconstruction.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
-<span style={{ backgroundColor: 'rgb(255, 255, 102)', fontWeight: 'bold' }}>When MRN goes live update this link from cloud to cloud/multi-region</span>
-#### [Multi-region Namespace](/cloud)<!--/multi-region)-->
+#### [Multi-region Namespace](/cloud/multi-region)
 
 A Multi-region Namespace (MRN) is a [Temporal Cloud](#temporal-cloud) Namespace that is configured to work across an active [region](/cloud/service-availability#regions) and a standby region.
 Each region corresponds to a dedicated Temporal Cloud Service. 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -269,7 +269,7 @@ _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
 #### [Multi-Cluster Replication](/self-hosted-guide/multi-cluster-replication)
 
-Multi-Cluster Replication asynchronously replicate Workflow Executions and metadata from an active [Cluster](#temporal-cluster) to a standby Cluster.
+Multi-Cluster Replication asynchronously replicates Workflow Executions and metadata from an active [Cluster](#temporal-cluster) to a standby Cluster.
 The replicated data is used for backup and state reconstruction.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -179,6 +179,14 @@ An append-only log of Events that represents the full state a Workflow Execution
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
+<span style={{ backgroundColor: 'rgb(255, 255, 102)', fontWeight: 'bold' }}>When MRN goes live update this link from self-hosted-guide/multi-cluster-replication to cloud/multi-region</span>
+#### [Failover](/self-hosted-guide/multi-cluster-replication) <!--[Failover](/cloud/multi-region)-->
+
+A failover shifts Workflow Execution processing from an active Cluster to a standby [Cluster](#temporal-cluster) during outages or other incidents.
+Standby Clusters use [Multi-Cluster Replication](#multi-cluster-replication) to duplicate data and prevent data loss during failover.
+
+_Tags: [term](/tags/term), [explanation](/tags/explanation)_
+
 #### [Failure](/temporal#failure)
 
 Temporal Failures are representations of various types of errors that occur in the system.
@@ -211,7 +219,9 @@ _Tags: [product-release-stages](/tags/product-release-stages), [term](/tags/term
 
 #### [Global Namespace](/namespaces#global-namespace)
 
-A Global Namespace is a Namespace that exists across Clusters when Multi-Cluster Replication is set up.
+A Global Namespace is a Namespace that duplicates data from an active [Cluster](#temporal-cluster) to a standby Cluster using [Multi-Cluster Replication](#multi-cluster-replication), keeping both Namespaces in sync.
+Global Namespaces are designed to respond to service issues like network congestion.
+When service to the primary Cluster is compromised, a [failover](#failover) transfers control from the active to the standby cluster.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
@@ -259,7 +269,19 @@ _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
 #### [Multi-Cluster Replication](/self-hosted-guide/multi-cluster-replication)
 
-Multi-Cluster Replication is a feature which asynchronously replicates Workflow Executions from active Clusters to other passive Clusters, for backup and state reconstruction.
+Multi-Cluster Replication asynchronously replicate Workflow Executions and metadata from an active [Cluster](#temporal-cluster) to a standby Cluster.
+The replicated data is used for backup and state reconstruction.
+
+_Tags: [term](/tags/term), [explanation](/tags/explanation)_
+
+<span style={{ backgroundColor: 'rgb(255, 255, 102)', fontWeight: 'bold' }}>When MRN goes live update this link from cloud to cloud/multi-region</span>
+#### [Multi-region Namespace](/cloud)<!--/multi-region)-->
+
+A Multi-region Namespace (MRN) is a [Temporal Cloud](#temporal-cloud) Namespace that is configured to work across an active [region](/cloud/service-availability#regions) and a standby region located within the same continent.
+Each region is hosted on a separate Temporal Cloud [Cluster](#temporal-cluster). 
+Temporal Cloud automatically replicates Workflow Executions and metadata from the active to the standby region using [Multi-Cluster Replication](#multi-cluster-replication).
+MRNs are designed to respond to service issues like network congestion.
+When service to the primary Cluster is compromised, a [failover](#failover) transfers control from the active to the standby Cluster.
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 

--- a/vercel.json
+++ b/vercel.json
@@ -1159,7 +1159,7 @@
       "destination": "/kb/all-the-ways-to-run-a-cluster"
     },
     {
-      "source": "/tctl:path*",
+      "source": "/tctl",
       "destination": "/tctl-v1"
     },
     {


### PR DESCRIPTION
JIRA: https://temporalio.atlassian.net/browse/EDU-2387

**NOTE: The page must be updated before deployment _after the main MRN page is merged_. Two links will not work until then and the PR will not get past the Vercel check.**

The two links are to /cloud/multi-region

These are defined by EDU-1181:

```
---
id: multi-region
slug: /cloud/multi-region
title: Multi-region Namespace- Temporal Cloud feature guide
```