### PR TITLE
Adds API Keys instructions for TS SDK

### DIFF
--- a/docs/develop/typescript/interceptors.mdx
+++ b/docs/develop/typescript/interceptors.mdx
@@ -118,7 +118,7 @@ Workflow interceptor registration is different from the other interceptors becau
 To register Workflow interceptors, export an `interceptors` function from a file located in the `workflows` directory and provide the name of that file to the Worker on creation via [WorkerOptions](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#interceptors).
 
 At the time of construction, the Workflow context is already initialized for the current Workflow.
-You may use call the [`workflowInfo()`](https://typescript.temporal.io/api/namespaces/workflow#workflowinfo) function to access Workflow-specific information from an interceptor.
+You may call the [`workflowInfo()`](https://typescript.temporal.io/api/namespaces/workflow#workflowinfo) function to access Workflow-specific information from an interceptor.
 
 `src/workflows/your-interceptors.ts`
 

--- a/docs/develop/typescript/interceptors.mdx
+++ b/docs/develop/typescript/interceptors.mdx
@@ -118,7 +118,7 @@ Workflow interceptor registration is different from the other interceptors becau
 To register Workflow interceptors, export an `interceptors` function from a file located in the `workflows` directory and provide the name of that file to the Worker on creation via [WorkerOptions](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#interceptors).
 
 At the time of construction, the Workflow context is already initialized for the current Workflow.
-You may use call the [`workflowInfo()`](https://typescript.temporal.io/api/interceptors/workflow#workflowinfo) function to access Workflow-specific information from an interceptor.
+You may use call the [`workflowInfo()`](https://typescript.temporal.io/api/namespaces/workflow#workflowinfo) function to access Workflow-specific information from an interceptor.
 
 `src/workflows/your-interceptors.ts`
 

--- a/docs/develop/typescript/testing-suite.mdx
+++ b/docs/develop/typescript/testing-suite.mdx
@@ -201,7 +201,7 @@ afterAll(async () => {
 });
 ```
 
-`TestWorkflowEnvironment` has [`client`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment/#client) and [`nativeConnection`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#nativeconnection) for creating Workers:
+`TestWorkflowEnvironment` has [`client`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#client) and [`nativeConnection`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#nativeconnection) for creating Workers:
 
 ```typescript
 import { Worker } from '@temporalio/worker';
@@ -334,7 +334,7 @@ test('sleeperWorkflow counts days correctly', async () => {
 
 Learn to skip time in Activities in the SDK of your choice.
 
-Call [`TestWorkflowEnvironment.sleep`](https://typescript.temporal.io/api/classes/testing.testworkflowenvironment/#sleep) from the mock Activity.
+Call [`TestWorkflowEnvironment.sleep`](https://typescript.temporal.io/api/classes/testing.TestWorkflowEnvironment#sleep) from the mock Activity.
 
 In the following test, `processOrderWorkflow` sends a notification to the user after one day.
 The `processOrder` mocked Activity calls `testEnv.sleep(‘2 days')`, during which the Workflow sends email (by calling the `sendNotificationEmail` Activity).

--- a/docs/production-deployment/cloud/api-keys.mdx
+++ b/docs/production-deployment/cloud/api-keys.mdx
@@ -614,7 +614,7 @@ const worker = await Worker.create({
 Update the API key on an existing `Connection` or `NativeConnection`:
 
 ```typescript
-connection.setApiKey(<APIKey>)
+connection.setApiKey(<APIKey>);
 ```
 
 #### TypeScript SDK (pre v 1.10.0)
@@ -626,7 +626,7 @@ const connection = await Connection.connect(
     address: <endpoint>,
     tls: true,
     metadata: {
-        'Authorization': `Bearer ${<APIKey>}`
+        'Authorization': `Bearer ${<APIKey>}`,
         'temporal-namespace': <namespace.accountid>,
     },
 )

--- a/docs/production-deployment/cloud/api-keys.mdx
+++ b/docs/production-deployment/cloud/api-keys.mdx
@@ -574,6 +574,86 @@ myClient.Connection.RpcMetadata = new Dictionary<string, string>()
 };
 ```
 
+#### TypeScript SDK (v 1.10.0+)
+
+Create an initial `Connection` (for use with `Client`):
+
+```typescript
+const connection = await Connection.connect(
+    address: <endpoint>,
+    tls: true,
+    apiKey: <APIKey>,
+    metadata: {
+        'temporal-namespace': <namespace.accountid>,
+    },
+)
+const client = new Client({
+    connection,
+    namespace: <namespace.accountid>,
+});
+```
+
+Create an initial Worker `NativeConnection` (for use with `Worker`):
+
+```typescript
+const connection = await NativeConnection.connect(
+    address: <endpoint>,
+    tls: true,
+    apiKey: <APIKey>,
+    metadata: {
+      'temporal-namespace': <namespace.accountid>,
+    },
+)
+const worker = await Worker.create({
+    connection,
+    namespace: <namespace.accountid>,
+    // ...
+});
+```
+
+Update the API key on an existing `Connection` or `NativeConnection`:
+
+```typescript
+connection.setApiKey(<APIKey>)
+```
+
+#### TypeScript SDK (pre v 1.10.0)
+
+Create an initial `Connection` (for use with `Client`):
+
+```typescript
+const connection = await Connection.connect(
+    address: <endpoint>,
+    tls: true,
+    metadata: {
+        'Authorization': `Bearer ${<APIKey>}`
+        'temporal-namespace': <namespace.accountid>,
+    },
+)
+const client = new Client({
+    connection,
+    namespace: <namespace.accountid>,
+});
+```
+
+Create an initial Worker `NativeConnection` (for use with `Worker`):
+
+```typescript
+const connection = await NativeConnection.connect(
+    address: <endpoint>,
+    tls: true,
+    metadata: {
+        'Authorization': `Bearer ${<APIKey>}`
+        'temporal-namespace': <namespace.accountid>,
+    },
+)
+const worker = await Worker.create({
+    connection,
+    namespace: <namespace.accountid>,
+    // ...
+});
+```
+
 ### `tcld`
 
 To use an API key with `tcld`, choose one of these methods:
@@ -585,7 +665,6 @@ To use an API key with `tcld`, choose one of these methods:
 
 To use an API key with the [Cloud Ops API](/ops), securely pass the API key in your API client.
 For a complete example, see [Cloud Samples in Go](https://github.com/temporalio/cloud-samples-go/blob/1dd4254b6ed1937e361005c0144410e72b8a5542/client/api/apikey.go).
-
 
 ### Terraform Provider
 


### PR DESCRIPTION
## What does this PR do?

- Adds instructions for connecting to Temporal Cloud with API keys using the TypeScript SDK.
- Also fixed two broken links to TS generated API docs
