### PR TITLE
EDU-3696: Adjusting sidebar menu text

### DIFF
--- a/docs/develop/go/go-sdk-multithreading.mdx
+++ b/docs/develop/go/go-sdk-multithreading.mdx
@@ -1,7 +1,7 @@
 ---
 id: go-sdk-multithreading
 title: Temporal Go SDK multithreading
-sidebar_label: Go SDK multithreading
+sidebar_label: Multithreading
 description: The Temporal Go SDK ensures deterministic multithreading in Workflows using workflow.Go(), avoiding race conditions and eliminating the need for mutexes.
 toc_max_heading_level: 4
 keywords:

--- a/docs/develop/go/index.mdx
+++ b/docs/develop/go/index.mdx
@@ -46,7 +46,7 @@ Connect to a Temporal Service and start a Workflow Execution.
 - [Start Workflow Execution](/develop/go/temporal-clients#start-workflow-execution)
 - [How to start a Workflow Execution](/develop/go/temporal-clients#start-workflow-execution)
 
-## [Go SDK Multithreading](/develop/go/go-sdk-multithreading)
+## [Multithreading](/develop/go/go-sdk-multithreading)
 
 Safely use multithreading with the Go SDK.
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to 3230, this changes the sidebar entry from "Go SDK multithreading" to simply "Multithreading," for better parallelism with the other menu items


