### PR TITLE
EDU-2837: clarify datadog subsection in cloud docs is a tutorial

### DIFF
--- a/docs/production-deployment/cloud/metrics/datadog.mdx
+++ b/docs/production-deployment/cloud/metrics/datadog.mdx
@@ -34,8 +34,7 @@ Temporal's integration with Datadog extends the monitoring capabilities of your 
 
 :::note
 
-This tutorial provides an example application to help users capture metrics from Temporal's PromQL endpoint and export to  DataDog.
-Temporal Cloud's Observability endpoint supports PromQL only. 
+This tutorial provides an example application to help users capture metrics from Temporal's PromQL endpoint and export to DataDog.
 
 :::
 

--- a/docs/production-deployment/cloud/metrics/datadog.mdx
+++ b/docs/production-deployment/cloud/metrics/datadog.mdx
@@ -32,6 +32,13 @@ tags:
 Exporting cloud metrics to Datadog provides enhanced observability, allowing you to monitor, alert, and visualize key performance indicators of your applications and infrastructure.
 Temporal's integration with Datadog extends the monitoring capabilities of your Temporal Cloud deployment.
 
+:::note
+
+This tutorial provides an example application to help users capture metrics from Temporal's PromQL endpoint and export to  DataDog.
+Temporal Cloud's Observability endpoint supports PromQL only. 
+
+:::
+
 ### What will you learn?
 
 You will set up your environment to export metrics from Temporal Cloud to Datadog, including:


### PR DESCRIPTION
Longer term we should probably consider moving this to the Learn site with the other tutorials and replacing this with more reference-style content in docs.