### PR TITLE
EDU-3972: Adds definitions in-line

### DIFF
--- a/src/components/definitions/ExpandableDefinition.js
+++ b/src/components/definitions/ExpandableDefinition.js
@@ -1,0 +1,44 @@
+const ExpandableDefinition = ({ label = "Definition", definition }) => {
+  return (
+    <span style={{ display: 'inline-flex', alignItems: 'center', whiteSpace: 'nowrap' }}>
+      <button
+        onClick={toggleDefinition}
+        style={{
+          background: 'none',
+          border: 'none',
+          color: '#007acc',
+          cursor: 'pointer',
+          fontSize: '0.9rem',
+          margin: '0 5px',
+          verticalAlign: 'middle',
+          transition: 'transform 0.3s ease-in-out',
+          transform: isOpen ? 'rotate(45deg)' : 'none',
+          display: 'inline', // Keep the button inline with the text
+        }}
+      >
+        ⊕ {/* Circled plus */}
+      </button>
+      {isOpen && (
+        <span
+          style={{
+            display: 'inline',  // Keep the definition inline as well
+            fontStyle: 'italic',
+            fontFamily: 'Georgia, serif',
+            marginLeft: '5px',
+            maxWidth: '80%',
+            padding: '5px',
+            border: '2px solid #B0B0B0',
+            borderRadius: '8px',
+            transition: 'max-height 0.3s ease-out',
+            overflow: 'hidden',
+          }}
+        >
+          <span style={{ fontWeight: 'bold' }}>
+            {label}: {/* Dynamically change the label */}
+          </span>
+          {definition}
+        </span>
+      )}
+    </span>
+  );
+};


### PR DESCRIPTION
Present definitions in-line so users don’t leave the site or the page and to boost our authority.

Tested with screen readers and on mobile.

```
import ExpandableDefinition from '@site/src/components/definitions/ExpandableDefinition';

Text starts <span class="nowrap">replica<ExpandableDefinition label="Definition" definition="Something something definition Namespace becomes unavailable." /></span>, ...more text
```

- Note that you must use the span wrap around the word and its definition to keep them together.
- The definition will push the defined word away from the comma. There’s no way to delay the definition other than using, for example, a <detail>, which is overkill here.
