### PR TITLE
update Nexus data converter encryption options

### DIFF
--- a/docs/encyclopedia/temporal-nexus-security.mdx
+++ b/docs/encyclopedia/temporal-nexus-security.mdx
@@ -60,4 +60,18 @@ In Temporal Cloud multiple security provisions are in place to ensure it can act
 ### Payload Encryption and Data Converter {#payload-encryption-data-converter}
 
 The Data Converter works the same for a Nexus Operation as it does for other payloads sent between a Worker and Temporal Cloud.
-There is support for a single Data Converter to be used for inbound inputs and outbound outputs, which means the encryption key often used in a custom Data Converter must be the same for both the caller and the handler.
+The caller and handler Workers must have compatible Data Converters as operation inputs and results are passed between the two.
+
+If encryption keys are used to encrypt payloads, they must be available in both the caller and handler. This may be achieved by either:
+- Using the same encryption key in both the caller and handler, for example a shared symmetric key stored in your KMS.
+- Using different encryption keys and passing the KMS encryption key ID via payload metadata.
+  - Operation input payload:
+    - Caller encrypts the input payload and puts the caller's KMS encryption key ID in payload metadata.
+    - Handler decrypts the input payload using the KMS encryption key ID in payload metadata.
+  - Operation result payload:
+    - Handler encrypts the result payload and puts the handler's KMS encryption key ID in payload metadata.
+    - Caller decrypts the result payload using the KMS encryption key ID in payload metadata.
+  - Codec server can decrypt payloads using the KMS encryption key ID in payload metadata.
+  - Nexus Workers in different regions may require a multi-region KMS.
+
+Please let us know if you need per-Endpoint or per-Service payload encryption or better handling for asymmetric keys.

--- a/docs/encyclopedia/temporal-nexus-security.mdx
+++ b/docs/encyclopedia/temporal-nexus-security.mdx
@@ -62,16 +62,7 @@ In Temporal Cloud multiple security provisions are in place to ensure it can act
 The Data Converter works the same for a Nexus Operation as it does for other payloads sent between a Worker and Temporal Cloud.
 The caller and handler Workers must have compatible Data Converters as operation inputs and results are passed between the two.
 
-If encryption keys are used to encrypt payloads, they must be available in both the caller and handler. This may be achieved by either:
-- Using the same encryption key in both the caller and handler, for example a shared symmetric key stored in your KMS.
-- Using different encryption keys and passing the KMS encryption key ID via payload metadata.
-  - Operation input payload:
-    - Caller encrypts the input payload and puts the caller's KMS encryption key ID in payload metadata.
-    - Handler decrypts the input payload using the KMS encryption key ID in payload metadata.
-  - Operation result payload:
-    - Handler encrypts the result payload and puts the handler's KMS encryption key ID in payload metadata.
-    - Caller decrypts the result payload using the KMS encryption key ID in payload metadata.
-  - Codec server can decrypt payloads using the KMS encryption key ID in payload metadata.
-  - Nexus Workers in different regions may require a multi-region KMS.
+If encryption keys are used to encrypt payloads, they must be available in both the caller and handler. For example,
+the caller and handler can use a shared symmetric key stored in your KMS.
 
-Please let us know if you need per-Endpoint or per-Service payload encryption or better handling for asymmetric keys.
+Please let us know if you need per-Service payload encryption or better handling for asymmetric encryption keys.

--- a/docs/evaluate/temporal-cloud/security.mdx
+++ b/docs/evaluate/temporal-cloud/security.mdx
@@ -76,7 +76,11 @@ Workers authenticate with Temporal Cloud as they do today with mTLS certificates
 Nexus requests are sent from the caller’s Namespace to the handler’s Namespace over a secure multi-region mTLS Envoy mesh.
 
 For payload encryption, the DataConverter works the same for a Nexus Operation as it does for other payloads sent between a Worker and Temporal Cloud.
