### PR TITLE
[DRAFT] EDU-3173: Add Nexus Task Queues to Encyclopedia

### DIFF
--- a/docs/encyclopedia/workers.mdx
+++ b/docs/encyclopedia/workers.mdx
@@ -219,8 +219,21 @@ The Temporal Service interprets the outcome and determines whether to retry the 
 ## What is a Task Queue? {#task-queue}
 
 A Task Queue is a lightweight, dynamically allocated queue that one or more [Worker Entities](#worker-entity) poll for [Tasks](#task).
+For each Task Queue name, Temporal creates separate queues for each Task Queue type, specifically:
 
-There are two types of Task Queues, Activity Task Queues and Workflow Task Queues.
+- **Activity Task Queue**: A queue that holds Activity Tasks.
+  Activity Tasks represent units of work within a larger business process.
+  Each Activity Task contains the context required by an Activity Definition.
+  Workers poll Activity Tasks from the Activity Task Queue and use them to initiate Activity Executions.
+- **Workflow Task Queue**: A queue that holds Workflow Tasks.
+  Workflow Tasks contain the context needed by a Workflow Definition.
+  Workers poll Workflow Tasks from the Workflow Task Queue and use them to initiate Workflow Executions.
+- **Nexus Task Queue** ([Public Preview](/evaluate/development-production-features/release-stages#public-preview)): A queue that holds Nexus Tasks.
+  Nexus Tasks are used for units of work passed between Namespaces.
+  Workers configured with the Nexus Service poll the Nexus Task Queue for available tasks and handle them by initiating Workflow Executions in the target Namespace.
+  Each Nexus Task contains the context required by the target Workflow Definition.
+
+Each Task Queue type provides unaggregated data.
 
 <div className="tdiw">
   <div className="tditw">


### PR DESCRIPTION
Update Encyclopedia coverage to include Nexus Task Queues

- Maybe mention other Task Queue types as well, probably as an aside/note?
- The graphic probably needs updating
- Midway screenshots attached below.

![snapshot-10-31-24@09-44-03](https://github.com/user-attachments/assets/4dfa783d-ea4c-4d4d-9538-8df7141b4635)

![snapshot-10-31-24@09-44-17](https://github.com/user-attachments/assets/7f48b4c4-c781-4ba4-9a8a-54c40b875646)

![snapshot-10-31-24@09-44-35](https://github.com/user-attachments/assets/fe7a0a3e-f428-47ca-a13f-29edee42e8a1)

![snapshot-10-31-24@09-44-50](https://github.com/user-attachments/assets/6561d559-3295-4bde-bd68-062ff703daaa)
