### PR TITLE
Use value_set/unset to update search attributes

### DIFF
--- a/docs/develop/python/observability.mdx
+++ b/docs/develop/python/observability.mdx
@@ -218,20 +218,20 @@ These attributes are useful for querying Workflows based on the customer ID or t
 
 You can upsert Search Attributes to add or update Search Attributes from within Workflow code.
 
-To upsert custom Search Attributes, use the [`upsert_search_attributes()`](https://python.temporal.io/temporalio.workflow.html#upsert_search_attributes) method to pass instances of `SearchAttributePair()` containing each of your keys and starting values to a parameter to a `TypedSearchAttributes()` object:
+To upsert custom Search Attributes, use the [`upsert_search_attributes()`](https://python.temporal.io/temporalio.workflow.html#upsert_search_attributes) method to pass a list of `SearchAttributeUpdate()`. These can be created via value_set calls on search attribute keys:
 
 ```python
-workflow.upsert_search_attributes(TypedSearchAttributes([
-    SearchAttributePair(customer_id_key, "customer_2")
-]))
+workflow.upsert_search_attributes([
+    customer_id_key.value_set("customer_2")
+])
 ```
 
 ### Remove a Search Attribute from a Workflow {#remove-search-attribute}
 
-To remove a Search Attribute that was previously set, set it to an empty array: `[]`.
+To remove a Search Attributes that was previously set, use a value_unset call on the search attribute key.
 
 ```python
-workflow.upsert_search_attributes(TypedSearchAttributes([
-    SearchAttributePair(customer_id_key, [])
-]))
+workflow.upsert_search_attributes([
+    customer_id_key.value_unset()
+])
 ```


### PR DESCRIPTION
## What does this PR do?

Update the docs for updating python search attributes.

## Notes to reviewers

Stumbled across this issue when trying this out for the first time and deprecated method didn't cleanly validate through pyright. Assume this is the official mechanism for updating search attributes in python now?
