### PR TITLE
Update Vale terms to include Frontend Service

### DIFF
--- a/vale/styles/Temporal/terms.yml
+++ b/vale/styles/Temporal/terms.yml
@@ -32,6 +32,7 @@ swap:
   durable exeuction: Durable Execution
   event history: Event History
   failure converter: Failure Converter
+  frontend service: Frontend Service
   grpc: gRPC
   '\bheartbeat\b': Heartbeat
   heartbeat timeout: Heartbeat Timeout


### PR DESCRIPTION
This misses several items including optional issues (warning) history, action, frontend, matching.
We don't have the conditional package installed to issue those warnings.