### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository contains a large chunk of the Temporal information corpus.
 - [Contributing guidance](./CONTRIBUTING.md)
 - [Style guidance](./STYLE.md)
 
-### Current component versioning philosphy
+### Current component versioning philosophy
 
 Temporal includes many different components and core dependencies. Many components are independently versioned, meaning that they document their stability and support for their own dependencies. The [Temporal Go SDK reference](https://pkg.go.dev/go.temporal.io/sdk?tab=versions) provides a good example of document versioning.
 

--- a/docs/develop/python/index.mdx
+++ b/docs/develop/python/index.mdx
@@ -61,7 +61,7 @@ The [Workflow messages feature guide](/develop/python/message-passing) shows how
 
 ## Cancellation
 
-The [Cancellation feature guide](/develop/python/cancellation)shows how to cancel a Workflow Execution.
+The [Cancellation feature guide](/develop/python/cancellation) shows how to cancel a Workflow Execution.
 
 - [Cancel an Activity from a Workflow](/develop/python/cancellation)
 

--- a/docs/references/errors.mdx
+++ b/docs/references/errors.mdx
@@ -204,7 +204,7 @@ Let the Workflow complete any current Activities before redeploying the code.
 ## Pending Child Workflows Limit Exceeded {#pending-child-workflows-limit-exceeded}
 
 This error indicates that the [Workflow](/workflows) has reached capacity for pending [Child Workflows](/encyclopedia/child-workflows).
-Therefore, the [Workflow Task](/workers#workflow-task)was failed to prevent additional Child Workflows from being added.
+Therefore, the [Workflow Task](/workers#workflow-task) was failed to prevent additional Child Workflows from being added.
 
 Wait for the system to finish any currently running Child Workflows before redeploying this Task.
 
@@ -224,7 +224,7 @@ Wait for Signals to be processed by the Workflow before retrying the Task.
 
 ## Reset Sticky Task Queue {#reset-sticky-task-queue}
 
-This error indicates that the Sticky [Task Queue](/workers#task-queue)needs to be reset.
+This error indicates that the Sticky [Task Queue](/workers#task-queue) needs to be reset.
 
 If you see this error, reset the Sticky Task Queue.
 The system will retry automatically.


### PR DESCRIPTION
## What does this PR do?

Just fixed some little typos on the documentation.

Also here is the regex to check if any markdown link has a letter right after them:
`\[.*?\]\([^()]*\)[a-zA-Z]`
matches `[link](url)ups` therefore rendering as '[link](url)ups'