### PR TITLE
EDU-3229: Workflow Initializers Encyclopedia entry

### DIFF
--- a/docs/encyclopedia/application-message-passing.mdx
+++ b/docs/encyclopedia/application-message-passing.mdx
@@ -222,20 +222,20 @@ This execution is on a single thread–while this means you don’t have to worr
 
 #### Initializing the Workflow first {#workflow-initializers}
 
-Notice from the [diagram](#message-handler-concurrency) that messages can be processed before the first time your Workflow's main method runs.
+Initialize your Workflow's state before handling messages. This prevents reading uninitialized instance variables.
 
-In practice, this happens in two main scenarios:
+To see why, refer to the [diagram](#message-handler-concurrency). It shows that your Workflow processes messages before the first run of your Workflow's main method.
 
-- You are using [Signal-with-Start](#signal-with-start), in which case the message handler always runs first.
-- Your Worker is delayed, such as when it's backlogged.
+This happens in two main scenarios:
 
-So, it's important to initialize your Workflow's state before messages come in, otherwise you will be reading uninitialized instance variables.
+- When using [Signal-with-Start](#signal-with-start), the message handler always runs first.
+- When your Worker experiences delays, such as during backlogs.
 
-In object-oriented languages, you should annotate your constructor as a Workflow Initializer. Initializers take the same arguments as your Workflow's main method so that you can fully set up your state.
+For object-oriented languages, use your constructor to set up state. Annotate your constructor as an Workflow Initializer and take the same arguments as your Workflow's main method.
 
-Note that you cannot make blocking calls from your constructor. For that case, if you have a Signal or Update handler, you can make it [wait](#waiting).
+Note that you can't make blocking calls from your constructor. If you need to block, make your Signal or Update handler [wait](#waiting) for an initialization flag.
 
-In other languages, wait to register your handlers until after you've done any initialization that your message handlers might need.
+In other languages, register any message handlers only after completing initialization.
 
 ### Message handler patterns {#message-handler-patterns}
 

--- a/docs/encyclopedia/application-message-passing.mdx
+++ b/docs/encyclopedia/application-message-passing.mdx
@@ -246,7 +246,7 @@ In Go and TypeScript, register any message handlers only after completing initia
 
 Here are several common patterns for write operations, Signal and Update handlers. They don't apply to pure read operations, i.e. Queries or [Update Validators](#update-validators):
 
-- Returning immediately from a handler.
+- Returning immediately from a handler
 - Waiting for the Workflow to be ready to process them
 - Kicking off activities and other asynchronous tasks
 - Injecting work into the main Workflow

--- a/docs/encyclopedia/application-message-passing.mdx
+++ b/docs/encyclopedia/application-message-passing.mdx
@@ -222,17 +222,17 @@ This execution is on a single thread–while this means you don’t have to worr
 
 #### Initializing the Workflow first {#workflow-initializers}
 
-Initialize your Workflow's state before handling messages. This prevents reading uninitialized instance variables.
+Initialize your Workflow's state before handling messages. This prevents your Workflow reading uninitialized instance variables.
 
 To see why, refer to the [diagram](#message-handler-concurrency). It shows that your Workflow processes messages before the first run of your Workflow's main method.
 
-This happens in several scenarios, such as:
+The message handler runs first in several scenarios, such as:
 
-- When using [Signal-with-Start](#signal-with-start), the message handler always runs first.
-- When your Worker experiences delays, such as during backlogs.
+- When using [Signal-with-Start](#signal-with-start).
+- When your Worker experiences delays, such as when the Task Queue it polls gets backlogged.
 - When messages arrive immediately after a Workflow continues as new but before it resumes.
 
-For all languages except Go and TypeScript, use your constructor to set up state. Annotate your constructor as an Workflow Initializer and take the same arguments as your Workflow's main method.
+For all languages except Go and TypeScript, use your constructor to set up state. Annotate your constructor as a Workflow Initializer and take the same arguments as your Workflow's main method.
 
 Note that you can't make blocking calls from your constructor. If you need to block, make your Signal or Update handler [wait](#waiting) for an initialization flag.
 

--- a/docs/encyclopedia/application-message-passing.mdx
+++ b/docs/encyclopedia/application-message-passing.mdx
@@ -222,9 +222,11 @@ This execution is on a single thread–while this means you don’t have to worr
 
 #### Initializing the Workflow first {#workflow-initializers}
 
-Initialize your Workflow's state before handling messages. This prevents your Workflow reading uninitialized instance variables.
+Initialize your Workflow's state before handling messages.
+This prevents your handler from reading uninitialized instance variables.
 
-To see why, refer to the [diagram](#message-handler-concurrency). It shows that your Workflow processes messages before the first run of your Workflow's main method.
+To see why, refer to the [diagram](#message-handler-concurrency).
+It shows that your Workflow processes messages before the first run of your Workflow's main method.
 
 The message handler runs first in several scenarios, such as:
 
@@ -232,9 +234,11 @@ The message handler runs first in several scenarios, such as:
 - When your Worker experiences delays, such as when the Task Queue it polls gets backlogged.
 - When messages arrive immediately after a Workflow continues as new but before it resumes.
 
-For all languages except Go and TypeScript, use your constructor to set up state. Annotate your constructor as a Workflow Initializer and take the same arguments as your Workflow's main method.
+For all languages except Go and TypeScript, use your constructor to set up state.
+Annotate your constructor as a Workflow Initializer and take the same arguments as your Workflow's main method.
 
-Note that you can't make blocking calls from your constructor. If you need to block, make your Signal or Update handler [wait](#waiting) for an initialization flag.
+Note that you can't make blocking calls from your constructor.
+If you need to block, make your Signal or Update handler [wait](#waiting) for an initialization flag.
 
 In Go and TypeScript, register any message handlers only after completing initialization.
 

--- a/docs/encyclopedia/application-message-passing.mdx
+++ b/docs/encyclopedia/application-message-passing.mdx
@@ -226,16 +226,17 @@ Initialize your Workflow's state before handling messages. This prevents reading
 
 To see why, refer to the [diagram](#message-handler-concurrency). It shows that your Workflow processes messages before the first run of your Workflow's main method.
 
-This happens in two main scenarios:
+This happens in several scenarios, such as:
 
 - When using [Signal-with-Start](#signal-with-start), the message handler always runs first.
 - When your Worker experiences delays, such as during backlogs.
+- When messages arrive immediately after a Workflow continues as new but before it resumes.
 
-For object-oriented languages, use your constructor to set up state. Annotate your constructor as an Workflow Initializer and take the same arguments as your Workflow's main method.
+For all languages except Go and TypeScript, use your constructor to set up state. Annotate your constructor as an Workflow Initializer and take the same arguments as your Workflow's main method.
 
 Note that you can't make blocking calls from your constructor. If you need to block, make your Signal or Update handler [wait](#waiting) for an initialization flag.
 
-In other languages, register any message handlers only after completing initialization.
+In Go and TypeScript, register any message handlers only after completing initialization.
 
 ### Message handler patterns {#message-handler-patterns}
 

--- a/docs/encyclopedia/application-message-passing.mdx
+++ b/docs/encyclopedia/application-message-passing.mdx
@@ -220,22 +220,39 @@ Every time the Workflow wakes up--generally, it wakes up when it needs to--it wi
 
 This execution is on a single thread–while this means you don’t have to worry about parallelism, you do need to worry about concurrency if you have written Signal and Update handlers that can block. These can run interleaved with the main Workflow and with one another, resulting in potential race conditions. These methods should be made reentrant.
 
+#### Initializing the Workflow first {#workflow-initializers}
+
+Notice from the [diagram](#message-handler-concurrency) that messages can be processed before the first time your Workflow's main method runs.
+
+In practice, this happens in two main scenarios:
+
+- You are using [Signal-with-Start](#signal-with-start), in which case the message handler always runs first.
+- Your Worker is delayed, such as when it's backlogged.
+
+So, it's important to initialize your Workflow's state before messages come in, otherwise you will be reading uninitialized instance variables.
+
+In object-oriented languages, you should annotate your constructor as a Workflow Initializer. Initializers take the same arguments as your Workflow's main method so that you can fully set up your state.
+
+Note that you cannot make blocking calls from your constructor. For that case, if you have a Signal or Update handler, you can make it [wait](#waiting).
+
+In other languages, wait to register your handlers until after you've done any initialization that your message handlers might need.
+
 ### Message handler patterns {#message-handler-patterns}
 
 Here are several common patterns for write operations, Signal and Update handlers. They don't apply to pure read operations, i.e. Queries or [Update Validators](#update-validators):
 
-- Synchronous, returning immediately.
-- Waiting for the Workflow to be ready to process them.
+- Returning immediately from a handler.
+- Waiting for the Workflow to be ready to process them
 - Kicking off activities and other asynchronous tasks
-- Injecting work into the main Workflow.
-- Finishing handlers before the Workflow completes.
-- Ensuring your messages are processed exactly once.
+- Injecting work into the main Workflow
+- Finishing handlers before the Workflow completes
+- Ensuring your messages are processed exactly once
 
 #### Synchronous handlers
 
 Synchronous handlers don’t kick off any long-running operations or otherwise block. They're guaranteed to run atomically.
 
-#### Waiting
+#### Waiting {#waiting}
 
 A Signal or Update handler can block waiting for the Workflow to reach a certain state using a Wait Condition. See the links below to find out how to use this with your SDK.
 


### PR DESCRIPTION
## What does this PR do?
Overview documentation the new Workflow Initializer feature.

## Notes to reviewers
* Per-SDK docs are TBD.
* Plan is to link to this from my blog post on message handling.

Test plan:
```
yarn start
http://localhost:3000/encyclopedia/workflow-message-passing#workflow-initializers
```
Click on links.

<!-- delete if n/a -->
