### PR TITLE
[DONT MERGE YET] adds landing page for application message passing

### DIFF
--- a/docs/evaluate/development-features/application-message-passing.mdx
+++ b/docs/evaluate/development-features/application-message-passing.mdx
@@ -1,0 +1,44 @@
+---
+id: application-message-passing
+title: Application Message Passing - Temporal development feature
+description: Enhance your Workflows with Signals and Queries, allowing dynamic responses to external events and real-time state access for comprehensive monitoring and tracking.
+sidebar_label: Application Message Passing
+tags:
+  - signals
+  - queries
+  - workflows
+  - activities
+  - workers
+keywords:
+  - temporal application
+  - workflow design
+  - business logic activities
+  - temporal workers
+  - temporal SDK tutorial
+  - go sdk temporal guide
+  - java sdk temporal guide
+  - python sdk temporal guide
+  - typescript sdk temporal guide
+  - learning temporal workflows
+  - developing with temporal
+  - temporal workflow execution
+  - temporal activity management
+  - worker process execution
+  - signals
+  - queries
+---
+
+Integrating Signals and Queries is an essential skill to build responsive applications. Signals allow Workflows to react to events at runtime, while Queries enable on-demand data retrieval from ongoing Workflows without disrupting their execution.
+
+**Signals**: Signals allow you to send messages asynchronously to running Workflow Executions, enabling you to change their state and control their flow in real-time. This feature is particularly useful in scenarios where Workflows must react to external events or user interactions.
+
+**Queries**: Queries provide a way to access and monitor the internal state of your Workflow Executions in real-time. This is essential for monitoring the progress of long-running Workflows and retrieving their results.
+
+See the SDK feature guides for implementation details:
+
+- [Go SDK Messaging feature guide](/dev-guide/go/messages)
+- [Java SDK Messaging feature guide](/dev-guide/java/messages)
+- [Python SDK Messaging feature guide](/dev-guide/python/messages)
+- [TypeScript SDK Messaging feature guide](/dev-guide/typescript/messages)
+
+For a deep dive into Application Message Passing, enroll in one of [our courses](https://learn.temporal.io/courses/interacting_with_workflows).

--- a/docs/evaluate/development-features/application-message-passing.mdx
+++ b/docs/evaluate/development-features/application-message-passing.mdx
@@ -36,9 +36,9 @@ Integrating Signals and Queries is an essential skill to build responsive applic
 
 See the SDK feature guides for implementation details:
 
-- [Go SDK Messaging feature guide](/dev-guide/go/messages)
-- [Java SDK Messaging feature guide](/dev-guide/java/messages)
-- [Python SDK Messaging feature guide](/dev-guide/python/messages)
-- [TypeScript SDK Messaging feature guide](/dev-guide/typescript/messages)
+- [Go SDK Messaging Feature Guide](/dev-guide/go/messages)
+- [Java SDK Messaging Feature Guide](/dev-guide/java/messages)
+- [Python SDK Messaging Feature Guide](/dev-guide/python/messages)
+- [TypeScript SDK Messaging Feature Guide](/dev-guide/typescript/messages)
 
 For a deep dive into Application Message Passing, enroll in one of [our courses](https://learn.temporal.io/courses/interacting_with_workflows).

--- a/docs/evaluate/development-features/index.mdx
+++ b/docs/evaluate/development-features/index.mdx
@@ -23,6 +23,8 @@ keywords:
   - debugging temporal applications
   - data encryption in applications
   - throughput composability
+  - signals
+  - queries
 ---
 
 Through a Temporal SDK, Temporal provides a wide range of features that enable developers to build applications that serve a wide range of use cases.
@@ -40,3 +42,4 @@ Through a Temporal SDK, Temporal provides a wide range of features that enable d
 - **Debugging**: Surface errors and step through code to find issues.
 - **Data encryption**: Transform data and protect the privacy of the users of your application.
 - **[Throughput composability](/evaluate/development-features/throughput-composability)**: Breakup business processes (Workflows) by data streams, team ownership, or other organization factors.
+- **[Application Message Passing](/evaluate/development-features/application-message-passing)**: Build responsive applications that react to events at runtime and enable data retrieval from ongoing Workflows.

--- a/sidebars.js
+++ b/sidebars.js
@@ -24,6 +24,7 @@ module.exports = {
             "evaluate/development-features/core-application",
             "evaluate/development-features/temporal-client",
             "evaluate/development-features/throughput-composability",
+            "evaluate/development-features/application-message-passing",
           ],
         },
         "security",


### PR DESCRIPTION
This adds the landing page for application message passing as requested by [EDU-2334](https://temporalio.atlassian.net/browse/EDU-2334).

Do not merge until the Interacting with Workflows course goes into GA (5/21) and until the messaging feature guides get merged as well.

[EDU-2334]: https://temporalio.atlassian.net/browse/EDU-2334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