### PR TITLE
Adding .NET link and adding missing anchor for temporal service

### DIFF
--- a/docs/production-deployment/self-hosted-guide/monitoring.mdx
+++ b/docs/production-deployment/self-hosted-guide/monitoring.mdx
@@ -40,7 +40,7 @@ If you implement the examples, ensure that your local docker-compose is set up, 
 
 To set up Prometheus and Grafana:
 
-1. Set up Prometheus endpoints for your [Temporal Service metrics](#cluster-metrics-setup) and [SDK metrics](#sdk-metrics-setup).
+1. Set up Prometheus endpoints for your [Temporal Service metrics](#temporal-service-metrics-setup) and [SDK metrics](#sdk-metrics-setup).
 2. [Configure Prometheus](#prometheus-configuration) to receive metrics data from your Temporal Service and SDK Clients.
    Make sure to test whether you are receiving metrics data on your Prometheus endpoint.
 3. [Set up Grafana](#grafana) to use Prometheus as a data source.
@@ -49,7 +49,7 @@ To set up Prometheus and Grafana:
 The Temporal Service and SDKs emit all metrics by default.
 However, you must enable Prometheus in your application code (using the Temporal SDKs) and your Temporal Service configuration to collect the metrics emitted from your SDK and Temporal Service.
 
-### Temporal Service metrics setup
+### Temporal Service metrics setup {#temporal-service-metrics-setup}
 
 To enable Prometheus to receive metrics data, set listen addresses in the Server configuration for Prometheus to scrape from.
 
@@ -101,6 +101,7 @@ The Metrics section in the Observability guide details how to set this up for al
 - [PHP](/develop/php/observability)
 - [Python](/develop/python/observability#metrics)
 - [TypeScript](/develop/typescript/observability#metrics)
+- [.NET](/develop/dotnet/observability#metrics)
 
 For example, with the Java SDK, you can set up the Prometheus registry and Micrometer stats reporter, set the scope, and expose an endpoint from which Prometheus can scrape the SDK Client metrics in the following way.
 


### PR DESCRIPTION
## What does this PR do?
Originally no anchor -  #cluster-metrics-setup
Changing to temporal-service-metric-setup
Adding .NET metrics link 


## Notes to reviewers

<!-- delete if n/a -->
