### PR TITLE
Fix accidental latex rendering in pricing page

### DIFF
--- a/docs/production-deployment/cloud/introduction/pricing.mdx
+++ b/docs/production-deployment/cloud/introduction/pricing.mdx
@@ -38,7 +38,7 @@ Actions are the fundamental consumption pricing unit in Temporal Cloud.
 An Action in Temporal occurs as part of an execution of your Workflow.
 Each time you execute a Temporal Workflow (a Workflow Execution), the associated Actions are collected and ultimately represent the state and progress of your Temporal Application.
 
-Actions are collected and billed monthly for each Namespace. The base rate is $25 per one million Actions per month (across all Namespaces), and you are billed only for the prorated amount of Actions you use. If you use fewer than one million Actions per month, your bill for Actions will be less than $25 for that month.
+Actions are collected and billed monthly for each Namespace. The base rate is \$25 per one million Actions per month (across all Namespaces), and you are billed only for the prorated amount of Actions you use. If you use fewer than one million Actions per month, your bill for Actions will be less than \$25 for that month.
 
 | **Actions per month** | **Cost per 1M (USD)** |
 | --------------------- | --------------------- |


### PR DESCRIPTION
## What does this PR do?

This escapes the `$`s used in the `What is an Action?` paragraph that I believe are currently being interpreted as a TeX math mode block. Below are what I currently see in the deployed docs:
<img width="1429" alt="Screenshot 2024-05-06 at 5 34 06 PM" src="https://github.com/temporalio/documentation/assets/24440116/b0585f9b-7f00-4c38-ae22-989f846af2c2">

vs. this change:
<img width="1007" alt="Screenshot 2024-05-06 at 5 33 53 PM" src="https://github.com/temporalio/documentation/assets/24440116/8860dee8-5e27-473b-b9ac-cbf1d65f8af2">

Fixes #2807