### PR TITLE
EDU-2602: Add "Replication Lag" to the Glossary

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -429,7 +429,7 @@ Remote data encoding is using your custom Data Converter to decode (and encode) 
 
 <!-- _Tags: [term](/tags/term), [queries](/tags/queries), [explanation](/tags/explanation)_ -->
 
-#### [Replication Lag](/dataconversion#replication-lag)
+#### [Replication Lag](/cloud#replication-lag)
 
 The transmission delay of Workflow updates and history events from the active region to the standby region.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -427,6 +427,12 @@ A Query is a synchronous operation that is used to report the state of a Workflo
 
 Remote data encoding is using your custom Data Converter to decode (and encode) your Payloads remotely through endpoints.
 
+<!-- _Tags: [term](/tags/term), [queries](/tags/queries), [explanation](/tags/explanation)_ -->
+
+#### [Replication Lag](/dataconversion#replication-lag)
+
+The transmission delay of Workflow updates and history events from the active region to the standby region.
+
 <!-- _Tags: [term](/tags/term), [explanation](/tags/explanation)_ -->
 
 #### [Requests Per Second (RPS)](/references/dynamic-configuration#service-level-rps-limits)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -429,7 +429,7 @@ Remote data encoding is using your custom Data Converter to decode (and encode) 
 
 <!-- _Tags: [term](/tags/term), [queries](/tags/queries), [explanation](/tags/explanation)_ -->
 
-#### [Replication Lag](/cloud#replication-lag)
+#### [Replication Lag](/cloud/multi-region#replication-lag)
 
 The transmission delay of Workflow updates and history events from the active region to the standby region.
 


### PR DESCRIPTION
## What does this PR do?
This PR adds a new entry to the [Temporal Glossary](https://docs.temporal.io/glossary) for Replication Lag and closes https://temporalio.atlassian.net/browse/EDU-2602

## Notes to reviewers
I wasn't exactly sure what "category" (for lack of a better word) to locate this definition under, so I went with `cloud`.

<!-- delete if n/a -->
