### PR TITLE
Make python and typescript TOC levels consistent

### DIFF
--- a/docs/develop/dotnet/message-passing.mdx
+++ b/docs/develop/dotnet/message-passing.mdx
@@ -3,7 +3,7 @@ id: message-passing
 title: Messages - Temporal .NET SDK feature guide
 sidebar_label: Messages
 description: Develop with Queries, Signals, and Updates with the Temporal .NET SDK.
-toc_max_heading_level: 4
+toc_max_heading_level: 3
 keywords:
   - temporal dotnet signals
   - send signal from client

--- a/docs/develop/go/message-passing.mdx
+++ b/docs/develop/go/message-passing.mdx
@@ -3,7 +3,7 @@ id: message-passing
 title: Messages  - Go SDK feature guide
 sidebar_label: Messages
 description: Develop with Queries, Signals, and Updates with the Temporal Go SDK.
-toc_max_heading_level: 4
+toc_max_heading_level: 3
 keywords:
   - temporal go signals
   - send signal from client

--- a/docs/develop/java/message-passing.mdx
+++ b/docs/develop/java/message-passing.mdx
@@ -3,7 +3,7 @@ id: message-passing
 title: Messages - Temporal Java SDK feature guide
 sidebar_label: Messages
 description: Develop with Queries, Signals, and Updates with the Temporal Java SDK.
-toc_max_heading_level: 4
+toc_max_heading_level: 3
 keywords:
   - temporal java signals
   - send signal from client

--- a/docs/develop/python/message-passing.mdx
+++ b/docs/develop/python/message-passing.mdx
@@ -3,7 +3,7 @@ id: message-passing
 title: Messages - Python SDK feature guide
 sidebar_label: Messages
 description: Develop with Queries, Signals, and Updates with the Temporal Python SDK.
-toc_max_heading_level: 2
+toc_max_heading_level: 4
 keywords:
   - temporal python signals
   - send signal from client

--- a/docs/develop/python/message-passing.mdx
+++ b/docs/develop/python/message-passing.mdx
@@ -3,7 +3,7 @@ id: message-passing
 title: Messages - Python SDK feature guide
 sidebar_label: Messages
 description: Develop with Queries, Signals, and Updates with the Temporal Python SDK.
-toc_max_heading_level: 4
+toc_max_heading_level: 3
 keywords:
   - temporal python signals
   - send signal from client

--- a/docs/develop/typescript/message-passing.mdx
+++ b/docs/develop/typescript/message-passing.mdx
@@ -3,7 +3,7 @@ id: message-passing
 title: Messages - Typescript SDK feature guide
 sidebar_label: Messages
 description: Develop with Queries, Signals, and Updates with the Temporal Typescript SDK.
-toc_max_heading_level: 2
+toc_max_heading_level: 4
 keywords:
   - temporal typescript signals
   - send signal from client

--- a/docs/develop/typescript/message-passing.mdx
+++ b/docs/develop/typescript/message-passing.mdx
@@ -3,7 +3,7 @@ id: message-passing
 title: Messages - Typescript SDK feature guide
 sidebar_label: Messages
 description: Develop with Queries, Signals, and Updates with the Temporal Typescript SDK.
-toc_max_heading_level: 4
+toc_max_heading_level: 3
 keywords:
   - temporal typescript signals
   - send signal from client


### PR DESCRIPTION
This PR makes all message-passing TOC levels consistent (we can consider moving them all to 3 in a subsequent PR). Leaving PHP since we have not updated that recently.

```
documentation(toc-levels) rg toc_max_heading_level docs/develop/*/message-passing.mdx
docs/develop/dotnet/message-passing.mdx
6:toc_max_heading_level: 4

docs/develop/java/message-passing.mdx
6:toc_max_heading_level: 4

docs/develop/go/message-passing.mdx
6:toc_max_heading_level: 4

docs/develop/php/message-passing.mdx
5:toc_max_heading_level: 2

docs/develop/typescript/message-passing.mdx
6:toc_max_heading_level: 4

docs/develop/python/message-passing.mdx
6:toc_max_heading_level: 4
```