### PR TITLE
EDU-3787: Corrects two links on child-workflows Encycl page

### DIFF
--- a/docs/encyclopedia/child-workflows.mdx
+++ b/docs/encyclopedia/child-workflows.mdx
@@ -29,8 +29,8 @@ A Child Workflow Execution is a [Workflow Execution](/workflows#workflow-executi
 
 - [Go SDK Child Workflow feature guide](/develop/go/child-workflows)
 - [Java SDK Child Workflow feature guide](/develop/java/child-workflows)
-- [PHP SDK Child Workflow feature guide](/develop/php/continue-as-new)
-- [Python SDK Child Workflow feature guide](/develop/python/continue-as-new)
+- [PHP SDK Child Workflow feature guide](/develop/php/child-workflows)
+- [Python SDK Child Workflow feature guide](/develop/python/child-workflows)
 - [TypeScript SDK Child Workflow feature guide](/develop/typescript/child-workflows)
 - [.NET SDK Child Workflow feature guide](/develop/dotnet/child-workflows)
 


### PR DESCRIPTION
What it says on the package. Minimal changes. Links manually tested.