### PR TITLE
Docs for NextRetryDelay

### DIFF
--- a/docs/develop/java/failure-detection.mdx
+++ b/docs/develop/java/failure-detection.mdx
@@ -189,6 +189,20 @@ To set a Retry Policy, known as the [Retry Options](/encyclopedia/retry-policies
                 .build();
   ```
 
+### Overriding the retry interval with Next Retry Delay {#next-retry-delay}
+You may throw an [Application Failure](/references/failures#application-failure) with the NextRetryDelay field set.  This value will replace and override whatever the retry interval would be on the retry policy.
+
+For example, if in an activity, you want to base the interval on the number of attempts, you might do:
+  ```java 
+  int attempt = Activity.getExecutionContext().getInfo().getAttempt();
+
+  throw ApplicationFailure.newFailureWithCauseAndDelay(
+      "Something bad happened on attempt " + attempt,
+      "my_failure_type",
+      null,
+      3 * Duration.ofSeconds(attempt));
+  ```
+
 ## Heartbeat an Activity {#activity-heartbeats}
 
 **How to Heartbeat an Activity using the Java SDK.**

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -122,7 +122,7 @@ The wait time before a retry is the _retry interval_. A retry interval is the sm
 ### Per-error next retry delay
 
 Sometimes, your Activity or Workflow raises a special exception that needs a different retry interval from the Retry Policy.
-To accomplish this, you may throw an [Application Failure](/references/failures#application-failure) with the next retry delay field set. This value will replace and override whatever the retry interval would be on the retry policy.
+To accomplish this, you may throw an [Application Failure](/references/failures#application-failure) with the Next Retry Delay field set. This value will replace and override whatever the retry interval would be on the Retry Policy.
 Note that your retries will still cap out under the retry policy's Maximum Attempts, as well as overall timeouts--i.e. if it's an activity, its Schedule-to-Close Timeout or, if it's a workflow, the Execution Timeout.
 
 ## Event History

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -119,11 +119,15 @@ The wait time before a retry is the _retry interval_. A retry interval is the sm
 
 <PrettyImage src="/img/retry-interval-diagram.png" title="Diagram that shows the retry interval and its formula" />
 
-### Per-error next retry delay
+### Per-error Next Retry Delay
 
 Sometimes, your Activity or Workflow raises a special exception that needs a different retry interval from the Retry Policy.
 To accomplish this, you may throw an [Application Failure](/references/failures#application-failure) with the Next Retry Delay field set. This value will replace and override whatever the retry interval would be on the Retry Policy.
 Note that your retries will still cap out under the Retry Policy's Maximum Attempts, as well as overall timeouts. For an Activity, its Schedule-to-Close Timeout applies. For a Workflow, the Execution Timeout applies.
+
+<RelatedReadContainer>
+    <RelatedReadItem path="/develop/java/failure-detection#next-retry-delay" text="Customize retry delays per error in the Java SDK." archetype="feature-guide" />
+</RelatedReadContainer>
 
 ## Event History
 

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -123,7 +123,7 @@ The wait time before a retry is the _retry interval_. A retry interval is the sm
 
 Sometimes, your Activity or Workflow raises a special exception that needs a different retry interval from the Retry Policy.
 To accomplish this, you may throw an [Application Failure](/references/failures#application-failure) with the next retry delay field set. This value will replace and override whatever the retry interval would be on the retry policy.
-Note that your retries will still cap out under the retry policy's Maximum Attempts.
+Note that your retries will still cap out under the retry policy's Maximum Attempts, as well as overall timeouts--i.e. if it's an activity, its Schedule-to-Close Timeout or, if it's a workflow, the Execution Timeout.
 
 ## Event History
 

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -119,6 +119,11 @@ The wait time before a retry is the _retry interval_. A retry interval is the sm
 
 <PrettyImage src="/img/retry-interval-diagram.png" title="Diagram that shows the retry interval and its formula" />
 
+### Per-error next retry delay
+
+Sometimes, your Activity or Workflow raises a special exception that needs a different retry interval from the Retry Policy.
+To accomplish this, you may throw an [Application Failure](/references/failures#application-failure) with the next retry delay field set. This value will replace and override whatever the retry interval would be on the retry policy.
+
 ## Event History
 
 There are some subtle nuances to how Events are recorded to an Event History when a Retry Policy comes into play.

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -123,6 +123,7 @@ The wait time before a retry is the _retry interval_. A retry interval is the sm
 
 Sometimes, your Activity or Workflow raises a special exception that needs a different retry interval from the Retry Policy.
 To accomplish this, you may throw an [Application Failure](/references/failures#application-failure) with the next retry delay field set. This value will replace and override whatever the retry interval would be on the retry policy.
+Note that your retries will still cap out under the retry policy's Maximum Attempts and Maximum Interval.
 
 ## Event History
 

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -123,7 +123,7 @@ The wait time before a retry is the _retry interval_. A retry interval is the sm
 
 Sometimes, your Activity or Workflow raises a special exception that needs a different retry interval from the Retry Policy.
 To accomplish this, you may throw an [Application Failure](/references/failures#application-failure) with the Next Retry Delay field set. This value will replace and override whatever the retry interval would be on the Retry Policy.
-Note that your retries will still cap out under the retry policy's Maximum Attempts, as well as overall timeouts--i.e. if it's an activity, its Schedule-to-Close Timeout or, if it's a workflow, the Execution Timeout.
+Note that your retries will still cap out under the Retry Policy's Maximum Attempts, as well as overall timeouts. For an Activity, its Schedule-to-Close Timeout applies. For a Workflow, the Execution Timeout applies.
 
 ## Event History
 

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -123,7 +123,7 @@ The wait time before a retry is the _retry interval_. A retry interval is the sm
 
 Sometimes, your Activity or Workflow raises a special exception that needs a different retry interval from the Retry Policy.
 To accomplish this, you may throw an [Application Failure](/references/failures#application-failure) with the next retry delay field set. This value will replace and override whatever the retry interval would be on the retry policy.
-Note that your retries will still cap out under the retry policy's Maximum Attempts and Maximum Interval.
+Note that your retries will still cap out under the retry policy's Maximum Attempts.
 
 ## Event History
 

--- a/docs/references/failures.mdx
+++ b/docs/references/failures.mdx
@@ -78,6 +78,7 @@ During conversion, the following Application Failure fields are set:
 - `non_retryable` is set to false.
 - `details` are left unset.
 - `cause` is a Failure converted from the error's `cause` property.
+- `next_retry_delay` is left unset.
 - call stack is copied.
 
 When an [Activity Execution](/activities#activity-execution) fails, the Application Failure from the last Activity Task is the `cause` field of the [ActivityFailure](#activity-failure) thrown in the Workflow.
@@ -86,6 +87,12 @@ When an [Activity Execution](/activities#activity-execution) fails, the Applicat
 
 When an Activity or Workflow throws an Application Failure, the Failure's `type` field is matched against a Retry Policy's list of [non-retryable errors](/encyclopedia/retry-policies#non-retryable-errors) to determine whether to retry the Activity or Workflow.
 Activities and Workflow can also avoid retrying by setting an Application Failure's `non_retryable` flag to `true`.
+
+### Setting the Next Retry Delay {#next-retry-delay}
+
+By setting the "next retry delay" for a given Application Failure, you can tell the server to wait that amount of time before trying the Activity or Workflow again.  This will override whatever the Retry Policy would have computed for your specific exception.
+
+Java: [NextRetryDelay](/develop/java/failure-detection#next-retry-delay)
 
 ## Cancelled Failure
 

--- a/docs/references/failures.mdx
+++ b/docs/references/failures.mdx
@@ -90,7 +90,7 @@ Activities and Workflow can also avoid retrying by setting an Application Failur
 
 ### Setting the Next Retry Delay {#next-retry-delay}
 
-By setting the "next retry delay" for a given Application Failure, you can tell the server to wait that amount of time before trying the Activity or Workflow again.  This will override whatever the Retry Policy would have computed for your specific exception.
+By setting the Next Retry Delay for a given Application Failure, you can tell the server to wait that amount of time before trying the Activity or Workflow again. This will override whatever the Retry Policy would have computed for your specific exception.
 
 Java: [NextRetryDelay](/develop/java/failure-detection#next-retry-delay)
 


### PR DESCRIPTION
## What does this PR do?
Adds documentation for the new "Next Retry Delay" feature.
I've added overview docs and SDK-specific docs for one language, Java.

## Notes to reviewers
My first documentation contribution.
If this looks good, I would prefer to open a new PR for the other language-specific docs, or I may ask others to do so. 

Testing:
http://localhost:3000/references/failures#next-retry-delay
http://localhost:3000/develop/java/failure-detection#next-retry-delay

What the Java page looks like
<img width="948" alt="Screenshot 2024-06-26 at 7 26 48 PM" src="https://github.com/temporalio/documentation/assets/166441821/779ed8b6-555a-4168-9023-a2c5f2a6247e">


<!-- delete if n/a -->
