### PR TITLE
EDU-3717: versioning.mdx typo 

### DIFF
--- a/docs/develop/java/versioning.mdx
+++ b/docs/develop/java/versioning.mdx
@@ -119,7 +119,7 @@ See the [Pre-release README](https://github.com/temporalio/temporal/blob/main/do
 
 :::
 A Build ID corresponds to a deployment. If you don't already have one, we recommend a hash of the code--such as a Git SHA--combined with a human-readable timestamp.
-To use [Worker Versioning](/workers#worker-versioning), you need to pass a Build ID to your Go Worker and opt in to Worker Versioning.
+To use [Worker Versioning](/workers#worker-versioning), you need to pass a Build ID to your Java Worker and opt in to Worker Versioning.
 
 ### Assign a Build ID to your Worker and opt in to Worker Versioning
 


### PR DESCRIPTION
Fix Worker typo: "Java Worker" not "Go Worker"
https://temporalio.atlassian.net/browse/EDU-3717 