### PR TITLE
Make it explicit that Update handler executes before main Workflow coroutine in Update-With-Start

### DIFF
--- a/docs/develop/go/message-passing.mdx
+++ b/docs/develop/go/message-passing.mdx
@@ -389,7 +389,7 @@ Minimum Temporal Server version [Temporal Server version 1.26](https://github.co
 [send an Update](/develop/go/message-passing#send-update-from-client) that checks whether an already-running Workflow with that ID exists:
 
 - If the Workflow exists, the Update is processed.
-- If the Workflow does not exist, a new Workflow Execution is started with the given ID, and the Update is processed immediately after.
+- If the Workflow does not exist, a new Workflow Execution is started with the given ID, and the Update is processed before the main Workflow method starts to execute.
 
 Use the [`Client.UpdateWithStartWorkflow`](https://pkg.go.dev/go.temporal.io/sdk/client#Client.UpdateWithStartWorkflow) API call.
 It returns once the requested Update wait stage has been reached; or when a provided context times out.

--- a/docs/develop/java/message-passing.mdx
+++ b/docs/develop/java/message-passing.mdx
@@ -398,7 +398,7 @@ Minimum Temporal Server version [Temporal Server version 1.26](https://github.co
 [send an Update](/develop/java/message-passing#send-update-from-client) that checks whether an already-running Workflow with that ID exists:
 
 - If the Workflow exists, the Update is processed.
-- If the Workflow does not exist, a new Workflow Execution is started with the given ID, and the Update is processed immediately after.
+- If the Workflow does not exist, a new Workflow Execution is started with the given ID, and the Update is processed before the main Workflow method starts to execute.
 
 Use the [`startUpdateWithStart`](https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowClient.html#startUpdateWithStart(io.temporal.workflow.Functions.Func,io.temporal.client.UpdateOptions,io.temporal.client.WithStartWorkflowOperation)) WorkflowClient API.
 It returns once the requested Update wait stage has been reached; or when the request times out.

--- a/docs/develop/python/message-passing.mdx
+++ b/docs/develop/python/message-passing.mdx
@@ -332,7 +332,7 @@ Minimum Temporal Server version [Temporal Server version 1.26](https://github.co
 [send an Update](/develop/python/message-passing#send-update-from-client) that checks whether an already-running Workflow with that ID exists:
 
 - If the Workflow exists, the Update is processed.
-- If the Workflow does not exist, a new Workflow Execution is started with the given ID, and the Update is processed immediately after.
+- If the Workflow does not exist, a new Workflow Execution is started with the given ID, and the Update is processed before the main Workflow method starts to execute.
 
 Use [`execute_update_with_start_workflow`](https://python.temporal.io/temporalio.client.Client.html#start_update_with_start_workflow) to start the Update and wait for the result in one go.
 

--- a/docs/develop/typescript/message-passing.mdx
+++ b/docs/develop/typescript/message-passing.mdx
@@ -367,7 +367,7 @@ Minimum Temporal Server version [Temporal Server version 1.26](https://github.co
 [send an Update](/develop/typescript/message-passing#send-update-from-client) that checks whether an already-running Workflow with that ID exists:
 
 - If the Workflow exists, the Update is processed.
-- If the Workflow does not exist, a new Workflow Execution is started with the given ID, and the Update is processed immediately after.
+- If the Workflow does not exist, a new Workflow Execution is started with the given ID, and the Update is processed before the main Workflow method starts to execute.
 
 Use [`executeUpdateWithStart`](https://typescript.temporal.io/api/classes/client.WorkflowClient#executeUpdateWithStart) to start an Update and wait for the result in one go.
 


### PR DESCRIPTION
WISOTT. Addresses request for clarification from user: https://community.temporal.io/t/clarification-how-to-use-startupdatewithstart/16575