### PR TITLE
Resolves Heartbeat Throttling Coverage Omits Handling of Final Heartbeat

### DIFF
--- a/docs/encyclopedia/detecting-activity-failures.mdx
+++ b/docs/encyclopedia/detecting-activity-failures.mdx
@@ -207,7 +207,7 @@ Throttling is implemented as follows:
   - Sets the timer again.
 
 Throttling allows the Worker to reduce network traffic and load on the Temporal Service by suppressing Heartbeats that aren’t necessary to prevent a Heartbeat Timeout.
-While this may result in some messages not being delivered to the Temporal Service, throttling does not apply to the final Heartbeat message in the case of Activity Failure.
+Throttling does not apply to the final Heartbeat message in the case of Activity Failure.
 If an Activity fails just after recording progress information in a Heartbeat message, that progress information will be available during the next retry attempt, provided that the Worker itself did not crash before delivering it to the Temporal Service.
 
 ### Which Activities should Heartbeat?

--- a/docs/encyclopedia/detecting-activity-failures.mdx
+++ b/docs/encyclopedia/detecting-activity-failures.mdx
@@ -206,6 +206,10 @@ Throttling is implemented as follows:
   - Sends the most recent Heartbeat.
   - Sets the timer again.
 
+Throttling allows the Worker to reduce network traffic and load on the Temporal Service by suppressing Heartbeats that aren’t necessary to prevent a Heartbeat Timeout.
+While this may result in some messages not being delivered to the Temporal Service, throttling does not apply to the final Heartbeat message in the case of Activity Failure.
+If an Activity fails just after recording progress information in a Heartbeat message, that progress information will be available during the next retry attempt, provided that the Worker itself did not crash before delivering it to the Temporal Service.
+
 ### Which Activities should Heartbeat?
 
 Heartbeating is best thought about not in terms of time, but in terms of "How do you know you are making progress?"


### PR DESCRIPTION
## What does this PR do?
See: [EDU-2514](https://temporalio.atlassian.net/browse/EDU-2514)
Adds paragraph to describe how the final heartbeat message is not subject to throttling if the Activity Execution fails. 

## Notes to reviewers

<!-- delete if n/a -->


[EDU-2514]: https://temporalio.atlassian.net/browse/EDU-2514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