### PR TITLE
EDU-3639: removed import docs

### DIFF
--- a/docs/production-deployment/cloud/terraform-provider.mdx
+++ b/docs/production-deployment/cloud/terraform-provider.mdx
@@ -550,25 +550,8 @@ To delete an API Key with Terraform, remove the Terraform API Key resources conf
 
 **How do I Import a Temporal API Key?**
 
-If you have an existing API Key in Temporal Cloud, you can import it into Terraform using the `terraform import` command.
-
-1. Provide a configuration placeholder in your Terraform configuration.
-
-   ```yml
-   resource "temporalcloud_apikey" "import_key"{
-   }
-   ```
-
-1. Run the `terraform import` command and pass in the API Key ID
-   Your API Key ID is available in the Cloud UI in the API Key's details page
-
-   ```bash
-   terraform import temporalcloud_apikey.import_key zJV5zQ3IhsAbw75dAkVNEMsAd3a5AemC
-   ```
-
-The API Key is now a part of the Terraform state and all changes to the API Key should be managed by Terraform.
-Import does not import the API Key Token.
-The Token is only available at the time of API Key creation.
+Importing an API Key into Terraform is not a supported operation. This is because the API Key Token is a sensitive value that is not available after creation, therefore it is likely not available during import time.
+Instead of importing an API Key, Temporal recommends creating new API Keys with Terraform.
 
 ## Data Sources - Regions and Namespaces
 

--- a/docs/production-deployment/cloud/terraform-provider.mdx
+++ b/docs/production-deployment/cloud/terraform-provider.mdx
@@ -554,7 +554,6 @@ You cannot import an API Key into Terraform.
 Once created, the API Key secret isn't stored and can't be retrieved, so you can't access it using import.
 
 Instead, Temporal recommends creating a new API Key using Terraform directly.
-Instead of importing an API Key, Temporal recommends creating new API Keys with Terraform.
 
 ## Data Sources - Regions and Namespaces
 

--- a/docs/production-deployment/cloud/terraform-provider.mdx
+++ b/docs/production-deployment/cloud/terraform-provider.mdx
@@ -550,7 +550,10 @@ To delete an API Key with Terraform, remove the Terraform API Key resources conf
 
 **How do I Import a Temporal API Key?**
 
-Importing an API Key into Terraform is not a supported operation. This is because the API Key Token is a sensitive value that is not available after creation, therefore it is likely not available during import time.
+You cannot import an API Key into Terraform.
+Once created, the API Key secret isn't stored and can't be retrieved, so you can't access it using import.
+
+Instead, Temporal recommends creating a new API Key using Terraform directly.
 Instead of importing an API Key, Temporal recommends creating new API Keys with Terraform.
 
 ## Data Sources - Regions and Namespaces


### PR DESCRIPTION
## What does this PR do?
Removes the Import docs for API Keys in the TF docs to align with this TF PR https://github.com/temporalio/terraform-provider-temporalcloud/pull/202
