### PR TITLE
EDU-3927: [Ready-to-roll] fixed curly braces in API keys doc

### DIFF
--- a/docs/production-deployment/cloud/api-keys.mdx
+++ b/docs/production-deployment/cloud/api-keys.mdx
@@ -652,14 +652,14 @@ connection.setApiKey(<APIKey>);
 Create an initial `Connection` (for use with `Client`):
 
 ```typescript
-const connection = await Connection.connect(
+const connection = await Connection.connect({
     address: <endpoint>,
     tls: true,
     metadata: {
         'Authorization': `Bearer ${<APIKey>}`,
         'temporal-namespace': <namespace_id>.<account_id>,
     },
-)
+})
 const client = new Client({
     connection,
     namespace: <namespace_id>.<account_id>,
@@ -669,14 +669,14 @@ const client = new Client({
 Create an initial Worker `NativeConnection` (for use with `Worker`):
 
 ```typescript
-const connection = await NativeConnection.connect(
+const connection = await NativeConnection.connect({
     address: <endpoint>,
     tls: true,
     metadata: {
         'Authorization': `Bearer ${<APIKey>}`
         'temporal-namespace': <namespace_id>.<account_id>,
     },
-)
+})
 const worker = await Worker.create({
     connection,
     namespace: <namespace_id>.<account_id>,


### PR DESCRIPTION
This TS call needs curly braces
