### PR TITLE
EDU-2719: Fixes heading typo of missing 'to'

### DIFF
--- a/docs/develop/go/core-application.mdx
+++ b/docs/develop/go/core-application.mdx
@@ -410,7 +410,7 @@ func main() {
 }
 ```
 
-### How develop Workflow logic {#workflow-logic-requirements}
+### How to develop Workflow logic {#workflow-logic-requirements}
 
 Workflow logic is constrained by [deterministic execution requirements](/workflows#deterministic-constraints).
 Therefore, each language is limited to the use of certain idiomatic techniques.

--- a/docs/develop/php/core-application.mdx
+++ b/docs/develop/php/core-application.mdx
@@ -94,7 +94,7 @@ interface YourWorkflowDefinitionInterface
 }
 ```
 
-### How develop Workflow logic {#workflow-logic-requirements}
+### How to develop Workflow logic {#workflow-logic-requirements}
 
 Workflow logic is constrained by [deterministic execution requirements](/workflows#deterministic-constraints).
 Therefore, each language is limited to the use of certain idiomatic techniques.

--- a/docs/develop/typescript/core-application.mdx
+++ b/docs/develop/typescript/core-application.mdx
@@ -389,7 +389,7 @@ export async function helloWorld(): Promise<string> {
 
 <!--SNIPEND-->
 
-### How develop Workflow logic {#workflow-logic-requirements}
+### How to develop Workflow logic {#workflow-logic-requirements}
 
 Workflow logic is constrained by [deterministic execution requirements](/workflows#deterministic-constraints).
 Therefore, each language is limited to the use of certain idiomatic techniques.


### PR DESCRIPTION
Did a global search to find repeats as well as the request for Typescript