### PR TITLE
EDU-3637: Match account cancellation language in pricing.mdx

### DIFF
--- a/docs/evaluate/temporal-cloud/legacy-pricing.mdx
+++ b/docs/evaluate/temporal-cloud/legacy-pricing.mdx
@@ -440,7 +440,8 @@ We charge applicable sales tax in US jurisdictions as required.
 
 **How do I cancel my account?**
 
-To cancel your Temporal Cloud account, [contact Support](https://temporalsupport.zendesk.com/).
+Account Owners can delete their account and cancel their subscription in the Plans tab in the billing center.
+See our [billing and cost](/cloud/billing-and-cost) page for details on how to access the billing center.
 
 **Will I lose access immediately if I cancel my account?**
 


### PR DESCRIPTION
## What does this PR do?
The current [pricing page](https://docs.temporal.io/cloud/pricing) directs users to contact Support if they wish to cancel their account. However, this is actually something SSU users can now do on their own.

There is already new language for this in the _new_ [pricing](https://github.com/temporalio/documentation/blob/main/docs/evaluate/temporal-cloud/pricing.mdx) page, which launches in January. But in the meantime, we are giving incorrect information.

This PR updates the "legacy" pricing page which is currently live to use the same language as the forthcoming pricing page.

Also closes https://temporalio.atlassian.net/browse/EDU-3637