### PR TITLE
EDU-3970: Make disclosure elements more discoverable

### DIFF
--- a/docs/evaluate/temporal-cloud/pricing.mdx
+++ b/docs/evaluate/temporal-cloud/pricing.mdx
@@ -21,6 +21,8 @@ tags:
   - Support
 ---
 
+import DiscoverableDisclosure from '@site/src/components/disclosures/DiscoverableDisclosure';
+
 Temporal Cloud is a consumption-based service.
 You pay only for what you use.
 Our pricing reflects your use of [_Actions_](#action), [_Storage_](#storage), and [_Support_](/cloud/support#support).
@@ -75,11 +77,7 @@ Active and Retained Storage allocations are translated into GBh at a rate of 1GB
 Actions are the primary unit of consumption-based pricing for Temporal Cloud.
 They track billable operations within the Temporal Cloud Service, such as starting Workflows, recording a Heartbeat or sending messages.
 
-<details>
-
-<summary>
-[Toggle to View] The following operations result in Actions:
-</summary>
+<DiscoverableDisclosure label="Operations that result in Actions">
 
 **WORKFLOWS**
 
@@ -154,7 +152,7 @@ Each execution of a Schedule accrues three actions:
 - The underlying Temporal primitives (such as Workflows, Activities, and Signals) created by a Nexus Operation handler (directly or indirectly) result in the normal Actions for those primitives billed to the handler’s Namespace.
   This includes retries for underlying Temporal primitives like Activities but _not_ for handling the Nexus Operation itself or a retry of the Nexus Operation itself.
 
-</details>
+</DiscoverableDisclosure>
 
 [Reach out](https://pages.temporal.io/contact-us) to our team for more information or to help size your number of Actions.
 

--- a/src/components/disclosures/DiscoverableDisclosure.js
+++ b/src/components/disclosures/DiscoverableDisclosure.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+const DiscoverableDisclosure = ({ label = "Summary", children }) => {
+  return (
+    <details
+      style={{
+        borderRadius: '0.5rem',
+        margin: '1rem',
+        padding: '16px 24px',
+        border: '2px solid #ccc',
+        transition: '200ms',
+      }}
+    >
+      <summary
+        style={{
+          cursor: 'pointer',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'flex-start',
+          fontSize: '1.0rem',
+          padding: '8px 16px',
+          minHeight: '40px',
+          lineHeight: '1.5',
+        }}
+      >
+      Dive deeper&nbsp;—&nbsp;<strong>{label}</strong> &nbsp;&nbsp; [Toggle to Open]
+      </summary>
+
+      <div
+        style={{
+          marginTop: '5px',
+          padding: '10px',
+          borderRadius: '8px',
+          transition: 'max-height 0.3s ease-out',
+          overflow: 'hidden',
+        }}
+      >
+        {children}
+      </div>
+    </details>
+  );
+};
+
+export default DiscoverableDisclosure;


### PR DESCRIPTION
Adds external CSS to make disclosured elements (folded information) clearer to discover and use.

- Complaint is that disclosure elements (detail/summary) are not sufficiently visible or comprehensible in-line within the documentation.
- Add custom CSS so the element becomes discoverable, while remaining suitable and compliant for mobile and accessibility
- This will be incorporated in a non-design-reviewed form in High Availability work, and will be extended to the Pricing page as well.


