### PR TITLE
add encode endpoint sample

### DIFF
--- a/docs/production-deployment/data-encryption.mdx
+++ b/docs/production-deployment/data-encryption.mdx
@@ -125,7 +125,7 @@ The following example shows a sample `POST` request body with base64 encoding.
     "metadata": {
       "encoding": <base64EncodedEncodingHint>
     },
-    "data": <base64 of decoded value>
+    "data": <encryptedPayloadData>
   }, ...]
 }
 ```
@@ -218,6 +218,37 @@ Content-Type: application/json
       "shopperId":"your-shopper-id-example",
       "email":"your-email@domain.com"
     }}]
+}
+```
+
+You can also perform remote encoding on an `/encode` endpoint, which looks the same in reverse:
+
+- Scheme: `https`
+- Host: `dev.mydomain.com/codec`
+- Path: `/encode`
+
+```json
+HTTP/1.1 POST /encode
+Host: https://dev.mydomain.com/codec
+Content-Type: application/json
+X-Namespace: myapp-dev.acctid123
+Authorization: Bearer <token>
+
+{"payloads":[{"metadata":{"encoding":"json/protobuf","messageType":"temporal_shop.orchestrations.v1.StartShoppingCartRequest"},"data"::{"cartId":"example-cart","shopperId":"your-shopper-id-example","email":"your-email@domain.com"}}]}
+
+200 OK
+Content-Type: application/json
+
+{
+  "payloads": [
+    {
+      "metadata": {
+        "encoding": "anNvbi9wcm90b2J1Zg==",
+        "messageType": "dGVtcG9yYWxfc2hvcC5vcmNoZXN0cmF0aW9ucy52MS5TdGFydFNob3BwaW5nQ2FydFJlcXVlc3Q="
+      },
+      "data": "eyJjYXJ0SWQiOiJleGFtcGxlLWNhcnQiLCJzaG9wcGVySWQiOiJ5b3VyLXNob3BwZXItaWQtZXhhbXBsZSIsImVtYWlsIjoieW91ci1lbWFpbEBkb21haW4uY29tIn0"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
One thing I'm not sure about here is whether showing the POST values as non-base64 encoded is potentially misleading (I've seen people get confused about this aspect of our codec server reference before) -- but if I *do* show the input as base64 encoded, it's *more* confusing since it's indistinguishable from encrypted strings. Made a small change to the "Request body" section of this page simultaneously to try to rectify that.