### PR TITLE
EDU-3276: Fixes broken link for Advanced visibility page

### DIFF
--- a/docs/encyclopedia/visibility.mdx
+++ b/docs/encyclopedia/visibility.mdx
@@ -57,7 +57,7 @@ Visibility, within the Temporal Platform, is the subsystem and APIs that enable 
 - For Temporal Server versions 1.19.1 and earlier, you must [integrate with ElasticSearch](/self-hosted-guide/visibility#elasticsearch) to use advanced Visibility.
   Elasticsearch takes on the Visibility request load, relieving potential performance issues.
   We highly recommend operating a Temporal Service with Elasticsearch for any use case that spawns more than just a few Workflow Executions.
-- On Temporal Cloud, [advanced Visibility is enabled by default for all users](/cloud/users#invite-users).
+- On Temporal Cloud, advanced Visibility is enabled by default for [all users](/cloud/users#invite-users).
 
 ## What is Dual Visibility? {#dual-visibility}
 


### PR DESCRIPTION
- Removes link that looks as if it should link to advanced Visibility but doesn't, and is in the advanced visibility section.
- Moves link to just "all users", linking to "adding users".