### PR TITLE
EDU-2361: Fix incorrect information in Python Foundations Workflow type

### DIFF
--- a/docs/dev-guide/python/foundations.mdx
+++ b/docs/dev-guide/python/foundations.mdx
@@ -397,7 +397,7 @@ Workflows have a Type that are referred to as the Workflow name.
 
 The following examples demonstrate how to set a custom name for your Workflow Type.
 
-You can customize the Workflow name with a custom name in the decorator argument. For example, `@workflow.defn(name="your-workflow-name")`. If the name parameter is not specified, the Workflow name defaults to the function name.
+You can customize the Workflow name with a custom name in the decorator argument. For example, `@workflow.defn(name="your-workflow-name")`. If the name parameter is not specified, the Workflow name defaults to the unqualified class name.
 
 <div className="copycode-notice-container">
   <a href="https://github.com/temporalio/documentation/blob/main/sample-apps/python/your_app/your_workflows_dacx.py">


### PR DESCRIPTION
* Fixed as Chad suggested
* Ran grammar/spellcheck over affected file.
