### PR TITLE
Fix docs for `no_poller_tasks`

### DIFF
--- a/docs/references/cluster-metrics.mdx
+++ b/docs/references/cluster-metrics.mdx
@@ -101,7 +101,6 @@ Example: `histogram_quantile(0.95, sum(rate(asyncmatch_latency_bucket{service_na
 
 Emitted whenever a task is added to a task queue that has no poller, and is a counter metric.
 This is usually an indicator that either the Worker or the starter programs are using the wrong Task Queue.
-Use `no_poller_tasks_per_tl` to get data per Task Queue.
 
 ## History Service metrics
 


### PR DESCRIPTION
`no_poller_tasks_by_tl` was deleted in 2022: https://github.com/temporalio/temporal/pull/3579. `no_poller_tasks` has a `taskqueue` label on it that can be used to query per-taskqueue data.