### PR TITLE
Update TS SDK to 1.10.0 and remove Node 14

### DIFF
--- a/docs/dev-guide/tscript/foundations.mdx
+++ b/docs/dev-guide/tscript/foundations.mdx
@@ -155,7 +155,7 @@ An SDK provides you with the following:
 
 [![NPM](https://img.shields.io/npm/v/temporalio.svg?style=for-the-badge)](https://www.npmjs.com/search?q=author%3Atemporal-sdk-team)
 
-This project requires Node.js 14.18 or later.
+This project requires Node.js 16.15 or later.
 
 **Create a project**
 

--- a/docs/dev-guide/tscript/project-setup.mdx
+++ b/docs/dev-guide/tscript/project-setup.mdx
@@ -356,9 +356,9 @@ npx @temporalio/create --sample empty backgroundcheck
 
 :::note
 
-The Temporal TypeScript SDK is dropping support for Node.js 14 and Node.js 16 due to their end-of-life status.
+The Temporal TypeScript SDK is dropping support for Node.js 16 due to its end-of-life status.
 
-The [Temporal TypeScript SDK 1.9 version](https://github.com/temporalio/sdk-typescript/releases/tag/v1.9.0) is the last minor release supporting Node.js 14, and version 1.10 may be the last supporting Node.js 16.
+The [Temporal TypeScript SDK 1.10 version](https://github.com/temporalio/sdk-typescript/releases/tag/v1.10.0) is the last minor release supporting Node.js 16.
 
 Update your deployments to supported Node.js versions to ensure continued compatibility and security updates.
 

--- a/sample-apps/typescript/chapter_durable_execution/backgroundcheck/package.json
+++ b/sample-apps/typescript/chapter_durable_execution/backgroundcheck/package.json
@@ -22,14 +22,14 @@
     ]
   },
   "dependencies": {
-    "@temporalio/activity": "^1.9.3",
-    "@temporalio/client": "^1.9.3",
-    "@temporalio/worker": "^1.9.3",
-    "@temporalio/workflow": "^1.9.3",
+    "@temporalio/activity": "^1.10.0",
+    "@temporalio/client": "^1.10.0",
+    "@temporalio/worker": "^1.10.0",
+    "@temporalio/workflow": "^1.10.0",
     "nanoid": "3.x"
   },
   "devDependencies": {
-    "@temporalio/testing": "^1.9.3",
+    "@temporalio/testing": "^1.10.0",
     "@tsconfig/node20": "^20.1.4",
     "@types/mocha": "10.0.6",
     "@types/node": "^20.11.30",

--- a/sample-apps/typescript/chapter_durable_execution/backgroundcheck_nondeterministic/package.json
+++ b/sample-apps/typescript/chapter_durable_execution/backgroundcheck_nondeterministic/package.json
@@ -21,15 +21,15 @@
     ]
   },
   "dependencies": {
-    "@temporalio/activity": "^1.9.3",
-    "@temporalio/client": "^1.9.3",
-    "@temporalio/worker": "^1.9.3",
-    "@temporalio/workflow": "^1.9.3",
+    "@temporalio/activity": "^1.10.0",
+    "@temporalio/client": "^1.10.0",
+    "@temporalio/worker": "^1.10.0",
+    "@temporalio/workflow": "^1.10.0",
     "nanoid": "3.3.7"
   },
   "devDependencies": {
     "@tsconfig/node20": "^20.1.4",
-    "@temporalio/testing": "^1.9.3",
+    "@temporalio/testing": "^1.10.0",
     "@types/node": "^20.11.30",
     "@types/mocha": "10.0.6",
     "@typescript-eslint/eslint-plugin": "^7.4.0",

--- a/sample-apps/typescript/chapter_project_setup/backgroundcheck/package.json
+++ b/sample-apps/typescript/chapter_project_setup/backgroundcheck/package.json
@@ -22,14 +22,14 @@
     ]
   },
   "dependencies": {
-    "@temporalio/activity": "^1.9.3",
-    "@temporalio/client": "^1.9.3",
-    "@temporalio/worker": "^1.9.3",
-    "@temporalio/workflow": "^1.9.3",
+    "@temporalio/activity": "^1.10.0",
+    "@temporalio/client": "^1.10.0",
+    "@temporalio/worker": "^1.10.0",
+    "@temporalio/workflow": "^1.10.0",
     "nanoid": "^3.3.7"
   },
   "devDependencies": {
-    "@temporalio/testing": "^1.9.3",
+    "@temporalio/testing": "^1.10.0",
     "@tsconfig/node20": "^20.1.4",
     "@types/mocha": "^10.0.6",
     "@types/node": "^20.11.30",


### PR DESCRIPTION
## What does this PR do?

- Update references to TS SDK to 1.10.0.
- Update minimum Node version for the TS SDK to 16.15.