### PR TITLE
add Nexus APIs to cloud user permissions

### DIFF
--- a/docs/encyclopedia/nexus.mdx
+++ b/docs/encyclopedia/nexus.mdx
@@ -54,7 +54,7 @@ Nexus Operations can be implemented with Temporal primitives, like Workflows, or
 
 ## Queue-based Worker architecture
 
-Nexus uses the Temporal queue-based Worker architecture and built-in Nexus Machinery to ensure reliable execution of a Nexus Operations.
+Nexus uses the Temporal queue-based Worker architecture and built-in Nexus Machinery to ensure reliable execution of Nexus Operations.
 If a Nexus Service is down, a caller Workflow can continue to schedule Nexus Operations and they will be processed when the service is up.
 
 Nexus handler Workers poll the Endpoint's target Namespace and Task Queue for [Nexus Tasks](/workers#nexus-task) to process.

--- a/docs/production-deployment/cloud/account-setup/users.mdx
+++ b/docs/production-deployment/cloud/account-setup/users.mdx
@@ -259,11 +259,13 @@ This table provides API-level details for the permissions granted to a user thro
 | CountIdentities                   | ✔         | ✔         | ✔             | ✔            | ✔             |
 | CreateAPIKey                      | ✔         | ✔         | ✔             | ✔            | ✔             |
 | CreateNamespace                   |           | ✔         |               | ✔            | ✔             |
+| CreateNexusEndpoint               |           | ✔         |               | ✔            | ✔             |
 | CreateServiceAccount              |           |           |               | ✔            | ✔             |
 | CreateServiceAccountAPIKey        |           |           |               | ✔            | ✔             |
 | CreateStripeCustomerPortalSession |           |           | ✔             |              | ✔             |
 | CreateUser                        |           |           |               | ✔            | ✔             |
 | DeleteAPIKey                      | ✔         | ✔         | ✔             | ✔            | ✔             |
+| DeleteNexusEndpoint               |           | ✔         |               | ✔            | ✔             |
 | DeleteServiceAccount              |           |           |               | ✔            | ✔             |
 | DeleteUser                        |           |           |               | ✔            | ✔             |
 | GetAccount                        | ✔         | ✔         | ✔             | ✔            | ✔             |
@@ -279,6 +281,8 @@ This table provides API-level details for the permissions granted to a user thro
 | GetIdentity                       | ✔         | ✔         | ✔             | ✔            | ✔             |
 | GetNamespaces                     | ✔         | ✔         | ✔             | ✔            | ✔             |
 | GetNamespacesUsage                |           |           |               | ✔            | ✔             |
+| GetNexusEndpoint                  | ✔         | ✔         | ✔             | ✔            | ✔             |
+| GetNexusEndpoints                 | ✔         | ✔         | ✔             | ✔            | ✔             |
 | GetRegion                         | ✔         | ✔         | ✔             | ✔            | ✔             |
 | GetRegions                        | ✔         | ✔         | ✔             | ✔            | ✔             |
 | GetRequestStatus                  | ✔         | ✔         | ✔             | ✔            | ✔             |
@@ -305,6 +309,7 @@ This table provides API-level details for the permissions granted to a user thro
 | SyncCurrentUserInvite             | ✔         | ✔         | ✔             | ✔            | ✔             |
 | UpdateAccount                     |           |           |               | ✔            | ✔             |
 | UpdateAPIKey                      | ✔         | ✔         | ✔             | ✔            | ✔             |
+| UpdateNexusEndpoint               |           | ✔         |               | ✔            | ✔             |
 | UpdateServiceAccount              |           |           |               | ✔            | ✔             |
 | UpdateUser                        |           |           |               | ✔            | ✔             |
 


### PR DESCRIPTION
## What does this PR do?
Adds Nexus Endpoint permissions to the tables in: https://docs.temporal.io/cloud/users#account-level-roles-and-namespace-level-permissions