-There is support for a single DataConverter for inbound inputs and outbound outputs, which means the encryption key often used in a custom DataConverter must be available in both the caller and the handler.
+The caller and handler Workers must have compatible Data Converters as operation inputs and results are passed between the two.
+
+If encryption keys are used to encrypt payloads, they must be available in both the caller and handler. This may be achieved by either:
+- Using the same encryption key in both the caller and handler, for example a shared symmetric key stored in your KMS.
+- Using different encryption keys and passing the KMS encryption key ID via payload metadata.
 
 See [Nexus Security](/nexus/security) for more information.
 

--- a/docs/evaluate/temporal-cloud/security.mdx
+++ b/docs/evaluate/temporal-cloud/security.mdx
@@ -76,11 +76,6 @@ Workers authenticate with Temporal Cloud as they do today with mTLS certificates
 Nexus requests are sent from the caller’s Namespace to the handler’s Namespace over a secure multi-region mTLS Envoy mesh.
 
 For payload encryption, the DataConverter works the same for a Nexus Operation as it does for other payloads sent between a Worker and Temporal Cloud.
-The caller and handler Workers must have compatible Data Converters as operation inputs and results are passed between the two.
-
-If encryption keys are used to encrypt payloads, they must be available in both the caller and handler. This may be achieved by either:
-- Using the same encryption key in both the caller and handler, for example a shared symmetric key stored in your KMS.
-- Using different encryption keys and passing the KMS encryption key ID via payload metadata.
 
 See [Nexus Security](/nexus/security) for more information.
 

--- a/docs/production-deployment/cloud/nexus/operations.mdx
+++ b/docs/production-deployment/cloud/nexus/operations.mdx
@@ -201,10 +201,5 @@ See [Nexus Secure Routing](/nexus/security#secure-routing) for additional detail
 ## Payload Encryption
 
 For payload encryption, the DataConverter works the same for a Nexus Operation as it does for other payloads sent between a Worker and Temporal Cloud.
-The caller and handler Workers must have compatible Data Converters as operation inputs and results are passed between the two.
-
-If encryption keys are used to encrypt payloads, they must be available in both the caller and handler. This may be achieved by either:
-- Using the same encryption key in both the caller and handler, for example a shared symmetric key stored in your KMS.
-- Using different encryption keys and passing the KMS encryption key ID via payload metadata.
 
 See [Nexus Payload Encryption & Data Converter](/nexus/security#payload-encryption-data-converter) for additional details. 

--- a/docs/production-deployment/cloud/nexus/operations.mdx
+++ b/docs/production-deployment/cloud/nexus/operations.mdx
@@ -201,7 +201,10 @@ See [Nexus Secure Routing](/nexus/security#secure-routing) for additional detail
 ## Payload Encryption
 
 For payload encryption, the DataConverter works the same for a Nexus Operation as it does for other payloads sent between a Worker and Temporal Cloud.
-Currently there is support for a single DataConverter to be used for inbound inputs and outbound outputs, which means the encryption key often used in a custom DataConverter must be the same for both the caller and the handler.
-Please let us know if you need per-Endpoint or per-Service payload encryption.
+The caller and handler Workers must have compatible Data Converters as operation inputs and results are passed between the two.
+
+If encryption keys are used to encrypt payloads, they must be available in both the caller and handler. This may be achieved by either:
+- Using the same encryption key in both the caller and handler, for example a shared symmetric key stored in your KMS.
+- Using different encryption keys and passing the KMS encryption key ID via payload metadata.
 
 See [Nexus Payload Encryption & Data Converter](/nexus/security#payload-encryption-data-converter) for additional details. 


### PR DESCRIPTION
## What does this PR do?

Makes it clear that Nexus does support callers and handlers using different encryption keys today, if you flow the KMS encryption key id in the payload metadata and both caller and handler have access to those KMS keys.

## Notes to reviewers

Reference example: https://github.com/temporalio/reference-app-orders-go/blob/main/app/temporalutil/data_converter.go

