### PR TITLE
corrects anchor errors

### DIFF
--- a/docs/cli/batch.mdx
+++ b/docs/cli/batch.mdx
@@ -32,7 +32,7 @@ The List Filter identifies the Workflow Executions in the Batch Job; the Batch t
 There are three types of Batch Jobs:
 
 - Cancel: cancels the Workflow Executions specified by the List Filter.
-- Signal: sends a [Signal](/encyclopedia/workflow-message-passing#signals) to the Workflow Executions specified by the List Filter.
+- Signal: sends a [Signal](/encyclopedia/workflow-message-passing#sending-signals) to the Workflow Executions specified by the List Filter.
 - Terminate: terminates the Workflow Executions specified by the List Filter.
 
 Batch operations can affect multiple Workflows simultaneously.

--- a/docs/cli/operator.mdx
+++ b/docs/cli/operator.mdx
@@ -613,7 +613,7 @@ Use the following options to change this command's behavior.
 
 ### list
 
-The `temporal operator search-attribute list` command displays a list of all [Search Attributes](/visibility#search-attribute) that can be used in [Queries](/encyclopedia/workflow-message-passing#queries).
+The `temporal operator search-attribute list` command displays a list of all [Search Attributes](/visibility#search-attribute) that can be used in [Queries](/encyclopedia/workflow-message-passing#sending-queries).
 
 `temporal workflow list --query`.
 

--- a/docs/cli/workflow.mdx
+++ b/docs/cli/workflow.mdx
@@ -398,7 +398,7 @@ Use the following command options to change the information returned by this com
 
 ## query
 
-The `temporal workflow query` command sends a [Query](/encyclopedia/workflow-message-passing#queries) to a [Workflow Execution](/workflows#workflow-execution).
+The `temporal workflow query` command sends a [Query](/encyclopedia/workflow-message-passing#sending-queries) to a [Workflow Execution](/workflows#workflow-execution).
 
 Queries can retrieve all or part of the Workflow state within given parameters.
 Queries can also be used on completed [Workflows](/workflows#workflow-execution).
@@ -623,7 +623,7 @@ Use the following options to change the behavior of this command.
 
 ## signal
 
-The `temporal workflow signal` command is used to send a [Signal](/encyclopedia/workflow-message-passing#signals) to a [Workflow Execution](/workflows#workflow-execution) by [Workflow Id](/workflows#workflow-id) or [List Filter](/visibility#list-filter).
+The `temporal workflow signal` command is used to send a [Signal](/encyclopedia/workflow-message-passing#sending-signals) to a [Workflow Execution](/workflows#workflow-execution) by [Workflow Id](/workflows#workflow-id) or [List Filter](/visibility#list-filter).
 
 Use the following options to change the command's behavior.
 

--- a/docs/develop/dotnet/index.mdx
+++ b/docs/develop/dotnet/index.mdx
@@ -80,7 +80,7 @@ The [Workflow messages feature guide](/develop/dotnet/message-passing) shows how
 **Updates**
 
 - [Define an Update](/develop/dotnet/message-passing#define-update): An Update is an operation that can mutate the state of a Workflow Execution and return a response.
-- [Send an Update](/develop/dotnet/message-passing#send-update): An Update is sent from the Temporal Client.
+- [Send an Update](/develop/dotnet/message-passing#send-update-from-client): An Update is sent from the Temporal Client.
 
 ## Interrupt a Workflow
 

--- a/docs/develop/dotnet/message-passing.mdx
+++ b/docs/develop/dotnet/message-passing.mdx
@@ -26,7 +26,7 @@ This page shows how to do the following:
 
 **How to develop with Signals using the Temporal .NET SDK**
 
-A [Signal](/encyclopedia/workflow-message-passing#signals) is a message sent to a running Workflow Execution.
+A [Signal](/encyclopedia/workflow-message-passing#sending-signals) is a message sent to a running Workflow Execution.
 
 Signals are defined in your code and handled in your Workflow Definition.
 Signals can be sent to Workflow Executions from a Temporal Client or from another Workflow Execution.
@@ -153,7 +153,7 @@ public async Task DynamicSignalAsync(string signalName, IRawValue[] args)
 
 ## Queries {#queries}
 
-A [Query](/encyclopedia/workflow-message-passing#queries) is a synchronous operation that is used to get the state of a Workflow Execution.
+A [Query](/encyclopedia/workflow-message-passing#sending-queries) is a synchronous operation that is used to get the state of a Workflow Execution.
 
 ### Define a Query {#define-query}
 
@@ -223,7 +223,7 @@ public string DynamicQueryAsync(string queryName, IRawValue[] args)
 
 **How to develop with Updates using the Temporal .NET SDK**
 
-An [Update](/encyclopedia/workflow-message-passing#updates) is an operation that can mutate the state of a Workflow Execution and return a response.
+An [Update](/encyclopedia/workflow-message-passing#sending-updates) is an operation that can mutate the state of a Workflow Execution and return a response.
 
 ### Define an Update {#define-update}
 
@@ -250,7 +250,7 @@ public async Task<string> UpdateStatusAsync(Status status)
 }
 ```
 
-### Send an Update from a Temporal Client {#send-update}
+### Send an Update from a Temporal Client {#send-update-from-client}
 
 **How to send an Update from a Temporal Client using the Temporal .NET SDK**
 

--- a/docs/develop/go/debugging.mdx
+++ b/docs/develop/go/debugging.mdx
@@ -316,7 +316,7 @@ func (s *UnitTestSuite) Test_ProgressWorkflow() {
 
 :::note
 
-`RegisterDelayedCallback` can also be used to send [Signals](/encyclopedia/workflow-message-passing#signals).
+`RegisterDelayedCallback` can also be used to send [Signals](/encyclopedia/workflow-message-passing#sending-signals).
 When using "Signal-With-Start", set the delay to `0`.
 :::
 

--- a/docs/develop/go/message-passing.mdx
+++ b/docs/develop/go/message-passing.mdx
@@ -35,7 +35,7 @@ This page shows how to do the following:
 
 ## Signals {#signals}
 
-A [Signal](/encyclopedia/workflow-message-passing#signals) is a message sent to a running Workflow Execution.
+A [Signal](/encyclopedia/workflow-message-passing#sending-signals) is a message sent to a running Workflow Execution.
 
 Signals are defined in your code and handled in your Workflow Definition.
 Signals can be sent to Workflow Executions from a Temporal Client or from another Workflow Execution.
@@ -115,7 +115,7 @@ Otherwise, the Signals will be lost.
 
 When a Signal is sent successfully from the Temporal Client, the [WorkflowExecutionSignaled](/references/events#workflowexecutionsignaled) Event appears in the Event History of the Workflow that receives the Signal.
 
-Use the `SignalWorkflow()` method on an instance of the [Go SDK Temporal Client](https://pkg.go.dev/go.temporal.io/sdk/client#Client) to send a [Signal](/encyclopedia/workflow-message-passing#signals) to a [Workflow Execution](/workflows#workflow-execution).
+Use the `SignalWorkflow()` method on an instance of the [Go SDK Temporal Client](https://pkg.go.dev/go.temporal.io/sdk/client#Client) to send a [Signal](/encyclopedia/workflow-message-passing#sending-signals) to a [Workflow Execution](/workflows#workflow-execution).
 
 Pass in both the [Workflow Id](/workflows#workflow-id) and [Run Id](/workflows#run-id) to uniquely identify the Workflow Execution.
 If only the Workflow Id is supplied (provide an empty string as the Run Id param), the Workflow Execution that is Running receives the Signal.
@@ -194,7 +194,7 @@ if err != nil {
 
 ## Queries {#queries}
 
-A [Query](/encyclopedia/workflow-message-passing#queries) is a synchronous operation that is used to get the state of a Workflow Execution.
+A [Query](/encyclopedia/workflow-message-passing#sending-queries) is a synchronous operation that is used to get the state of a Workflow Execution.
 
 ### How to define a Query {#define-query}
 
@@ -312,7 +312,7 @@ log.Println("Received Query result. Result: " + result)
 
 ## Updates {#updates}
 
-An [Update](/encyclopedia/workflow-message-passing#updates) is an operation that can mutate the state of a Workflow Execution and return a response.
+An [Update](/encyclopedia/workflow-message-passing#sending-updates) is an operation that can mutate the state of a Workflow Execution and return a response.
 
 ### Define an Update {#define-update}
 
@@ -456,7 +456,7 @@ func isPositive(ctx workflow.Context, u YourUpdateArg) error {
 
 **How to send an Update from a Temporal Client using the Go SDK.**
 
-Invoke the `UpdateWorkflow()` method on an instance of the [Go SDK Temporal Client](https://pkg.go.dev/go.temporal.io/sdk/client#Client) to dispatch an [Update](/encyclopedia/workflow-message-passing#updates) to a Workflow Execution.
+Invoke the `UpdateWorkflow()` method on an instance of the [Go SDK Temporal Client](https://pkg.go.dev/go.temporal.io/sdk/client#Client) to dispatch an [Update](/encyclopedia/workflow-message-passing#sending-updates) to a Workflow Execution.
 
 You must provide the Workflow Id, but specifying a Run Id is optional.
 If you supply only the Workflow Id (and provide an empty string as the Run Id param), the currently running Workflow Execution receives the Update.

--- a/docs/develop/go/test-suites.mdx
+++ b/docs/develop/go/test-suites.mdx
@@ -253,7 +253,7 @@ func (s *UnitTestSuite) Test_ProgressWorkflow() {
 
 :::note
 
-`RegisterDelayedCallback` can also be used to send [Signals](/encyclopedia/workflow-message-passing#signals).
+`RegisterDelayedCallback` can also be used to send [Signals](/encyclopedia/workflow-message-passing#sending-signals).
 When using "Signal-With-Start", set the delay to `0`.
 :::
 

--- a/docs/develop/java/message-passing.mdx
+++ b/docs/develop/java/message-passing.mdx
@@ -29,7 +29,7 @@ tags:
 
 ## Signals {#signals}
 
-A [Signal](/encyclopedia/workflow-message-passing#signals) is a message sent to a running Workflow Execution.
+A [Signal](/encyclopedia/workflow-message-passing#sending-signals) is a message sent to a running Workflow Execution.
 
 Signals are defined in your code and handled in your Workflow Definition.
 Signals can be sent to Workflow Executions from a Temporal Client or from another Workflow Execution.
@@ -66,7 +66,7 @@ Things to consider when defining Signals:
   In some cases, Signal method implementation might require some initialization to be performed by the Workflow method code first—for example, when the Signal processing depends on, and is defined by the Workflow input.
   In this case, you can use a flag to determine whether the Workflow method is already triggered; if not, persist the Signal data into a collection for delayed processing by the Workflow method.
 
-### Handle Signals in a Workflow in Java {#handle-signals}
+### Handle Signals in a Workflow in Java {#handle-signal}
 
 **How to handle Signals in a Workflow using the Java SDK.**
 
@@ -171,7 +171,7 @@ Customer customer = new Customer("John", "Spanish", "john@john.com");
 workflow.addCustomer(customer); //addCustomer is the Signal method defined in the greetCustomer Workflow.
 ```
 
-See [Handle Signals](#handle-signals) for details on how to handle Signals in a Workflow.
+See [Handle Signals](#handle-signal) for details on how to handle Signals in a Workflow.
 
 ### Send a Signal from a Workflow {#send-signal-from-workflow}
 
@@ -269,7 +269,7 @@ Note that the Signal handler `setCustomer` is executed before the `@WorkflowMeth
 
 ## Queries {#queries}
 
-A [Query](/encyclopedia/workflow-message-passing#queries) is a synchronous operation that is used to get the state of a Workflow Execution.
+A [Query](/encyclopedia/workflow-message-passing#sending-queries) is a synchronous operation that is used to get the state of a Workflow Execution.
 
 ### Define a Query {#define-query}
 
@@ -501,7 +501,7 @@ Note that you can only register one `Workflow.registerListener(Object)` per Work
 
 ## Updates {#updates}
 
-An [Update](/encyclopedia/workflow-message-passing#updates) is an operation that can mutate the state of a Workflow Execution and return a response.
+An [Update](/encyclopedia/workflow-message-passing#sending-updates) is an operation that can mutate the state of a Workflow Execution and return a response.
 
 ### Define Update {#define-update}
 

--- a/docs/develop/php/message-passing.mdx
+++ b/docs/develop/php/message-passing.mdx
@@ -12,7 +12,7 @@ description: Learn how to develop with Signals, Queries, and Updates in Temporal
 
 ## How to develop with Signals {#signals}
 
-A [Signal](/encyclopedia/workflow-message-passing#signals) is a message sent to a running Workflow Execution.
+A [Signal](/encyclopedia/workflow-message-passing#sending-signals) is a message sent to a running Workflow Execution.
 
 Signals are defined in your code and handled in your Workflow Definition.
 Signals can be sent to Workflow Executions from a Temporal Client or from another Workflow Execution.
@@ -24,7 +24,7 @@ A Signal has a name and can have arguments.
 - The name, also called a Signal type, is a string.
 - The arguments must be [serializable](/dataconversion).
 
-Workflows can answer synchronous [Queries](/encyclopedia/workflow-message-passing#queries) and receive [Signals](/encyclopedia/workflow-message-passing#signals).
+Workflows can answer synchronous [Queries](/encyclopedia/workflow-message-passing#sending-queries) and receive [Signals](/encyclopedia/workflow-message-passing#sending-signals).
 
 All interface methods must have one of the following annotations:
 
@@ -187,7 +187,7 @@ $run = $workflowClient->startWithSignal(
 
 ## How to develop with Queries {#queries}
 
-A [Query](/encyclopedia/workflow-message-passing#queries) is a synchronous operation that is used to get the state of a Workflow Execution.
+A [Query](/encyclopedia/workflow-message-passing#sending-queries) is a synchronous operation that is used to get the state of a Workflow Execution.
 
 ### How to define a Query {#define-query}
 
@@ -196,7 +196,7 @@ A Query has a name and can have arguments.
 - The name, also called a Query type, is a string.
 - The arguments must be [serializable](/dataconversion).
 
-Workflows can answer synchronous [Queries](/encyclopedia/workflow-message-passing#queries) and receive [Signals](/encyclopedia/workflow-message-passing#signals).
+Workflows can answer synchronous [Queries](/encyclopedia/workflow-message-passing#sending-queries) and receive [Signals](/encyclopedia/workflow-message-passing#sending-signals).
 
 All interface methods must have one of the following annotations:
 
@@ -345,7 +345,7 @@ Queries are sent from a Temporal Client.
 
 ## How to develop with Updates {#updates}
 
-An [Update](/encyclopedia/workflow-message-passing#updates) is an operation that can mutate the state of a Workflow Execution and return a response.
+An [Update](/encyclopedia/workflow-message-passing#sending-updates) is an operation that can mutate the state of a Workflow Execution and return a response.
 
 ### How to define an Update {#define-update}
 

--- a/docs/develop/python/message-passing.mdx
+++ b/docs/develop/python/message-passing.mdx
@@ -38,7 +38,7 @@ This page shows how to do the following:
 
 **How to develop with Signals using the Python SDK.**
 
-A [Signal](/encyclopedia/workflow-message-passing#signals) is a message sent asynchronously to a running Workflow Execution which can be used to change the state and control the flow of a Workflow Execution.
+A [Signal](/encyclopedia/workflow-message-passing#sending-signals) is a message sent asynchronously to a running Workflow Execution which can be used to change the state and control the flow of a Workflow Execution.
 It can only deliver data to a Workflow Execution that has not already closed.
 
 Signals are defined in your code and handled in your Workflow Definition.
@@ -223,7 +223,7 @@ async def main():
 
 ## Queries {#queries}
 
-A [Query](/encyclopedia/workflow-message-passing#queries) is a synchronous operation that is used to get the state of a Workflow Execution.
+A [Query](/encyclopedia/workflow-message-passing#sending-queries) is a synchronous operation that is used to get the state of a Workflow Execution.
 
 ### How to define a Query {#define-query}
 
@@ -303,7 +303,7 @@ To send a Query to a Workflow Execution from Client code, use the `query()` meth
 
 ## Develop with Updates {#updates}
 
-An [Update](/encyclopedia/workflow-message-passing#updates) is an operation that can mutate the state of a Workflow Execution and return a response.
+An [Update](/encyclopedia/workflow-message-passing#sending-updates) is an operation that can mutate the state of a Workflow Execution and return a response.
 
 ### How to define an Update {#define-update}
 

--- a/docs/develop/typescript/message-passing.mdx
+++ b/docs/develop/typescript/message-passing.mdx
@@ -37,7 +37,7 @@ Interact with running Workflows by messaging them using Signals and Queries.
 
 **What is a Signal?**
 
-A [Signal](/encyclopedia/workflow-message-passing#signals) is a message sent asynchronously to a running Workflow Execution which can be used to change the state and control the flow of a Workflow Execution.
+A [Signal](/encyclopedia/workflow-message-passing#sending-signals) is a message sent asynchronously to a running Workflow Execution which can be used to change the state and control the flow of a Workflow Execution.
 It can only deliver data to a Workflow Execution that has not already closed.
 
 You define Signals in your code.
@@ -200,7 +200,7 @@ await client.workflow.signalWithStart(yourWorkflow, {
 
 **How to develop with Queries**
 
-A [Query](/encyclopedia/workflow-message-passing#queries) is a synchronous operation that is used to get the state of a Workflow Execution.
+A [Query](/encyclopedia/workflow-message-passing#sending-queries) is a synchronous operation that is used to get the state of a Workflow Execution.
 
 - [Define a Query](#define-query)
 - [Handle a Query](#handle-query)

--- a/docs/encyclopedia/application-message-passing.mdx
+++ b/docs/encyclopedia/application-message-passing.mdx
@@ -82,7 +82,7 @@ Use an Update for synchronous read/write requests. If your request must be async
 
 This section will help you write clients that send messages to Workflows.
 
-### Sending Signals
+### Sending Signals {#sending-signals}
 
 You can send Signals from any Temporal Client, the Temporal CLI, or you can Signal one Workflow to another.
 
@@ -168,12 +168,14 @@ The start call will give you a handle you can use to track the Update, determine
 If you want to send an Update to another Workflow such as a Child Workflow from within a Workflow, you should do so within an Activity and use the Temporal Client as normal.
 
 <RelatedReadContainer>
-    <RelatedReadItem path="/develop/go/message-passing#send-update" text="Send Updates in Go" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/java/message-passing#send-update" text="Send Updates in Java" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/php/message-passing#send-update" text="Send Updates in PHP" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/python/message-passing#send-update" text="Send Updates in Python" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/typescript/message-passing#send-update" text="Send Updates in Typescript" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/dotnet/message-passing#send-update" text="Send Updates in .NET" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/go/message-passing#send-update-from-client" text="Send Updates in Go" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/java/message-passing#send-update-from-client" text="Send Updates in Java" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/php/message-passing#send-update-from-client" text="Send Updates in PHP" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/python/message-passing#send-update-from-client" text="Send Updates in Python" archetype="feature-guide" />
+    <!-- DOES NOT EXIST YET
+        <RelatedReadItem path="/develop/typescript/message-passing#send-update-from-client" text="Send Updates in Typescript" archetype="feature-guide" />
+    -->
+    <RelatedReadItem path="/develop/dotnet/message-passing#send-update-from-client" text="Send Updates in .NET" archetype="feature-guide" />
 </RelatedReadContainer>
 
 ### Sending Queries {#sending-queries}
@@ -269,6 +271,8 @@ Clients can provide an idempotency key. This can be important because Temporal's
 
 Inside your message handler, you can check your idempotency key--the Update ID or the one you provided to the Signal--to check whether the Workflow has already handled the update.
 
+<!-- DOES NOT EXIST YET
+
 See the links below for examples of solving this in your SDK.
 
 #### Authoring message handler patterns
@@ -283,6 +287,7 @@ See examples of the above patterns.
     <RelatedReadItem path="/develop/typescript/message-passing#handler-patterns" text="Author message handler patterns in Typescript" archetype="feature-guide" />
     <RelatedReadItem path="/develop/dotnet/message-passing#handler-patterns" text="Author message handler patterns in .NET" archetype="feature-guide" />
 </RelatedReadContainer>
+-->
 
 ### Update Validators {#update-validators}
 
@@ -299,6 +304,7 @@ Like Queries, Validators are not allowed to block.
 
 Once the Update handler is finished and has returned a value, the operation is considered Completed.
 
+<!-- DOES NOT EXIST YET
 <RelatedReadContainer>
     <RelatedReadItem path="/develop/go/message-passing#validate-update" text="Validate updates in Go" archetype="feature-guide" />
     <RelatedReadItem path="/develop/java/message-passing#validate-update" text="Validate updates in Java" archetype="feature-guide" />
@@ -307,6 +313,7 @@ Once the Update handler is finished and has returned a value, the operation is c
     <RelatedReadItem path="/develop/typescript/message-passing#validate-update" text="Validate updates in Typescript" archetype="feature-guide" />
     <RelatedReadItem path="/develop/dotnet/message-passing#validate-update" text="Validate updates in .NET" archetype="feature-guide" />
 </RelatedReadContainer>
+-->
 
 ### Exceptions in message handlers
 
@@ -344,9 +351,12 @@ Use these links to see a simple Signal handler.
     <RelatedReadItem path="/develop/php/message-passing#handle-signal" text="Handle Signals in PHP" archetype="feature-guide" />
     <RelatedReadItem path="/develop/python/message-passing#handle-signal" text="Handle Signals in Python" archetype="feature-guide" />
     <RelatedReadItem path="/develop/typescript/message-passing#handle-signal" text="Handle Signals in Typescript" archetype="feature-guide" />
+    <!-- DOES NOT EXIST YET
     <RelatedReadItem path="/develop/dotnet/message-passing#handle-signal" text="Handle Signals in .NET" archetype="feature-guide" />
+    -->
 </RelatedReadContainer>
 
+<!-- DOES NOT EXIST YET
 ### Writing Update Handlers {#writing-update-handlers}
 
 Use these links to see a simple update handler.
@@ -359,16 +369,19 @@ Use these links to see a simple update handler.
     <RelatedReadItem path="/develop/typescript/message-passing#handle-update" text="Handle Updates in Typescript" archetype="feature-guide" />
     <RelatedReadItem path="/develop/dotnet/message-passing#handle-update" text="Handle Updates in .NET" archetype="feature-guide" />
 </RelatedReadContainer>
+-->
 
 ### Writing Query Handlers {#writing-query-handlers}
 
 Author queries using these per-language guides.
 
 <RelatedReadContainer>
-    <RelatedReadItem path="/develop/go/message-passing#handle-queries" text="Handle Queries in Go" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/java/message-passing#handle-queries" text="Handle Queries in Java" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/php/message-passing#handle-queries" text="Handle Queries in PHP" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/python/message-passing#handle-queries" text="Handle Queries in Python" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/typescript/message-passing#handle-queries" text="Handle Queries in Typescript" archetype="feature-guide" />
-    <RelatedReadItem path="/develop/dotnet/message-passing#handle-queries" text="Handle Queries in .NET" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/go/message-passing#handle-query" text="Handle Queries in Go" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/java/message-passing#handle-query" text="Handle Queries in Java" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/php/message-passing#handle-query" text="Handle Queries in PHP" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/python/message-passing#handle-query" text="Handle Queries in Python" archetype="feature-guide" />
+    <RelatedReadItem path="/develop/typescript/message-passing#handle-query" text="Handle Queries in Typescript" archetype="feature-guide" />
+    <!-- DOES NOT EXIST YET
+    <RelatedReadItem path="/develop/dotnet/message-passing#handle-query" text="Handle Queries in .NET" archetype="feature-guide" />
+    -->
 </RelatedReadContainer>

--- a/docs/encyclopedia/child-workflows.mdx
+++ b/docs/encyclopedia/child-workflows.mdx
@@ -94,7 +94,7 @@ However, there are several valid reasons for using Child Workflows.
 
 Because a Child Workflow Execution can be processed by a completely separate set of [Workers](/workers#worker) than the Parent Workflow Execution, it can act as an entirely separate service.
 However, this also means that a Parent Workflow Execution and a Child Workflow Execution do not share any local state.
-As all Workflow Executions, they can communicate only via asynchronous [Signals](/encyclopedia/workflow-message-passing#signals).
+As all Workflow Executions, they can communicate only via asynchronous [Signals](/encyclopedia/workflow-message-passing#sending-signals).
 
 ### Paritition problems into smaller chunks
 

--- a/docs/encyclopedia/workflows.mdx
+++ b/docs/encyclopedia/workflows.mdx
@@ -298,7 +298,7 @@ It is the main unit of execution of a [Temporal Application](/temporal#temporal-
 - [How to start a Workflow Execution using the .NET SDK](/develop/dotnet/temporal-client#start-workflow)
 
 Each Temporal Workflow Execution has exclusive access to its local state.
-It executes concurrently to all other Workflow Executions, and communicates with other Workflow Executions through [Signals](/encyclopedia/workflow-message-passing#signals) and the environment through [Activities](/activities).
+It executes concurrently to all other Workflow Executions, and communicates with other Workflow Executions through [Signals](/encyclopedia/workflow-message-passing#sending-signals) and the environment through [Activities](/activities).
 While a single Workflow Execution has limits on size and throughput, a Temporal Application can consist of millions to billions of Workflow Executions.
 
 **Durability**
@@ -356,7 +356,7 @@ Awaitables are provided when using APIs for the following:
 
 - Awaiting: Progress can block using explicit "Await" APIs.
 - Requesting cancellation of another Workflow Execution: Progress can block on confirmation that the other Workflow Execution is cancelled.
-- Sending a [Signal](/encyclopedia/workflow-message-passing#signals): Progress can block on confirmation that the Signal sent.
+- Sending a [Signal](/encyclopedia/workflow-message-passing#sending-signals): Progress can block on confirmation that the Signal sent.
 - Spawning a [Child Workflow Execution](/encyclopedia/child-workflows): Progress can block on confirmation that the Child Workflow Execution started, and on the result of the Child Workflow Execution.
 - Spawning an [Activity Execution](/activities#activity-execution): Progress can block on the result of the Activity Execution.
 - Starting a Timer: Progress can block until the Timer fires.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -328,7 +328,7 @@ Learn more about the Public Preview release stage
 
 _Tags: [product-release-stages](/tags/product-release-stages), [term](/tags/term)_
 
-#### [Query](/encyclopedia/workflow-message-passing#queries)
+#### [Query](/encyclopedia/workflow-message-passing#sending-queries)
 
 A Query is a synchronous operation that is used to report the state of a Workflow Execution.
 
@@ -394,7 +394,7 @@ A Side Effect is a way to execute a short, non-deterministic code snippet, such 
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
-#### [Signal](/encyclopedia/workflow-message-passing#signals)
+#### [Signal](/encyclopedia/workflow-message-passing#sending-signals)
 
 A Signal is an asynchronous request to a Workflow Execution.
 
@@ -555,7 +555,7 @@ Temporal SDKs offer Timer APIs so that Workflow Executions are deterministic in 
 
 _Tags: [term](/tags/term), [explanation](/tags/explanation)_
 
-#### [Update](/encyclopedia/workflow-message-passing#updates)
+#### [Update](/encyclopedia/workflow-message-passing#sending-updates)
 
 An Update is a request to and a response from Workflow Execution.
 

--- a/docs/production-deployment/cloud/account-setup/namespaces.mdx
+++ b/docs/production-deployment/cloud/account-setup/namespaces.mdx
@@ -292,7 +292,7 @@ Sample naming convention:
 
 #### Example 3: Namespace per use case, domain, and environment
 
-We recommend using one namespace per use case, domain, and environment combination when multiple services that are part of the same use case need to communicate with each another via [Signals](/encyclopedia/workflow-message-passing#signals) or by starting [Child Workflows](/encyclopedia/child-workflows).
+We recommend using one namespace per use case, domain, and environment combination when multiple services that are part of the same use case need to communicate with each another via [Signals](/encyclopedia/workflow-message-passing#sending-signals) or by starting [Child Workflows](/encyclopedia/child-workflows).
 In this case, though, you must be mindful about Workflow Id uniqueness by prefixing each Workflow Id with a service-specific string.
 The name of each Task Queue must also be unique.
 If multiple teams are involved, the domain could also represent a team boundary.

--- a/docs/production-deployment/cloud/introduction/pricing.mdx
+++ b/docs/production-deployment/cloud/introduction/pricing.mdx
@@ -88,13 +88,13 @@ The following operations result in Actions:
 - **Search Attribute upsert requested.**
   Occurs after a Workflow starts and invokes `UpsertSearchAttributes`.
 - **Signal sent.**
-  Includes sending a [Signal](/encyclopedia/workflow-message-passing#signals) from a client or from within a Workflow to another Workflow.
-- **Query received.** [Queries](/encyclopedia/workflow-message-passing#queries) aren't recorded in Event History.
+  Includes sending a [Signal](/encyclopedia/workflow-message-passing#sending-signals) from a client or from within a Workflow to another Workflow.
+- **Query received.** [Queries](/encyclopedia/workflow-message-passing#sending-queries) aren't recorded in Event History.
   An operation such as viewing the call stack in the Temporal Cloud UI results in a Query.
 - **Side Effect recorded.**
   For a mutable [Side Effect](/workflows#side-effect), an Action occurs only when the value changes.
   (Be aware that some SDKs don't support Side Effects.)
-- **NEW: Workflow Update.** [[Workflow Updates](/encyclopedia/workflow-message-passing#updates)] is a primitive that combines a Signal and Query together for a single Action.
+- **NEW: Workflow Update.** [[Workflow Updates](/encyclopedia/workflow-message-passing#sending-updates)] is a primitive that combines a Signal and Query together for a single Action.
 
 **Child Workflows**
 

--- a/docs/production-deployment/data-encryption.mdx
+++ b/docs/production-deployment/data-encryption.mdx
@@ -25,10 +25,10 @@ Encrypting this data ensures that any sensitive application data is secure when 
 For example, if you have sensitive information passed in the following objects that are persisted in the Workflow Execution Event History, use encryption to secure it:
 
 - Inputs and outputs/results in your [Workflow](/workflows#workflow-execution), [Activity](/activities#activity-execution), and [Child Workflow](/encyclopedia/child-workflows)
-- [Signal](/encyclopedia/workflow-message-passing#signals) inputs
+- [Signal](/encyclopedia/workflow-message-passing#sending-signals) inputs
 - [Memo](/workflows#memo)
 - Headers (verify if applicable to your SDK)
-- [Query](/encyclopedia/workflow-message-passing#queries) inputs and results
+- [Query](/encyclopedia/workflow-message-passing#sending-queries) inputs and results
 - Results of [Local Activities](/activities#local-activity) and [Side Effects](/workflows#side-effect)
 - [Application errors and failures](/references/failures).
   Failure messages and call stacks are not encoded as codec-capable Payloads by default; you must explicitly enable encoding these common attributes on failures.

--- a/docs/production-deployment/migration.mdx
+++ b/docs/production-deployment/migration.mdx
@@ -64,7 +64,7 @@ To accomplish this migration, cancel your current Workflow and pass the current 
 Refer to [this repository](https://github.com/temporalio/migration-example/blob/main/src/main/java/io/temporal/migration/example/README.md) for an example of migrating running Workflows in Java.
 
 When performing a live migration, make sure your Worker capacity can support the migration load.
-Both a [Signal](/encyclopedia/workflow-message-passing#signals) and a [Query](/encyclopedia/workflow-message-passing#queries) will be executed during the course of the migration.
+Both a [Signal](/encyclopedia/workflow-message-passing#sending-signals) and a [Query](/encyclopedia/workflow-message-passing#sending-queries) will be executed during the course of the migration.
 Also, the Query API loads the entire history of Workflows into Workers to compute the result (if they are not already cached).
 That means that your self-hosted Temporal Service Worker capacity will need to support having those executions in memory to serve those requests.
 The volume of these requests might be high to execute against all the matches to a `ListFilter`.

--- a/docs/references/commands.mdx
+++ b/docs/references/commands.mdx
@@ -57,7 +57,7 @@ By default, you cannot have more than 2,000 pending Child Workflows.
 
 ### SignalExternalWorkflowExecution
 
-This Command is triggered by a call to [Signal](/encyclopedia/workflow-message-passing#signals) another Workflow Execution.
+This Command is triggered by a call to [Signal](/encyclopedia/workflow-message-passing#sending-signals) another Workflow Execution.
 
 - Awaitable: Yes, a Workflow Execution can await on the action resulting from this Command.
 - Corresponding Event: [SignalExternalWorkflowExecutionInitiated](/references/events#signalexternalworkflowexecutioninitiated)

--- a/docs/references/errors.mdx
+++ b/docs/references/errors.mdx
@@ -110,7 +110,7 @@ Adjust the size of the Payload to fit within the system's size limits.
 
 ## Bad Signal Input Size {#bad-signal-input-size}
 
-This error indicates that the Payload has exceeded the [Signal's](/encyclopedia/workflow-message-passing#signals) available input size.
+This error indicates that the Payload has exceeded the [Signal's](/encyclopedia/workflow-message-passing#sending-signals) available input size.
 
 Adjust the size of the Payload, and redeploy the [Workflow Task](/workers#workflow-task).
 
@@ -218,7 +218,7 @@ If you see this error, give the system time to process pending requests before r
 ## Pending Signals Limit Exceeded {#pending-signals-limit-exceeded}
 
 The Workflow has reached capacity for pending Signals.
-Therefore, the [Workflow Task](/workers#workflow-task) was failed after attempting to add more [Signals](/encyclopedia/workflow-message-passing#signals) to an external Workflow.
+Therefore, the [Workflow Task](/workers#workflow-task) was failed after attempting to add more [Signals](/encyclopedia/workflow-message-passing#sending-signals) to an external Workflow.
 
 Wait for Signals to be processed by the Workflow before retrying the Task.
 
@@ -281,7 +281,7 @@ Try entering a different Timer Id, and retry the [Workflow Task](/workers#workfl
 This error indicates new available [Events](/references/events) since the last [Workflow Task](/workers#workflow-task) started.
 The Workflow Task was failed because the [Workflow](/workflows) attempted to close itself without handling the new Events.
 
-`UnhandledCommand` can happen when the Workflow is receiving a high number of [Signals](/encyclopedia/workflow-message-passing#signals).
+`UnhandledCommand` can happen when the Workflow is receiving a high number of [Signals](/encyclopedia/workflow-message-passing#sending-signals).
 If the Workflow doesn't have enough time to handle these Signals, a RetryWorkflow Task is scheduled to handle these new Events.
 
 To prevent this error, drain the Signal Channel with the ReceiveAsync function.

--- a/docs/references/events.mdx
+++ b/docs/references/events.mdx
@@ -44,7 +44,7 @@ It indicates that the Temporal Service received a request to spawn the Workflow 
 | memo                               | Non-indexed information to show in the Workflow.                                                                                                                     |
 | search_attributes                  | Provides data for setting up a Workflow's [Search Attributes](/visibility#search-attribute).                                                                         |
 | prev_auto_reset_points             |                                                                                                                                                                      |
-| header                             | Information passed by the sender of the [Signal](/encyclopedia/workflow-message-passing#signals) that is copied into the [Workflow Task](/workers#workflow-task). |
+| header                             | Information passed by the sender of the [Signal](/encyclopedia/workflow-message-passing#sending-signals) that is copied into the [Workflow Task](/workers#workflow-task). |
 
 ### WorkflowExecutionCompleted
 
@@ -98,7 +98,7 @@ This [Event](/workflows#event) type indicates that the client has confirmed the 
 
 ### WorkflowExecutionSignaled
 
-This [Event](/workflows#event) type indicates the [Workflow](/workflows) has received a [Signal](/encyclopedia/workflow-message-passing#signals) Event.
+This [Event](/workflows#event) type indicates the [Workflow](/workflows) has received a [Signal](/encyclopedia/workflow-message-passing#sending-signals) Event.
 The Event type contains the Signal name, as well as a Signal payload.
 
 | Field       | Description                                                                                                     |
@@ -227,7 +227,7 @@ This Event type contains Activity inputs, as well as Activity Timeout configurat
 | activity_type                    | The [type of Activity](/activities#activity-type) that was scheduled.                                                                                                |
 | namespace                        | Namespace of the Workflow that the [Activity](/activities) resides in.                                                                                               |
 | task_queue                       | The [Task Queue](/workers#task-queue) that this Activity Task was enqueued in.                                                                                       |
-| header                           | Information passed by the sender of the [Signal](/encyclopedia/workflow-message-passing#signals) that is copied into the [Workflow Task](/workers#workflow-task). |
+| header                           | Information passed by the sender of the [Signal](/encyclopedia/workflow-message-passing#sending-signals) that is copied into the [Workflow Task](/workers#workflow-task). |
 | input                            | Information that is deserialized by the SDK to provide arguments to the [Workflow](/workflows) function.                                                             |
 | schedule_to_close_timeout        | The amount of time that a caller will wait for Activity completion. Limits the amount of time that retries will be attempted for this Activity.                      |
 | schedule_to_start_timeout        | Limits the time that an Activity Task can stay in a Task Queue. This timeout cannot be retried.                                                                      |
@@ -377,7 +377,7 @@ This [Event](/workflows#event) type indicates that the [Temporal Server](/cluste
 
 ### ExternalWorkflowExecutionSignaled
 
-This [Event](/workflows#event) type indicates that the [Temporal Server](/clusters#temporal-server) has successfully [Signaled](/encyclopedia/workflow-message-passing#signals) the targeted [Workflow](/workflows).
+This [Event](/workflows#event) type indicates that the [Temporal Server](/clusters#temporal-server) has successfully [Signaled](/encyclopedia/workflow-message-passing#sending-signals) the targeted [Workflow](/workflows).
 
 | Field              | Description                                                                                                                      |
 | ------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
@@ -396,7 +396,7 @@ The SDK client may use it for local activities or side effects.
 | marker_name                      | Identifies various markers.                                                                                                         |
 | details                          | Serialized information recorded in the marker.                                                                                      |
 | workflow_task_completed_event_id | The Id of the [WorkflowTaskCompleted](#workflowtaskcompleted) that the Event was reported with.                                     |
-| header                           | Information passed by the sender of the [Signal](/encyclopedia/workflow-message-passing#signals) that is copied into the marker. |
+| header                           | Information passed by the sender of the [Signal](/encyclopedia/workflow-message-passing#sending-signals) that is copied into the marker. |
 | failure                          | Serialized result of a [Workflow](/workflows) failure.                                                                              |
 
 ### StartChildWorkflowExecutionInitiated
@@ -433,7 +433,7 @@ This would also cause the [WorkflowExecutionStarted](#workflowexecutionstarted) 
 | initiated_event_id | Id of the [StartChildWorkflowExecutionInitiated](#startchildworkflowexecutioninitiated) Event this Event corresponds to.                         |
 | workflow_execution | Identifies the Workflow and the run of the Workflow Execution.                                                                                   |
 | workflow_type      | The name/type of Workflow that has started execution.                                                                                            |
-| header             | Information passed by the sender of the [Signal](/encyclopedia/workflow-message-passing#signals) that is copied into the Child Workflow Task. |
+| header             | Information passed by the sender of the [Signal](/encyclopedia/workflow-message-passing#sending-signals) that is copied into the Child Workflow Task. |
 
 ### ChildWorkflowExecutionCompleted
 
@@ -508,7 +508,7 @@ This would also cause the [WorkflowExecutionTerminated](#workflowexecutiontermin
 
 ### SignalExternalWorkflowExecutionInitiated
 
-This [Event](/workflows#event) type indicates that the [Temporal Server](/clusters#temporal-server) will try to [Signal](/encyclopedia/workflow-message-passing#signals) the targeted [Workflow](/workflows).
+This [Event](/workflows#event) type indicates that the [Temporal Server](/clusters#temporal-server) will try to [Signal](/encyclopedia/workflow-message-passing#sending-signals) the targeted [Workflow](/workflows).
 This Event type contains the Signal name, as well as a Signal payload.
 
 | Field                            | Description                                                                                     |
@@ -530,7 +530,7 @@ This [Event](/workflows#event) type indicates that the [Temporal Server](/cluste
 | workflow_task_completed_event_id | The Id of the [WorkflowTaskCompleted](#workflowtaskcompleted) that the Event was reported with.                                                                                                              |
 | namespace                        | [Namespace](/namespaces) of the Workflow that failed to execute.                                                                                                                                             |
 | workflow_execution               | Identifies the Workflow and the run of the [Workflow Execution](/workflows#workflow-execution).                                                                                                              |
-| initiated_event_id               | Id of the [RequestCancelExternalWorkflowExecutionInitiated](#requestcancelexternalworkflowexecutioninitiated) Event this failure [signal](/encyclopedia/workflow-message-passing#signals) corresponds to. |
+| initiated_event_id               | Id of the [RequestCancelExternalWorkflowExecutionInitiated](#requestcancelexternalworkflowexecutioninitiated) Event this failure [signal](/encyclopedia/workflow-message-passing#sending-signals) corresponds to. |
 
 ### UpsertWorkflowSearchAttributes
 
@@ -543,7 +543,7 @@ This [Event](/workflows#event) type indicates that the Workflow [Search Attribut
 
 ### WorkflowExecutionUpdateAcceptedEvent
 
-This [Event](/workflows#event) type indicates that a [Workflow Execution](/workflows#workflow-execution) has accepted an [Update](/encyclopedia/workflow-message-passing#updates) for execution.
+This [Event](/workflows#event) type indicates that a [Workflow Execution](/workflows#workflow-execution) has accepted an [Update](/encyclopedia/workflow-message-passing#sending-updates) for execution.
 The original request input payload is both indicated and stored by this Event, as it generates no Event when initially requesting an Update.
 
 | Field                                | Description                                                                                                                                                            |
@@ -555,7 +555,7 @@ The original request input payload is both indicated and stored by this Event, a
 
 ### WorkflowExecutionUpdateCompletedEvent
 
-This [Event](/workflows#event) type indicates that a [Workflow Execution](/workflows#workflow-execution) has executed an [Update](/encyclopedia/workflow-message-passing#updates) to completion.
+This [Event](/workflows#event) type indicates that a [Workflow Execution](/workflows#workflow-execution) has executed an [Update](/encyclopedia/workflow-message-passing#sending-updates) to completion.
 
 | Field             | Description                                                                                                                                  |
 | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/docs/tctl-v1/batch.mdx
+++ b/docs/tctl-v1/batch.mdx
@@ -114,7 +114,7 @@ tctl batch start --query <value> --batch_type <operation>
 
 ### `--signal_name`
 
-Specify the name of a [Signal](/encyclopedia/workflow-message-passing#signals). This modifier is required when `--batch_type` is `signal`.
+Specify the name of a [Signal](/encyclopedia/workflow-message-passing#sending-signals). This modifier is required when `--batch_type` is `signal`.
 
 **Example**
 
@@ -124,7 +124,7 @@ tctl batch start --query <value> --batch_type signal --signal_name <name>
 
 ### `--input`
 
-Pass input for the [Signal](/encyclopedia/workflow-message-passing#signals). Input must be in JSON format.
+Pass input for the [Signal](/encyclopedia/workflow-message-passing#sending-signals). Input must be in JSON format.
 
 Alias: `-i`
 

--- a/docs/tctl-v1/workflow.mdx
+++ b/docs/tctl-v1/workflow.mdx
@@ -859,7 +859,7 @@ tctl workflow observeid --max_field_length <length>
 
 Alias: `q`
 
-The `tctl workflow query` command sends a [Query](/encyclopedia/workflow-message-passing#queries) to a [Workflow Execution](/workflows#workflow-execution).
+The `tctl workflow query` command sends a [Query](/encyclopedia/workflow-message-passing#sending-queries) to a [Workflow Execution](/workflows#workflow-execution).
 
 Queries can be used to retrieve all or part of the Workflow state with given parameters.
 
@@ -1757,7 +1757,7 @@ tctl workflow showid <workflow_id> --reset_points_only
 
 ## signal
 
-The `tctl workflow signal` command [Signals](/encyclopedia/workflow-message-passing#signals) a [Workflow Execution](/workflows#workflow-execution).
+The `tctl workflow signal` command [Signals](/encyclopedia/workflow-message-passing#sending-signals) a [Workflow Execution](/workflows#workflow-execution).
 
 Workflows listen for Signals by their Signal name, and can be made to listen to one or more Signal names.
 Workflows can also listen for SQL queries.
@@ -1870,7 +1870,7 @@ tctl workflow signal --run_id <id>
 
 ### --name
 
-Specify the name of a [Signal](/encyclopedia/workflow-message-passing#signals).
+Specify the name of a [Signal](/encyclopedia/workflow-message-passing#sending-signals).
 
 **Example**
 
@@ -1880,7 +1880,7 @@ tctl workflow signal --query <query> --name <name>
 
 ### --input
 
-Pass input for the [Signal](/encyclopedia/workflow-message-passing#signals).
+Pass input for the [Signal](/encyclopedia/workflow-message-passing#sending-signals).
 Input must be in JSON format.
 
 Alias: `-i`
@@ -1893,7 +1893,7 @@ tctl workflow signal --query <query> --input <json>
 
 ### --input_file
 
-Pass input for the [Signal](/encyclopedia/workflow-message-passing#signals) from a JSON file.
+Pass input for the [Signal](/encyclopedia/workflow-message-passing#sending-signals) from a JSON file.
 
 **Example**
 

--- a/docs/troubleshooting/deadline-exceeded-error.mdx
+++ b/docs/troubleshooting/deadline-exceeded-error.mdx
@@ -55,7 +55,7 @@ Use [`grpc-health-probe`](https://github.com/grpc-ecosystem/grpc-health-probe) t
 ./grpc-health-probe -addr=historyAddress:historyPort -service=temporal.api.workflowservice.v1.HistoryService
 ```
 
-Logs can also be used to find failed Client [Query](/encyclopedia/workflow-message-passing#queries) requests.
+Logs can also be used to find failed Client [Query](/encyclopedia/workflow-message-passing#sending-queries) requests.
 
 ### Check your Temporal Service metrics
 


### PR DESCRIPTION
* Hides anchors for sections that were never written during IA reorganization
* Aligns anchors between SDKs for consistency
* Fixes anchors that were pointing to "obvious" anchor instead of correct anchor
* Fixes incorrect anchors

Reviewers: please make sure to download this branch and check that yarn builds cleanly without anchor errors.

$ cd documentation
$ git fetch --all
$ git checkout --track origin/EDU-2889
branch 'EDU-2889' set up to track 'origin/EDU-2889'.
Switched to a new branch 'EDU-2889'
$ git branch
* EDU-2889
  main
$ git status
On branch EDU-2889
Your branch is up to date with 'origin/EDU-2889'.

nothing to commit, working tree clean
$ yarn build
...
