### PR TITLE
EDU-3579: Fix a mistake in message-passing docs

### DIFF
--- a/docs/develop/dotnet/message-passing.mdx
+++ b/docs/develop/dotnet/message-passing.mdx
@@ -320,7 +320,7 @@ To send an Update to a Workflow Execution, you can:
     wf => wf.SetCurrentLanguageAsync(GreetingWorkflow.Language.Chinese));
   ```
 
-- 2. Use `StartUpdateAsync` to receive a handle as soon as the Update is accepted or rejected
+- 2. Use `StartUpdateAsync` to receive a handle as soon as the Update is accepted.
      It returns an `UpdateHandle`
 
   - Use this `UpdateHandle` later to fetch your results.

--- a/docs/develop/python/message-passing.mdx
+++ b/docs/develop/python/message-passing.mdx
@@ -291,7 +291,7 @@ To send an Update to a Workflow Execution, you can:
   )
   ```
 
-- Send [`start_update`](https://python.temporal.io/temporalio.client.WorkflowHandle.html#start_update) to receive an [`UpdateHandle`](https://python.temporal.io/temporalio.client.WorkflowUpdateHandle.html) as soon as the Update is accepted or rejected.
+- Send [`start_update`](https://python.temporal.io/temporalio.client.WorkflowHandle.html#start_update) to receive an [`UpdateHandle`](https://python.temporal.io/temporalio.client.WorkflowUpdateHandle.html) as soon as the Update is accepted.
 
   - Use this `UpdateHandle` later to fetch your results.
   - `async def` Update handlers normally perform long-running asynchronous operations, such as executing an Activity.


### PR DESCRIPTION
Fix two places where we incorrectly implied that a handle would be returned when the update is rejected.
