### PR TITLE
fix: example link

### DIFF
--- a/docs/develop/java/schedules.mdx
+++ b/docs/develop/java/schedules.mdx
@@ -197,7 +197,7 @@ YourWorkflowInterface workflow1 =
                 .build());
 ```
 
-For more details, see the [Cron Sample](https://github.com/temporalio/samples-java/blob/main/src/main/java/io/temporal/samples/hello/HelloCron.java)
+For more details, see the [Cron Sample](https://github.com/temporalio/samples-java/blob/main/core/src/main/java/io/temporal/samples/hello/HelloCron.java)
 
 ## Start Delay {#start-delay}
 


### PR DESCRIPTION
## What does this PR do?

This PR updates the link in the documentation (docs/develop/java/schedules.mdx) to point to the correct URL for the Cron Sample in the Temporal Java SDK. The previous link was incorrect, and the updated link ensures that users can access the intended resource.