### PR TITLE
Updating vale configuration for command-line use

### DIFF
--- a/vale/styles/config/vocabularies/Temporal/accept.txt
+++ b/vale/styles/config/vocabularies/Temporal/accept.txt
@@ -1,0 +1,15 @@
+Temporal's
+APIs
+Temporal Application
+application
+ensure
+Ensure
+sample
+samples
+attempt
+multiple
+maintain
+Sandboxing
+Temporal CLI
+Temporal Cloud
+Workflow Sandboxing

--- a/vale/styles/config/vocabularies/WordList.yml
+++ b/vale/styles/config/vocabularies/WordList.yml
@@ -1,0 +1,76 @@
+# Forked from Google and removed Google-specific suggestions.
+extends: substitution
+message: "Use '%s' instead of '%s'."
+link: 'https://developers.google.com/style/word-list'
+level: warning
+ignorecase: false
+action:
+  name: replace
+swap:
+  '(?:API Console|dev|developer) key': API key
+  '(?:cell ?phone|smart ?phone)': phone|mobile phone
+  '(?:dev|developer|APIs) console': API console
+  '(?:e-mail|Email|E-mail)': email
+  '(?:file ?path|path ?name)': path
+  '(?:kill|terminate|abort)': stop|exit|cancel|end
+  '(?:OAuth ?2|Oauth)': OAuth 2.0
+  '(?:ok|Okay)': OK|okay
+  '(?:WiFi|wifi)': Wi-Fi
+  '[\.]+apk': APK
+  '3\-D': 3D
+  'tap (?:&|and) hold': touch & hold
+  'un(?:check|select)': clear
+  above: preceding
+  account name: username
+  action bar: app bar
+  admin: administrator
+  Ajax: AJAX
+  (?i)a\.k\.a|aka: or|also known as
+  Android device: Android-powered device
+  android: Android
+  application: app
+  approx\.: approximately
+  authN: authentication
+  authZ: authorization
+  autoupdate: automatically update
+  cellular data: mobile data
+  cellular network: mobile network
+  chapter: documents|pages|sections
+  check box: checkbox
+  check: select
+  CLI: command-line tool
+  click on: click|click in
+  content type: media type
+  curated roles: predefined roles
+  data are: data is
+  disabled?: turn off|off
+  fewer data: less data
+  file name: filename
+  firewalls: firewall rules
+  functionality: capability|feature
+  Google account: Google Account
+  Google accounts: Google Accounts
+  Googling: search with Google
+  grayed-out: unavailable
+  HTTPs: HTTPS
+  in order to: to
+  ingest: import|load
+  k8s: Kubernetes
+  long press: touch & hold
+  network IP address: internal IP address
+  omnibox: address bar
+  open-source: open source
+  overview screen: recents screen
+  regex: regular expression
+  SHA1: SHA-1|HAS-SHA1
+  sign into: sign in to
+  sign-?on: single sign-on
+  static IP address: static external IP address
+  stylesheet: style sheet
+  synch: sync
+  tablename: table name
+  tablet: device
+  touch: tap
+  url:  URL
+  vs\.: versus
+  World Wide Web: web

--- a/vale/styles/config/vocabularies/badwords.yml
+++ b/vale/styles/config/vocabularies/badwords.yml
@@ -1,0 +1,21 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+level: error
+ignorecase: true
+action:
+  name: replace
+swap:
+  allow: enable
+  allows: enables
+  below: "following"
+  female: woman
+  females: women
+  learn to: ""
+  learned to: ""
+  learn how to: ""
+  learned how to: ""
+  utilization: usage
+  utilizing: using
+  utilize: use
+  utilized: used
+  utilizes: uses

