### PR TITLE
Update docs for python connection details connect_cloud_dacx.py

### DIFF
--- a/sample-apps/python/your_app/connect_cloud_dacx.py
+++ b/sample-apps/python/your_app/connect_cloud_dacx.py
@@ -16,8 +16,8 @@ async def main():
     with open("client-private-key.pem", "rb") as f:
         client_private_key = f.read()
     client = await Client.connect(
-        "your-custom-namespace.tmprl.cloud:7233",
-        namespace="<your-custom-namespace>.<id>",
+        "your-custom-namespace.account-id.tmprl.cloud:7233",
+        namespace="<your-custom-namespace>.<account-id>",
         tls=TLSConfig(
             client_cert=client_cert,
             client_private_key=client_private_key,


### PR DESCRIPTION
It's not explicit that you must use 'namespace.account_id' in the connection string for connecting to Temporal Cloud via Python SDK, so I added it in

## What does this PR do?

## Notes to reviewers

<!-- delete if n/a -->
