### PR TITLE
Fix and improve nexus sdk metrics docs

### DIFF
--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -493,10 +493,10 @@ Valid values for the `failure_reason` tag:
 
 - `internal_sdk_error`: There was an unexpected internal error within the SDK while handling the Nexus task. Indicates a
   bug in the SDK.
-`handler_error_{TYPE}`: The user handler code returned a predefined error, as specified in the [Nexus spec](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors).
-If the handler returns an unexpected error, the TYPE is set to `INTERNAL`.
-  spec](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors). If the handler returns an
-  unexpected error (or panics in languages where relevant), the TYPE is set to `INTERNAL`.
+- `handler_error_{TYPE}`: The user handler code returned a predefined error, as specified in the [Nexus
+  spec](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors).
+  If the handler returns an unexpected error, the TYPE is set to `INTERNAL`.
+- `timeout`: The user handler code did not return within the request timeout.
 - `operation_failed`: The user handler code has indicated that the operation has failed. In Go, this maps to an
   `UnsuccessfulOperationError` with a `failed` state.
 - `operation_canceled`: The user handler code has indicated that the operation has completed as canceled. In Go, this maps


### PR DESCRIPTION
- The document was malformed while accepting a review suggestion in the previous PR. Fixed that.
- Added `timeout` `failure_reason` tag.
