### PR TITLE
EDU-3950: fixes the typo for worker task queue

### DIFF
--- a/sample-apps/python/schedule_your_workflow/run_worker.py
+++ b/sample-apps/python/schedule_your_workflow/run_worker.py
@@ -10,7 +10,7 @@ async def main():
     client = await Client.connect("localhost:7233")
     worker = Worker(
         client,
-        task_queue="my-task-queue",
+        task_queue="schedules-task-queue",
         workflows=[YourSchedulesWorkflow],
         activities=[your_activity],
     )


### PR DESCRIPTION
## What does this PR do?
The file [`start_schedule_dacx.py`](https://github.com/temporalio/documentation/blob/6f4aab8548125c80b793d93f36a3de529cc465f9/sample-apps/python/schedule_your_workflow/start_schedule_dacx.py#L34C10-L34C51) refers to the schedule as `schedules-task-queue`, which is typed incorrectly while making the worker connection in [`run_worker.py`](https://github.com/temporalio/documentation/blob/6f4aab8548125c80b793d93f36a3de529cc465f9/sample-apps/python/schedule_your_workflow/run_worker.py#L13C9-L13C36), where it is set as:

```python
task_queue="my-task-queue"
```
This PR sets the worker's task queue as `schedules-task-queue`

