### PR TITLE
EDU-2598: Restores failover link and adds how-to link

### DIFF
--- a/docs/evaluate/production-features/temporal-cloud/high-availability.mdx
+++ b/docs/evaluate/production-features/temporal-cloud/high-availability.mdx
@@ -26,7 +26,7 @@ keywords:
 :::
 
 Temporal Cloud offers disaster-tolerant deployment for workloads with stringent availability requirements.
-With the multi-region feature enabled, Temporal Cloud automates [failover](/glossary#failover] and synchronizes data between Namespace regions.
+With the multi-region feature enabled, Temporal Cloud automates [failover](/glossary#failover) and synchronizes data between Namespace regions.
 
 This page introduces Temporal Cloud patterns that support your workload's availability requirements.
 

--- a/docs/production-deployment/cloud/multi-region.mdx
+++ b/docs/production-deployment/cloud/multi-region.mdx
@@ -18,7 +18,7 @@ tags:
 :::
 
 Temporal Cloud's multi-region Namespaces offer disaster-tolerant deployment for workloads with high availability requirements.
-With the multi-region feature enabled, Temporal Cloud automates failover and synchronizes data between Namespaces in different regions.
+With the multi-region feature enabled, Temporal Cloud automates [failover](/glossary#failover) and synchronizes data between Namespaces in different regions.
 You benefit from easy deployment and operational continuity to ensure data integrity, even in the face of unexpected challenges such as regional disruptions.
 
 For each multi-region Namespace, you designate a standby region in addition to your primary active region.
@@ -74,7 +74,7 @@ Temporal Cloud provides 99.99% service availability for all Namespaces, both sin
 
 **Upgrading to multi-region:**
 
-Enable the multi-region Namespace feature for your existing single-region Namespace by adding a second region to your Namespace.
+Enable the multi-region Namespace feature for your existing single-region Namespace by [adding a second region](/cloud/multi-region#add-regions) to your Namespace.
 Once provisioned, Temporal Cloud automatically begins data replication for your new standby region.
 
 **Advantages of using a multi-region Namespace:**


### PR DESCRIPTION
Fixes links on MRN coverage page and High Availability cloud page.