### PR TITLE
EDU-3434: Add slots used metric

### DIFF
--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -359,7 +359,7 @@ A Worker Entity has been registered, created, or started.
 
 ### worker_task_slots_available
 
-The total number of Workflow Task, Activity Task, Local Activity, or Nexus execution slots that are currently available.
+The total number of Workflow, Activity, Local Activity, or Nexus Task execution slots that are currently available.
 Use the `worker_type` key to differentiate execution slots.
 (Workflow Workers execute Workflow Tasks; Activity Workers execute Activity Tasks, etc.)
 

--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -370,7 +370,7 @@ For example, Workflow Workers execute Workflow Tasks, Activity Workers execute A
 
 ### worker_task_slots_used
 
-The total number of Workflow Task, Activity Task, Local Activity, or Nexus execution slots that are currently used.
+The total number of Workflow, Activity, Local Activity, or Nexus Tasks execution slots in current use.
 Use the `worker_type` key to differentiate execution slots.
 (Workflow Workers execute Workflow Tasks; Activity Workers execute Activity Tasks, etc.)
 

--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -372,7 +372,8 @@ For example, Workflow Workers execute Workflow Tasks, Activity Workers execute A
 
 The total number of Workflow, Activity, Local Activity, or Nexus Tasks execution slots in current use.
 Use the `worker_type` key to differentiate execution slots.
-(Workflow Workers execute Workflow Tasks; Activity Workers execute Activity Tasks, etc.)
+The Worker type specifies an ability to perform certain tasks.
+For example, Workflow Workers execute Workflow Tasks, Activity Workers execute Activity Tasks, and so forth.
 
 - Type: Gauge
 - Available in: Core, Go, Java

--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -114,7 +114,7 @@ Some keys may not be available in every SDK, and Histogram metrics may have diff
 | [unregistered_activity_invocation](#unregistered_activity_invocation)                   | Worker         | Counter     | Go             |
 | [worker_start](#worker_start)                                                           | Worker         | Counter     | Core, Go, Java |
 | [worker_task_slots_available](#worker_task_slots_available)                             | Worker         | Gauge       | Core, Go, Java |
-| [worker_task_slots_used](#worker_task_slots_used)                             | Worker         | Gauge       | Core, Go, Java |
+| [worker_task_slots_used](#worker_task_slots_used)                                       | Worker         | Gauge       | Core, Go, Java |
 | [workflow_active_thread_count](#workflow_active_thread_count)                           | Worker         | Gauge       | Java           |
 | [workflow_cancelled](#workflow_cancelled)                                               | Worker         | Counter     | Core, Go, Java |
 | [workflow_completed](#workflow_completed)                                               | Worker         | Counter     | Core, Go, Java |
@@ -504,8 +504,7 @@ Valid values for the `failure_reason` tag:
 
 - `internal_sdk_error`: There was an unexpected internal error within the SDK while handling the Nexus task. Indicates a
   bug in the SDK.
-- `handler_error_{TYPE}`: The user handler code returned a predefined error, as specified in the [Nexus
-  spec](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors).
+- `handler_error_{TYPE}`: The user handler code returned a predefined error, as specified in the [Nexus spec](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors).
   If the handler returns an unexpected error, the TYPE is set to `INTERNAL`.
 - `timeout`: The user handler code did not return within the request timeout.
 - `operation_failed`: The user handler code has indicated that the operation has failed. In Go, this maps to an

--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -114,6 +114,7 @@ Some keys may not be available in every SDK, and Histogram metrics may have diff
 | [unregistered_activity_invocation](#unregistered_activity_invocation)                   | Worker         | Counter     | Go             |
 | [worker_start](#worker_start)                                                           | Worker         | Counter     | Core, Go, Java |
 | [worker_task_slots_available](#worker_task_slots_available)                             | Worker         | Gauge       | Core, Go, Java |
+| [worker_task_slots_used](#worker_task_slots_used)                             | Worker         | Gauge       | Core, Go, Java |
 | [workflow_active_thread_count](#workflow_active_thread_count)                           | Worker         | Gauge       | Java           |
 | [workflow_cancelled](#workflow_cancelled)                                               | Worker         | Counter     | Core, Go, Java |
 | [workflow_completed](#workflow_completed)                                               | Worker         | Counter     | Core, Go, Java |
@@ -358,9 +359,19 @@ A Worker Entity has been registered, created, or started.
 
 ### worker_task_slots_available
 
-The total number of Workflow Task and Activity Task execution slots that are currently available.
+The total number of Workflow Task, Activity Task, Local Activity, or Nexus execution slots that are currently available.
 Use the `worker_type` key to differentiate execution slots.
-(Workflow Workers execute Workflow Tasks; Activity Workers execute Activity Tasks.)
+(Workflow Workers execute Workflow Tasks; Activity Workers execute Activity Tasks, etc.)
+
+- Type: Gauge
+- Available in: Core, Go, Java
+- Tags: `namespace`, `task_queue`, `worker_type`
+
+### worker_task_slots_used
+
+The total number of Workflow Task, Activity Task, Local Activity, or Nexus execution slots that are currently used.
+Use the `worker_type` key to differentiate execution slots.
+(Workflow Workers execute Workflow Tasks; Activity Workers execute Activity Tasks, etc.)
 
 - Type: Gauge
 - Available in: Core, Go, Java

--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -361,7 +361,8 @@ A Worker Entity has been registered, created, or started.
 
 The total number of Workflow, Activity, Local Activity, or Nexus Task execution slots that are currently available.
 Use the `worker_type` key to differentiate execution slots.
-(Workflow Workers execute Workflow Tasks; Activity Workers execute Activity Tasks, etc.)
+The Worker type specifies an ability to perform certain tasks.
+For example, Workflow Workers execute Workflow Tasks, Activity Workers execute Activity Tasks, and so forth.
 
 - Type: Gauge
 - Available in: Core, Go, Java


### PR DESCRIPTION
Add metric for task slots used that was introduced when introducing worker tuners / slot suppliers.