### PR TITLE
EDU-3601: Small change for TF User best practices docs.

### DIFF
--- a/docs/production-deployment/cloud/terraform-provider.mdx
+++ b/docs/production-deployment/cloud/terraform-provider.mdx
@@ -270,7 +270,9 @@ Cautions about Temporal User management:
 - Account Owners and Global Admins automatically gain access to all Namespaces in Temporal.
   Therefore, you cannot specify Namespace access for these roles.
   This is also true for Service Accounts.
-- Follow Terraform best practices for resource management. Manage a specific user in one and only one .tf file. There's a risk that you may overwrite a user's permissions if you don't.
+- Follow Terraform best practices for resource management.
+  Manage a specific user in one and only one .tf file.
+  There's a risk that you may overwrite a user's permissions if you don't.
 - To Import a user, you'll need the User's ID which is currently not available in the Temporal Cloud UI.
   You can fetch current User ID by running the `tcld user list` command.
 

--- a/docs/production-deployment/cloud/terraform-provider.mdx
+++ b/docs/production-deployment/cloud/terraform-provider.mdx
@@ -270,6 +270,7 @@ Cautions about Temporal User management:
 - Account Owners and Global Admins automatically gain access to all Namespaces in Temporal.
   Therefore, you cannot specify Namespace access for these roles.
   This is also true for Service Accounts.
+- Follow Terraform best practices for resource management. Manage a specific user in one and only one .tf file. There's a risk that you may overwrite a user's permissions if you don't.
 - To Import a user, you'll need the User's ID which is currently not available in the Temporal Cloud UI.
   You can fetch current User ID by running the `tcld user list` command.
 


### PR DESCRIPTION
This change adds guidance to mitigate overwriting a user's Temporal permissions as discussed in the TF issue https://github.com/temporalio/terraform-provider-temporalcloud/issues/119

The change is very small and localized to one Note block. This doc update accompanies a doc update in the Hashi Registry documentation. 