### PR TITLE
EDU-3747: Add Temporal Auth Scopes for web ui docker env vars

### DIFF
--- a/docs/references/web-ui-environment-variables.mdx
+++ b/docs/references/web-ui-environment-variables.mdx
@@ -30,6 +30,7 @@ docker run\
 -e TEMPORAL_AUTH_CLIENT_ID=xxxxx-xxxx.apps.googleusercontent.com\
 -e TEMPORAL_AUTH_CLIENT_SECRET=xxxxxxxxxxxxxxx\
 -e TEMPORAL_AUTH_CALLBACK_URL=https://xxxx.com:8080/auth/sso/callback\
+-e TEMPORAL_AUTH_SCOPES=openid,email,profile\
 -e TEMPORAL_UI_ENABLED=true\
 -e TEMPORAL_OPENAPI_ENABLED=true\
 -e TEMPORAL_TLS_CA=../ca.cert\

--- a/docs/references/web-ui-server-env-vars.mdx
+++ b/docs/references/web-ui-server-env-vars.mdx
@@ -25,6 +25,7 @@ docker run \
     -e TEMPORAL_AUTH_CLIENT_ID=xxxxx-xxxx.apps.googleusercontent.com \
     -e TEMPORAL_AUTH_CLIENT_SECRET=xxxxxxxxxxxxxxx \
     -e TEMPORAL_AUTH_CALLBACK_URL=https://xxxx.com:8080/auth/sso/callback \
+    -e TEMPORAL_AUTH_SCOPES=openid,email,profile \
     -e TEMPORAL_UI_ENABLED=true \
     -e TEMPORAL_OPENAPI_ENABLED=true \
     -e TEMPORAL_TLS_CA=../ca.cert \


### PR DESCRIPTION
## What does this PR do?

This adds the missing docker environment variable that's required to authenticate using an IDP, ie google as per the docs. 

Fixes #3268 

## Notes to reviewers

I had issues when using Zitadel IDP due to missing scopes. When looking into the ui-server I noticed https://github.com/temporalio/ui-server/blob/8abe1b660af4bdbe73b6fd1ecdb740c4ead29272/docker/README.md?plain=1#L22 the env, adding this resolved my issue regarding missing scopes.
