### PR TITLE
python: Added note about sandbox passthrough modules to activity section

### DIFF
--- a/docs/develop/python/core-application.mdx
+++ b/docs/develop/python/core-application.mdx
@@ -201,6 +201,8 @@ An Activity is a normal function or method execution that's intended to execute 
 An Activity can interact with world outside the Temporal Platform or use a Temporal Client to interact with a Temporal Service.
 For the Workflow to be able to execute the Activity, we must define the [Activity Definition](/activities#activity-definition).
 
+In Python, modules for external services must be added to the [sandbox passthrough modules](/encyclopedia/python-sdk-sandbox#passthrough-modules).
+
 You can develop an Activity Definition by using the `@activity.defn` decorator.
 Register the function as an Activity with a custom name through a decorator argument, for example `@activity.defn(name="your_activity")`.
 


### PR DESCRIPTION
## What does this PR do?

Adds a note about sandbox passthrough modules for Python - it took me a while to figure out why `requests` didn't work for a basic HTTP call.
