### PR TITLE
EDU-3255: Updates and aligns ordering for all dev guides

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -123,6 +123,7 @@ module.exports = {
           items: [
             "develop/go/core-application",
             "develop/go/temporal-clients",
+            "develop/go/namespaces",
             "develop/go/testing-suite",
             "develop/go/failure-detection",
             "develop/go/message-passing",
@@ -139,7 +140,6 @@ module.exports = {
             "develop/go/side-effects",
             "develop/go/selectors",
             "develop/go/sessions",
-            "develop/go/namespaces",
           ],
         },
         {
@@ -270,8 +270,8 @@ module.exports = {
             "develop/dotnet/schedules",
             "develop/dotnet/data-encryption",
             "develop/dotnet/durable-timers",
-            "develop/dotnet/continue-as-new",
             "develop/dotnet/child-workflows",
+            "develop/dotnet/continue-as-new",
           ],
         },
         "develop/activity-retry-simulator",


### PR DESCRIPTION
- Aligns dev guide order
- ~~Renames dotnet's Durable Timers to Timers to align~~ Please note that .NET uses a different URL pattern but the text is aligned and appears properly.