### PR TITLE
EDU-4045: Clarify confusing language about Account Owners

### DIFF
--- a/docs/production-deployment/cloud/account-setup/users.mdx
+++ b/docs/production-deployment/cloud/account-setup/users.mdx
@@ -152,11 +152,11 @@ For a Namespace, a user can have one of the following permissions:
 
 ## How to update an account-level role in Temporal Cloud {#update-roles}
 
-With Global Admin or Account Owner privileges, you can update any user's account-level [role](#account-level-roles) using either the Web UI or `tcld`.
-This does not apply to the Account Owner role.
-For security purposes, Account Owners can only be added by existing Account Owners. 
-Other Account Owner changes must be made through Temporal Support.
-To change an Account Owner's role or delete an Account Owner, you must submit a [support ticket](https://temporalsupport.zendesk.com/).
+With Global Admin or Account Owner privileges, you can update any user's account-level [role](#account-level-roles) using either the Web UI or the tcld CLI utility.
+The Account Owner role can only be granted by existing Account owners.
+
+For security reasons, changes to the Account Owner role must be made through Temporal Support.
+To change or delete an Account Owner, you must submit a [support ticket](https://temporalsupport.zendesk.com/).
 
 {/* How to update an account-level role in Temporal Cloud using Web UI */}
 


### PR DESCRIPTION
- Only Account Owners can grant Account Owner role
- Only Support can modify/remove Account Owner role

Language okayed by @captainbeardo 