### PR TITLE
Swapped argument order, as per convention

### DIFF
--- a/sample-apps/go/dev-guide/chapters/setup/tests/backgroundcheckboilerplate_test.go
+++ b/sample-apps/go/dev-guide/chapters/setup/tests/backgroundcheckboilerplate_test.go
@@ -70,7 +70,7 @@ func (s *UnitTestSuite) Test_BackgroundCheckWorkflow() {
 	// And check for the expected value of the Workflow result
 	var result string
 	s.NoError(env.GetWorkflowResult(&result))
-	s.Equal(result, ssnTraceResult)
+	s.Equal(ssnTraceResult, result)
 }
 
 /*


### PR DESCRIPTION
## What does this PR do?
It swaps the order of the two arguments passed to the `Equal` function used in the test. According to general convention, as well as the documentation for the Testify package, the expected value (`ssnTraceResult` in this case) should come before the calculated value being validated.

## Notes to reviewers

This closes [GitHub issue #2803](https://github.com/temporalio/documentation/issues/2803). I checked the source code for the [background check application](https://github.com/temporalio/background-checks/) itself, but found no test case corresponding to what's being fixed here, so it's likely that this mistake only exists in the documentation.