### PR TITLE
EDU-3718: Fixes typo in Java Develop coverage

### DIFF
--- a/docs/develop/java/temporal-client.mdx
+++ b/docs/develop/java/temporal-client.mdx
@@ -228,7 +228,7 @@ A Workflow Execution can be started either synchronously or asynchronously.
   ```
 
 - Asynchronous start initiates a Workflow Execution and immediately returns to the caller. This is the most common way to start Workflows in production code.
-  The `WorkflowClient` [https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java)](https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java)) provides some static methods, such as `start`, `execute`, `signalWithStart` etc., that help with starting your Workflows asynchronously.
+  The [`WorkflowClient`](https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/client/WorkflowClient.java) provides some static methods, such as `start`, `execute`, `signalWithStart` etc., that help with starting your Workflows asynchronously.
 
   The following examples show how to start Workflow Executions asynchronously, with either typed or untyped `WorkflowStub`.
 


### PR DESCRIPTION
The link to Asynchronous Workflow Execution Java Program should take the user to correct Github code.

Fixed: ![image](https://github.com/user-attachments/assets/65e895c7-c0ce-4ab8-821e-c3e3aaf8f70c)
