### PR TITLE
updated to use Apache Cassandra in first reference, per ASF trademark guidelines

### DIFF
--- a/docs/production-deployment/self-hosted-guide/deployment.mdx
+++ b/docs/production-deployment/self-hosted-guide/deployment.mdx
@@ -2,7 +2,7 @@
 id: deployment
 title: Deploying a Temporal Service
 sidebar_label: Deployment
-description: Deploy a Temporal Service using Docker, Kubernetes, or from scratch. Requires a database like Cassandra, MySQL, or PostgreSQL. Customize setup for your infrastructure and tooling.
+description: Deploy a Temporal Service using Docker, Kubernetes, or from scratch. Requires a database such as Apache Cassandra, MySQL, or PostgreSQL. Customize setup for your infrastructure and tooling.
 slug: /self-hosted-guide/deployment
 toc_max_heading_level: 4
 keywords:
@@ -26,7 +26,7 @@ The Temporal Server depends on a database.
 
 Supported databases include the following:
 
-- [Cassandra](/self-hosted-guide/visibility#cassandra)
+- [Apache Cassandra](/self-hosted-guide/visibility#cassandra)
 - [MySQL](/self-hosted-guide/visibility#mysql)
 - [PostgreSQL](/self-hosted-guide/visibility#postgresql)
 - [SQLite](/self-hosted-guide/visibility#sqlite)


### PR DESCRIPTION
## What does this PR do?
As per EDU-3712, it updates the first page of the Self-Hosting Guide to use "Apache Cassandra" for the first reference to that database, instead of "Cassandra." This change aligns our usage with the trademark guidance from the Apache Software Foundation. 

I also changed the word preceding the list of databases in the metadata from "like" to "such as" since that list refers to specific supported databases instead of a list of possible alternatives.