### PR TITLE
EDU-4137: Removes GCP audit logging page

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -416,7 +416,7 @@ module.exports = {
               },
               items: [
                 "production-deployment/cloud/audit-logging-aws",
-                "production-deployment/cloud/audit-logging-gcp",
+                // "production-deployment/cloud/audit-logging-gcp", // pre-release
               ],
             },
             {


### PR DESCRIPTION
Source of truth: @jumbogo and @yogeshtemporal 