### PR TITLE
EDU-4181: Corrects wrong shell environment variable name

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -153,6 +153,8 @@ This setting makes created Search Attributes immediately available.
 
 The following table describes the environment variables you can set for the Temporal CLI.
 
+<!-- This is an automatically generated file and the TEMPORAL_API_KEY correction will disappear on the next push. -->
+
 | Variable                                 | Definition                                                                | Client Option                   |
 | ---------------------------------------- | ------------------------------------------------------------------------- | ------------------------------- |
 | `TEMPORAL_ADDRESS`                       | Host and port (formatted as host:port) for the Temporal Frontend Service. | --address                       |
@@ -164,7 +166,15 @@ The following table describes the environment variables you can set for the Temp
 | `TEMPORAL_TLS_DISABLE_HOST_VERIFICATION` | Disables TLS host name verification. Default: false.                      | --tls-disable-host-verification |
 | `TEMPORAL_TLS_KEY`                       | Path to private certificate key.                                          | --tls-key-path                  |
 | `TEMPORAL_TLS_SERVER_NAME`               | Override for target TLS server name.                                      | --tls-server-name               |
-| `TEMPORAL_CLOUD_API_KEY`                 | API key used for authentication.                                          | --api-key                       |
+| `TEMPORAL_API_KEY`                       | API key used for authentication.                                          | --api-key                       |
+
+<!-- This is an automatically generated file and this caution will disappear on the next push. -->
+<!-- issue: https://github.com/temporalio/cli/issues/776 -->
+:::tip ENVIRONMENT VARIABLES
+
+Do not confuse environment variables, set with your shell, with temporal env options.
+
+:::
 
 ## Proxy support
 

--- a/docs/production-deployment/cloud/api-keys.mdx
+++ b/docs/production-deployment/cloud/api-keys.mdx
@@ -357,8 +357,8 @@ Authenticate with Temporal Cloud using API keys with the following clients:
 
 ### Temporal CLI
 
-To use your API key with the Temporal CLI, either pass it with the `--api-key` flag or set an environment variable (recommended).
-The CLI automatically picks up the `TEMPORAL_CLOUD_API_KEY` environment variable.
+To use your API key with the Temporal CLI, either pass it with the `--api-key` flag or set an environment variable in your shell (recommended).
+The CLI automatically picks up the `TEMPORAL_API_KEY` environment variable from your shell.
 
 In addition to the API key, the following client options are required:
 
@@ -382,6 +382,12 @@ temporal workflow list \
     --grpc-meta "temporal-namespace=<namespace_id>.<account_id>" \
     --tls
 ```
+
+:::tip ENVIRONMENT VARIABLES
+
+Do not confuse environment variables, set with your shell, with temporal env options.
+
+:::
 
 ### SDK
 
@@ -672,7 +678,13 @@ const worker = await Worker.create({
 To use an API key with `tcld`, choose one of these methods:
 
 - Use the `--api-key` flag.
-- Set the `TEMPORAL_CLOUD_API_KEY` environment variable.
+- Set the `TEMPORAL_API_KEY` environment variable in your shell.
+
+:::tip ENVIRONMENT VARIABLES
+
+Do not confuse environment variables, set with your shell, with temporal env options.
+
+:::
 
 ### Cloud Ops API
 

--- a/docs/production-deployment/cloud/terraform-provider.mdx
+++ b/docs/production-deployment/cloud/terraform-provider.mdx
@@ -55,8 +55,14 @@ Export your environment variable for secure access to the API Keys.
 
 ```bash
 # replace <your-secret-key> with the "secretKey": output from tcld apikey create command
-export TEMPORAL_CLOUD_API_KEY=<your-secret-key>
+export TEMPORAL_API_KEY=<your-secret-key>
 ```
+
+:::tip ENVIRONMENT VARIABLES
+
+Do not confuse environment variables, set with your shell, with temporal env options.
+
+:::
 
 </TabItem>
   <TabItem value="windows" label="Windows">
@@ -64,8 +70,14 @@ Export your environment variable for secure access to the API Keys.
 
 ```bash
 # replace <your-secret-key> with the "secretKey": output from tcld apikey create command
-set TEMPORAL_CLOUD_API_KEY=<your-secret-key>
+set TEMPORAL_API_KEY=<your-secret-key>
 ```
+
+:::tip ENVIRONMENT VARIABLES
+
+Do not confuse environment variables, set with your shell, with temporal env options.
+
+:::
 
 </TabItem>
 </Tabs>


### PR DESCRIPTION
Note: This includes the landing page for /cli, which is an auto-generated document. Issue has been filed with CLI team
