### PR TITLE
EDU-3361: Align Python and Go with .NET Workflow Init

### DIFF
--- a/docs/develop/java/message-passing.mdx
+++ b/docs/develop/java/message-passing.mdx
@@ -516,11 +516,11 @@ See [Finishing handlers before the Workflow completes](/encyclopedia/workflow-me
 
 ### Use `@WorkflowInit` to operate on Workflow input before any handler executes
 
-Normally, your Workflows constructor won't have any parameters.
-However, if you use the `@WorkflowInit` annotation on your constructor, you can give it the same [Workflow parameters](/develop/java/core-application#workflow-parameters) as your `@WorkflowMethod`.
+The `@WorkflowInit` annotation gives message handlers access to [Workflow input](/encyclopedia/workflow-message-passing#workflow-initializers).
+tializers).
+When you use the `@WorkflowInit` annotation on your constructor, you give the constructor the same Workflow parameters as your `@WorkflowMethod` method.
 The SDK will then ensure that your constructor receives the Workflow input arguments that the [Client sent](/develop/python/temporal-clients#start-workflow-execution).
 The Workflow input arguments are also passed to your `@WorkflowMethod` method -- that always happens, whether or not you use the `@WorkflowInit` annotation.
-This is useful if you have message handlers that need access to Workflow input: see [Initializing the Workflow first](/encyclopedia/workflow-message-passing#workflow-initializers).
 
 Here's an example.
 Notice that the constructor and `getGreeting` must have the same parameters:

--- a/docs/develop/python/message-passing.mdx
+++ b/docs/develop/python/message-passing.mdx
@@ -492,11 +492,10 @@ See [Finishing handlers before the Workflow completes](/encyclopedia/workflow-me
 
 ### Use `@workflow.init` to operate on Workflow input before any handler executes
 
-Normally, your Workflow `__init__` method won't have any parameters.
-However, if you use the `@workflow.init` decorator on your `__init__` method, you can give it the same [Workflow parameters](/develop/python/core-application#workflow-parameters) as your `@workflow.run` method.
+The `@workflow.init` decorator method gives message handlers access to [Workflow input](/encyclopedia/workflow-message-passing#workflow-initializers).
+When you use the `@workflow.init` decorator on your `__init__` method, you give the constructor the same Workflow parameters as your `@workflow.run` method.
 The SDK will then ensure that your `__init__` method receives the Workflow input arguments that the [Client sent](/develop/python/temporal-clients#start-workflow-execution).
-(The Workflow input arguments are also passed to your `@workflow.run` method -- that always happens, whether or not you use the `@workflow.init` decorator.)
-This is useful if you have message handlers that need access to workflow input: see [Initializing the Workflow first](/encyclopedia/workflow-message-passing#workflow-initializers).
+The Workflow input arguments are also passed to your `@workflow.run` method -- that always happens, whether or not you use the `@workflow.init` decorator.
 
 Here's an example.
 Notice that `__init__` and `get_greeting` must have the same parameters, with the same type annotations:


### PR DESCRIPTION
- Brings feature explanation to the first line.
- Removes parentheticals.
- Minor adjustments.