### PR TITLE
EDU-1798: Re-opens ticket and fixes missing pieces

### DIFF
--- a/docs/develop/python/temporal-clients.mdx
+++ b/docs/develop/python/temporal-clients.mdx
@@ -144,6 +144,10 @@ if __name__ == "__main__":
 When you connect to [Temporal Cloud](/cloud), you need to provide additional connection and client options that include the following:
 
 - The [Temporal Cloud Namespace Id](/cloud/namespaces#temporal-cloud-namespace-id).
+   A Namespace Id is made up of a Namespace name appended by your unique five- or six-digit [Temporal Cloud Account Id](/cloud/namespaces#temporal-cloud-account-id).
+   You can find this Account Id in the URL of your Namespace and on the "Namespaces" page on the Temporal Cloud website.
+   For example, in  `https://cloud.temporal.io/namespaces/yournamespacename.a2fx6/`, your Account Id is `a2fx6`.
+   The fully qualified Namespace Id for your client with this Namespace is `yournamespacename.a2fx6`.
 - The [Namespace's gRPC endpoint](/cloud/namespaces#temporal-cloud-grpc-endpoint).
   An endpoint listing is available at the [Temporal Cloud Website](https://cloud.temporal.io/namespaces) on each Namespace detail page.
   The endpoint contains the Namespace Id and port.
@@ -176,7 +180,7 @@ async def main():
         client_private_key = f.read()
     client = await Client.connect(
         "your-custom-namespace.tmprl.cloud:7233",
-        namespace="<your-custom-namespace>.<id>",
+        namespace="<your-custom-namespace>.<account-id>",
         tls=TLSConfig(
             client_cert=client_cert,
             client_private_key=client_private_key,


### PR DESCRIPTION
Adds text regarding the Account Id that must be appended to the Namespace name to ensure a Temporal Client is correctly configured.
