### PR TITLE
add temporal --command-timeout global option

### DIFF
--- a/docs/cli/activity.mdx
+++ b/docs/cli/activity.mdx
@@ -48,7 +48,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -95,7 +95,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--detail](/cli/cmd-options#detail)
 

--- a/docs/cli/batch.mdx
+++ b/docs/cli/batch.mdx
@@ -90,7 +90,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -140,7 +140,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -185,7 +185,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 

--- a/docs/cli/cmd-options.mdx
+++ b/docs/cli/cmd-options.mdx
@@ -283,7 +283,7 @@ Request concurrency.
 
 ## command-timeout
 
-The command execution timeout in seconds. 0 means no timeout.
+The command execution timeout. 0s means no timeout.
 
 ## cron
 

--- a/docs/cli/cmd-options.mdx
+++ b/docs/cli/cmd-options.mdx
@@ -281,9 +281,9 @@ When to use color: auto, always, never. (default: auto)
 
 Request concurrency.
 
-## context-timeout
+## command-timeout
 
-An optional timeout for the context of an RPC call (in seconds).
+Timeout for the span of a command.
 
 ## cron
 

--- a/docs/cli/cmd-options.mdx
+++ b/docs/cli/cmd-options.mdx
@@ -283,7 +283,7 @@ Request concurrency.
 
 ## command-timeout
 
-Timeout for the span of a command.
+The command execution timeout in seconds. 0 means no timeout.
 
 ## cron
 

--- a/docs/cli/env.mdx
+++ b/docs/cli/env.mdx
@@ -54,7 +54,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -94,7 +94,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -134,7 +134,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -166,7 +166,7 @@ List all environments.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 

--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -463,7 +463,7 @@ OPTIONS:
    --address value                          The host and port (formatted as host:port) for the Temporal Frontend Service. [$TEMPORAL_CLI_ADDRESS]
    --codec-auth value                       Sets the authorization header on requests to the Codec Server. [$TEMPORAL_CLI_CODEC_AUTH]
    --codec-endpoint value                   Endpoint for a remote Codec Server. [$TEMPORAL_CLI_CODEC_ENDPOINT]
-   --context-timeout value                  An optional timeout for the context of an RPC call (in seconds). (default: 5) [$TEMPORAL_CONTEXT_TIMEOUT]
+   --command-timeout duration               Timeout for the span of a command. (default 0s)
    --env value                              Name of the environment to read environmental variables from. (default: "default")
    --grpc-meta value [ --grpc-meta value ]  Contains gRPC metadata to send with requests (format: key=value). Values must be in a valid JSON format.
    --namespace value, -n value              Identifies a Namespace in the Temporal Workflow. (default: "default") [$TEMPORAL_CLI_NAMESPACE]

--- a/docs/cli/operator.mdx
+++ b/docs/cli/operator.mdx
@@ -84,7 +84,7 @@ Use the following options to change the output of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -123,7 +123,7 @@ Use the following options to change the behavior and output of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -159,7 +159,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -207,7 +207,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -246,7 +246,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -288,7 +288,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--enable-connection](/cli/cmd-options#enable-connection)
 
@@ -346,7 +346,7 @@ Use the options listed below to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--data](/cli/cmd-options#data)
 
@@ -399,7 +399,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -438,7 +438,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -476,7 +476,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -531,7 +531,7 @@ Use the options listed below to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--data](/cli/cmd-options#data)
 
@@ -620,6 +620,8 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
+- [--command-timeout](/cli/cmd-options#command-timeout)
+
 - [--description](/cli/cmd-options#description)
 
 - [--description-file](/cli/cmd-options#description-file)
@@ -688,6 +690,8 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
+- [--command-timeout](/cli/cmd-options#command-timeout)
+
 - [--env](/cli/cmd-options#env)
 
 - [--env-file](/cli/cmd-options#env-file)
@@ -746,6 +750,8 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
+- [--command-timeout](/cli/cmd-options#command-timeout)
+
 - [--env](/cli/cmd-options#env)
 
 - [--env-file](/cli/cmd-options#env-file)
@@ -803,6 +809,8 @@ Use the following options to change the behavior of this command.
 - [--codec-endpoint](/cli/cmd-options#codec-endpoint)
 
 - [--color](/cli/cmd-options#color)
+
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -878,6 +886,8 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
+- [--command-timeout](/cli/cmd-options#command-timeout)
+
 - [--description](/cli/cmd-options#description)
 
 - [--description-file](/cli/cmd-options#description-file)
@@ -951,7 +961,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -991,7 +1001,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -1028,7 +1038,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 

--- a/docs/cli/schedule.mdx
+++ b/docs/cli/schedule.mdx
@@ -68,7 +68,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--end-time](/cli/cmd-options#end-time)
 
@@ -155,7 +155,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--cron](/cli/cmd-options#cron)
 
@@ -243,7 +243,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -282,7 +282,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -329,7 +329,7 @@ Use the options below to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -382,7 +382,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -432,7 +432,7 @@ Use the following options to change this command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -487,7 +487,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--cron](/cli/cmd-options#cron)
 

--- a/docs/cli/task-queue.mdx
+++ b/docs/cli/task-queue.mdx
@@ -46,7 +46,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -90,7 +90,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -126,7 +126,7 @@ Fetch the sets of compatible build IDs associated with a Task Queue and associat
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -166,7 +166,7 @@ If a Task Queue isn't provided, reachability for the provided Build IDs is check
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 

--- a/docs/cli/workflow.mdx
+++ b/docs/cli/workflow.mdx
@@ -97,7 +97,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -142,7 +142,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -178,7 +178,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -229,7 +229,7 @@ Use the following command options to change the information returned by this com
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -279,7 +279,7 @@ Use the following command options to change how the Workflow Execution behaves d
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--cron](/cli/cmd-options#cron)
 
@@ -364,7 +364,7 @@ Use the following command options to change the information returned by this com
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -417,7 +417,7 @@ Use the following command options to change the information returned by this com
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -470,7 +470,7 @@ Use the following options to change reset behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -525,7 +525,7 @@ Use the following options to change reset behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--dry-run](/cli/cmd-options#dry-run)
 
@@ -581,7 +581,7 @@ Use the following options to change the behavior of this command.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -637,7 +637,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -688,7 +688,7 @@ Use the following options to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -735,7 +735,7 @@ Use the following command options to change how the Workflow Execution behaves u
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--cron](/cli/cmd-options#cron)
 
@@ -817,7 +817,7 @@ Use the following options to change termination behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 
@@ -863,7 +863,7 @@ Use the following options to change the command's behavior.
 
 - [--concurrency](/cli/cmd-options#concurrency)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--depth](/cli/cmd-options#depth)
 
@@ -907,7 +907,7 @@ Use the options listed below to change the command's behavior.
 
 - [--color](/cli/cmd-options#color)
 
-- [--context-timeout](/cli/cmd-options#context-timeout)
+- [--command-timeout](/cli/cmd-options#command-timeout)
 
 - [--env](/cli/cmd-options#env)
 


### PR DESCRIPTION
## What does this PR do?
Adds docs for the new `temporal --command-timeout` option
