### PR TITLE
Workflow-init support docs (Typescript)

### DIFF
--- a/docs/develop/typescript/message-passing.mdx
+++ b/docs/develop/typescript/message-passing.mdx
@@ -195,6 +195,7 @@ wf.setHandler(
   This includes the Update ID, which can be useful for deduplication when using Continue-As-New: see [Ensuring your messages are processed exactly once](/encyclopedia/workflow-message-passing#exactly-once-message-processing).
 - Update (and Signal) handlers can be `async`, letting them use Activities, Child Workflows, durable [`workflow.sleep`](https://typescript.temporal.io/api/namespaces/workflow#sleep) Timers, [`workflow.condition`](https://typescript.temporal.io/api/namespaces/workflow#condition) conditions, and more.
   See [Async handlers](#async-handlers) and [Workflow message passing](/encyclopedia/workflow-message-passing) for safe usage guidelines.
+- Delay calling [`workflow.setHandler`](https://typescript.temporal.io/api/namespaces/workflow#sethandler) until the workflow initialization needed by Update (or Signal) handlers has finished. This is safe because the SDK buffers messages when there are no registered handlers for them. Note that [`workflow.setHandler`](https://typescript.temporal.io/api/namespaces/workflow#sethandler) will immediately invoke the handler of buffered Updates (or Signals) with matching types, and this could lead to out-of-order processing of messages with different types.
 
 ## Send messages {#send-messages}
 


### PR DESCRIPTION
## What does this PR do?

This PR clarifies how to safely register update and signal handlers after needed workflow initialization (TypeScript).

This closes https://github.com/temporalio/sdk-typescript/issues/1483


<!-- delete if n/a -->