--- a/vale/styles/config/vocabularies/complexwords.yml
+++ b/vale/styles/config/vocabularies/complexwords.yml
@@ -1,0 +1,116 @@
+# This is a fork of Microsoft's word list
+extends: substitution
+message: "Consider using '%s' instead of '%s'."
+link: https://docs.microsoft.com/en-us/style-guide/word-choice/use-simple-words-concise-sentences
+ignorecase: true
+level: suggestion
+action:
+  name: replace
+swap:
+  "approximate(?:ly)?": about
+  abundance: plenty
+  accelerate: speed up
+  accentuate: stress
+  accompany: go with
+  accomplish: carry out|do
+  accorded: given
+  accordingly: so
+  accrue: add
+  accurate: right|exact
+  acquiesce: agree
+  acquire: get|buy
+  additional: more|extra
+  addressees: you
+  adjacent to: next to
+  adjustment: change
+  admissible: allowed
+  advantageous: helpful
+  advise: tell
+  aggregate: total
+  aircraft: plane
+  alleviate: ease
+  allocate: assign|divide
+  alternatively: or
+  alternatives: choices|options
+  ameliorate: improve
+  amend: change
+  anticipate: expect
+  apparent: clear|plain
+  ascertain: discover|find out
+  assistance: help
+  attain: meet
+  attempt: try
+  authorize: allow
+  belated: late
+  bestow: give
+  cease: stop|end
+  collaborate: work together
+  commence: begin
+  compensate: pay
+  component: part
+  comprise: form|include
+  concept: idea
+  concerning: about
+  confer: give|award
+  consequently: so
+  consolidate: merge
+  constitutes: forms
+  contains: has
+  convene: meet
+  demonstrate: show|prove
+  depart: leave
+  designate: choose
+  desire: want|wish
+  determine: decide|find
+  detrimental: bad|harmful
+  disclose: share|tell
+  discontinue: stop
+  disseminate: send|give
+  eliminate: end
+  elucidate: explain
+  employ: use
+  enclosed: inside|included
+  encounter: meet
+  endeavor: try
+  enumerate: count
+  equitable: fair
+  equivalent: equal
+  exclusively: only
+  expedite: hurry
+  facilitate: ease
+  finalize: complete|finish
+  frequently: often
+  identical: same
+  incorrect: wrong
+  indication: sign
+  initiate: start|begin
+  itemized: listed
+  jeopardize: risk
+  liaise: work with|partner with
+  maintain: keep|support
+  methodology: method
+  modify: change
+  monitor: check|watch
+  multiple: many
+  necessitate: cause
+  notify: tell
+  numerous: many
+  objective: aim|goal
+  obligate: bind|compel
+  optimum: best|most
+  permit: let
+  portion: part
+  possess: own
+  previous: earlier
+  previously: before
+  prioritize: rank
+  procure: buy
+  provide: give|offer
+  purchase: buy
+  relocate: move
+  solicit: request
+  state-of-the-art: latest
+  subsequent: later|next
+  substantial: large
+  sufficient: enough
+  transmit: send

--- a/vale/styles/config/vocabularies/programming.yml
+++ b/vale/styles/config/vocabularies/programming.yml
@@ -1,0 +1,12 @@
+extends: substitution
+message: Consider using '%s' instead of '%s'
+level: warning
+ignorecase: true
+action:
+  name: replace
+swap:
+  java: "Java"
+  javascript: "JavaScript"
+  jdk: "JDK"
+  nodejs: "Node.js"
+  typescript: "TypeScript"

--- a/vale/styles/config/vocabularies/section-headings-gerunds.yml
+++ b/vale/styles/config/vocabularies/section-headings-gerunds.yml
@@ -1,0 +1,7 @@
+extends: existence
+message: Section '%v' should not start with a gerund (verb ending in "ing")
+level: error
+scope: heading
+ignorecase: false
+raw:
+  '^(\w+ing\b.*)$'

--- a/vale/styles/config/vocabularies/sectionEndings.yml
+++ b/vale/styles/config/vocabularies/sectionEndings.yml
@@ -1,0 +1,76 @@
+extends: script
+message: "The main section '%v' is not preceded by a paragraph. Ensure sections end with a paragraph for a smooth transition."
+level: error
+link: https://tengolang.com/
+# We need this to access heading markup.
+scope: raw
+script: |
+  text := import("text")
+  matches := []
+
+  paragraph_re := "^(?:[a-z|A-Z].*)$"
+
+  lines := text.split(scope, "\n")
+  section_lines := []
+  in_main_body := false
+
+  for line in lines {
+    if text.re_match("^#{2,}", line) {
+
+      // skip the intro and prereq headings
+      if text.re_match("^#{2,} (Introduction|Prerequisites)", line) {
+        continue
+      }
+
+      // hit a heading that's actually a main body heading
+      in_main_body = true
+
+      if len(section_lines) > 1 {
+
+        last_line := section_lines[len(section_lines) - 1]
+        second_to_last_line := section_lines[len(section_lines) - 2]
+
+        if !text.re_match(paragraph_re, second_to_last_line) && last_line == "" {
+
+          startIndex := text.index(scope, line)
+
+          /* emojis throw off the start position. Need to get all the characters
+              prior to the start of our match position, count up the characters,
+              but check each char to see if it's an emoji so we add an additional
+              character to the count.
+
+              May not be required in newer Vale (2.25 or higher)
+          */
+
+          /*
+          // Extract substring from start of text string up to starting position of search term
+          text_before_match := text.substr(scope, 0, startIndex)
+
+          // split the text before the match into runes. Check for emojis
+          start := 0
+          for c in text.split(text_before_match, "") {
+              rune := char(c[0])
+              isEmoji := rune >= '\U0001F600' && rune <= '\U0001F64F'
+              if isEmoji {
+                  start++
+              }
+              start++
+              if start > startIndex {
+                  break
+              }
+          }
+          end := start + len(line)
+          */
+
+          matches = append(matches, {begin: startIndex, end: startIndex + len(line)})
+          section_lines = []
+        }
+
+      }
+    } else {
+      // if we're in the main body we'll start collecting the lines in the section.
+      if in_main_body {
+        section_lines = append(section_lines, line)
+      }
+    }
+  }

