### PR TITLE
EDU-3121: Updates API key info for accurate release stage

### DIFF
--- a/docs/production-deployment/cloud/api-keys.mdx
+++ b/docs/production-deployment/cloud/api-keys.mdx
@@ -21,7 +21,7 @@ tags:
 
 :::tip SUPPORT, STABILITY, AND DEPENDENCY INFO
 
-- API key authentication for Temporal Cloud, `tcld`, Namespace authentication, SDK-based API calls, and Terraform provider is currently in [Public Preview](/evaluate/development-production-features/release-stages#public-preview)
+API key authentication for Temporal Cloud, `tcld`, Namespace authentication, SDK-based API calls, and Terraform provider is currently in [Public Preview](/evaluate/development-production-features/release-stages#public-preview).
 
 :::
 

--- a/docs/production-deployment/cloud/api-keys.mdx
+++ b/docs/production-deployment/cloud/api-keys.mdx
@@ -21,8 +21,7 @@ tags:
 
 :::tip SUPPORT, STABILITY, AND DEPENDENCY INFO
 
-- API key authentication for Temporal Cloud, `tcld`, and Terraform provider, is currently in [Public Preview](/evaluate/development-production-features/release-stages#public-preview)
-- API key authentication for Namespace authentication and SDK-based API calls is in [Pre-release](/evaluate/development-production-features/release-stages#pre-release)
+- API key authentication for Temporal Cloud, `tcld`, Namespace authentication, SDK-based API calls, and Terraform provider is currently in [Public Preview](/evaluate/development-production-features/release-stages#public-preview)
 
 :::
 


### PR DESCRIPTION
Several features are in public preview today. Since this is a soft launch, it is set for pending publish with tomorrow (4 Sept) going live. Check in with @shakeelrao for any delays that might prevent going live.

Source of truth @shakeelrao 