### PR TITLE
Use non-deprecated form of `env set`

### DIFF
--- a/docs/cli/env.mdx
+++ b/docs/cli/env.mdx
@@ -79,10 +79,10 @@ Use the following options to change the command's behavior.
 The `temporal env set` command sets the value for an environmental property.
 Property names match CLI option names.
 
-`temporal env set prod.tls-cert-path /home/my-user/certs/cluster.cert`
+`temporal env set --env prod -k tls-cert-path -v /home/my-user/certs/cluster.cert`
 
 Properties can be set for the entire system, such as the frontend address:
-`temporal env set local.address 127.0.0.1:7233`
+`temporal env set --env local -k address -v 127.0.0.1:7233`
 
 Use the following options to change the command's behavior.
 

--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -418,10 +418,10 @@ To communicate with a different Server, like a production Namespace on Temporal 
 To create a new environment and set its properties:
 
 ```shell
-temporal env set prod.namespace production.f45a2
-temporal env set prod.address production.f45a2.tmprl.cloud:7233
-temporal env set prod.tls-cert-path /temporal/certs/prod.pem
-temporal env set prod.tls-key-path /temporal/certs/prod.key
+temporal env set --env prod -k namespace -v production.f45a2
+temporal env set --env prod -k address -v production.f45a2.tmprl.cloud:7233
+temporal env set --env prod -k tls-cert-path -v /temporal/certs/prod.pem
+temporal env set --env prod -k tls-key-path -v /temporal/certs/prod.key
 ```
 
 Check your settings:


### PR DESCRIPTION
Update docs to use non-deprecated form of `temporal env` command.

Users get a warning if they don't do this:

```
cli(main) temporal env set sdk-ci.namespace sdk-ci.a2dd6
temporal env set sdk-ci.address sdk-ci.a2dd6.tmprl.cloud:7233
temporal env set sdk-ci.tls-cert-path /tmp/client.crt
temporal env set sdk-ci.tls-key-path /tmp/client.key
time=2024-09-10T11:44:47.514 level=WARN msg="Arguments to env commands are deprecated; please use --env and --key (or -k) instead"
time=2024-09-10T11:44:47.514 level=INFO msg="Setting env property" env=sdk-ci property=namespace value=sdk-ci.a2dd6
time=2024-09-10T11:44:47.514 level=INFO msg="Writing env file" file=/Users/dan/.config/temporalio/temporal.yaml
time=2024-09-10T11:44:47.546 level=WARN msg="Arguments to env commands are deprecated; please use --env and --key (or -k) instead"
time=2024-09-10T11:44:47.546 level=INFO msg="Setting env property" env=sdk-ci property=address value=sdk-ci.a2dd6.tmprl.cloud:7233
time=2024-09-10T11:44:47.546 level=INFO msg="Writing env file" file=/Users/dan/.config/temporalio/temporal.yaml
time=2024-09-10T11:44:47.569 level=WARN msg="Arguments to env commands are deprecated; please use --env and --key (or -k) instead"
time=2024-09-10T11:44:47.569 level=INFO msg="Setting env property" env=sdk-ci property=tls-cert-path value=/tmp/client.crt
time=2024-09-10T11:44:47.569 level=INFO msg="Writing env file" file=/Users/dan/.config/temporalio/temporal.yaml
time=2024-09-10T11:44:47.593 level=WARN msg="Arguments to env commands are deprecated; please use --env and --key (or -k) instead"
time=2024-09-10T11:44:47.593 level=INFO msg="Setting env property" env=sdk-ci property=tls-key-path value=/tmp/client.key
time=2024-09-10T11:44:47.593 level=INFO msg="Writing env file" file=/Users/dan/.config/temporalio/temporal.yaml
```