--- a/vale/styles/config/vocabularies/terms.yml
+++ b/vale/styles/config/vocabularies/terms.yml
@@ -1,0 +1,91 @@
+extends: substitution
+message: Consider using '%s' instead of '%s'
+level: warning
+ignorecase: true
+action:
+  name: replace
+# swap maps tokens in form of bad: good
+swap:
+  '\bactivity\b': Activity
+  activity definition: Activity Definition
+  activity execution: Activity Execution
+  activity heartbeat: Activity Heartbeat
+  activity id: Activity Id
+  activity task: Activity Task
+  activity task execution: Activity Task Execution
+  activity type: Activity Type
+  advanced visibility: Advanced Visibility
+  archival: Archival
+  child workflow execution: Child Workflow Execution
+  codec server: Codec Server
+  continue-as-new: Continue-As-New
+  data converter: Data Converter
+  event history: Event History
+  frontend service: Frontend Service
+  grpc: gRPC
+  '\bheartbeat\b': Heartbeat
+  #heartbeating: Heartbeating
+  heartbeat timeout: Heartbeat Timeout
+  history service: History Service
+  history shard: History Shard
+  id: Id
+  ID: Id
+  IDs: Ids
+  list filter: List Filter
+  list filters: List Filters
+  local activity: Local Activity
+  local activities: Local Activities
+  matching service: Matching Service
+  namespace: Namespace
+  namespaces: Namespaces
+  parent close policy: Parent Close Policy
+  query: Query
+  queries: Queries
+  retry policy: Retry Policy
+  run id: Run Id
+  schedule-to-close timeout: Schedule-To-Close Timeout
+  schedule-to-start timeout: Schedule-To-Start Timeout
+  search attribute: Search Attribute
+  search attributes: Search Attributes
+  side effect: Side Effect
+  signal: Signal
+  signals: Signals
+  standard visibility: Standard Visibility
+  start-to-close timeout: Start-To-Close Timeout
+  state transition: State Transition
+  temporal server: Temporal Server
+  temporal cluster: Temporal Cluster
+  task: Task
+  task queue: Task Queue
+  task queues: Task Queues
+  task token: Task Token
+  task tokens: Task Tokens
+  '\btemporal ': Temporal
+  temporal platform: Temporal Platform
+  temporal sdk: Temporal SDK
+  temporal sdks: Temporal SDKs
+  temporal server: Temporal Server
+  '\bworker\b': Worker
+  '\bworkflow\b': Workflow
+  timer: Timer
+  timers: Timers
+  web ui: Web UI
+  worker: Worker
+  workers: Workers
+  worker service: Worker Service
+  workflow: Workflow
+  workflows: Workflows
+  workflow definition: Workflow Definition
+  workflow definitions: Workflow Definitions
+  workflow execution: Workflow Execution
+  workflow executions: Workflow Executions
+  workflow execution timeout: Workflow Execution Timeout
+  workflow id: Workflow Id
+  workflow ids: Workflow Ids
+  workflow id reuse policy: Workflow Id Reuse Policy
+  workflow run timeout: Workflow Run Timeout
+  workflow task: Workflow Task
+  workflow tasks: Workflow Tasks
+  workflow task execution: Workflow Task Execution
+  workflow task timeout: Workflow Task Timeout
+  workflow type: Workflow Type


### PR DESCRIPTION
@rachfop

This patch adjusts vale for CLI use according to a suggestion from the vale GitHub repo.
It should not affect VSCode use. It also eliminates my need to use a special script to get around the current issues.
I was going to use symbolic links but the repo suggested against that.