### PR TITLE
Adding double redirects for release stages 

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1813,7 +1813,11 @@
     },
     {
       "source": "/temporal/release-stages",
-      "destination": "/evaluate/release-stages"
+      "destination": "/evaluate/development-production-features/release-stages"
+    },
+    {
+      "source": "/evaluate/release-stages",
+      "destination": "/evaluate/development-production-features/release-stages"
     },
     {
       "source": "/getting-started",


### PR DESCRIPTION
## What does this PR do?
- adds redirect for release stages on old and new
- tested it by changing the end of the preview link to evaluate/release-stages and temporal/release-stages

## Notes to reviewers
[preview](https://vercel.live/link/temporal-documentation-git-redirectreleasestages.preview.thundergun.io?via=deployment-domains-list-branch)


<!-- delete if n/a -->
