### PR TITLE
update Nexus docs for attaching multiple callers and Java SDK GA support

### DIFF
--- a/docs/develop/go/temporal-nexus.mdx
+++ b/docs/develop/go/temporal-nexus.mdx
@@ -192,17 +192,9 @@ var HelloOperation = temporalnexus.NewWorkflowRunOperation(service.HelloOperatio
 Workflow IDs should typically be business meaningful IDs and are used to dedupe Workflow starts.
 For the `HelloOperation`, `input.ID` is passed as part of the Nexus Service contract.
 
-:::tip
+:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-[Pre-release feature](/evaluate/development-production-features/release-stages#pre-release): Attaching multiple Nexus callers to an underlying handler Workflow.
-
-When using `temporalnexus.NewWorkflowRunOperation` to start a handler Workflow with a [Workflow-Id-Conflict-Policy](/workflows#workflow-id-conflict-policy) of Use-Existing
-all caller Workflows will have completion Callbacks attached to the underlying handler Workflow.
-The initial caller Workflow will be linked from the handler's [WorkflowExecutionStarted](/references/events#workflowexecutionstarted) event and
-additional callers will be attached to the handler's [WorkflowExecutionOptionsUpdated](/references/events#workflowexecutionoptionsupdated) event.
-
-When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks will be copied to the new Workflow-Execution
-and the previous Workflow-Execution's completion Callback will be left in the Standby state indefinitely.
+[Attaching multiple Nexus callers to a handler Workflow](/nexus/operations#attaching-multiple-nexus-callers) using a [Conflict-Policy of Use-Existing](/workflows#workflow-id-conflict-policy) is a [Pre-release feature](/evaluate/development-production-features/release-stages#pre-release).
 
 :::
 

--- a/docs/develop/go/temporal-nexus.mdx
+++ b/docs/develop/go/temporal-nexus.mdx
@@ -192,6 +192,20 @@ var HelloOperation = temporalnexus.NewWorkflowRunOperation(service.HelloOperatio
 Workflow IDs should typically be business meaningful IDs and are used to dedupe Workflow starts.
 For the `HelloOperation`, `input.ID` is passed as part of the Nexus Service contract.
 
+:::tip
+
+[Pre-release feature](/evaluate/development-production-features/release-stages#pre-release): Attaching multiple Nexus callers to an underlying handler Workflow.
+
+When using `temporalnexus.NewWorkflowRunOperation` to start a handler Workflow with a [Workflow-Id-Conflict-Policy](/workflows#workflow-id-conflict-policy) of Use-Existing
+all caller Workflows will have completion Callbacks attached to the underlying handler Workflow.
+The initial caller Workflow will be linked from the handler's [WorkflowExecutionStarted](/references/events#workflowexecutionstarted) event and
+additional callers will be attached to the handler's [WorkflowExecutionOptionsUpdated](/references/events#workflowexecutionoptionsupdated) event.
+
+When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks and bi-directional Links will be copied to the new Workflow-Execution
+and the previous Workflow-Execution's completion Callback will be left in the Standby state indefinitely.
+
+:::
+
 ### Register a Nexus Service in a Worker
 
 After developing an asynchronous Nexus Operation handler to start a Workflow, the next step is to register a Nexus Service in a Worker.

--- a/docs/develop/go/temporal-nexus.mdx
+++ b/docs/develop/go/temporal-nexus.mdx
@@ -201,7 +201,7 @@ all caller Workflows will have completion Callbacks attached to the underlying h
 The initial caller Workflow will be linked from the handler's [WorkflowExecutionStarted](/references/events#workflowexecutionstarted) event and
 additional callers will be attached to the handler's [WorkflowExecutionOptionsUpdated](/references/events#workflowexecutionoptionsupdated) event.
 
-When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks and bi-directional Links will be copied to the new Workflow-Execution
+When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks will be copied to the new Workflow-Execution
 and the previous Workflow-Execution's completion Callback will be left in the Standby state indefinitely.
 
 :::

--- a/docs/develop/java/temporal-nexus.mdx
+++ b/docs/develop/java/temporal-nexus.mdx
@@ -275,17 +275,9 @@ public class NexusServiceImpl {
 
 Workflow IDs should typically be business meaningful IDs and are used to dedupe Workflow starts. In general business meaningful IDs should be passed in the Operation input as part of the Nexus Service contract.
 
-:::tip
+:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-[Pre-release feature](/evaluate/development-production-features/release-stages#pre-release): Attaching multiple Nexus callers to an underlying handler Workflow.
-
-When using `WorkflowRunOperation.fromWorkflowMethod` to start a handler Workflow with a [Workflow-Id-Conflict-Policy](/workflows#workflow-id-conflict-policy) of Use-Existing
-all caller Workflows will have completion Callbacks attached to the underlying handler Workflow.
-The initial caller Workflow will be linked from the handler's [WorkflowExecutionStarted](/references/events#workflowexecutionstarted) event and
-additional callers will be attached to the handler's [WorkflowExecutionOptionsUpdated](/references/events#workflowexecutionoptionsupdated) event.
-
-When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks will be copied to the new Workflow-Execution
-and the previous Workflow-Execution's completion Callback will be left in the Standby state indefinitely.
+[Attaching multiple Nexus callers to a handler Workflow](/nexus/operations#attaching-multiple-nexus-callers) using a [Conflict-Policy of Use-Existing](/workflows#workflow-id-conflict-policy) is a [Pre-release feature](/evaluate/development-production-features/release-stages#pre-release).
 
 :::
 

--- a/docs/develop/java/temporal-nexus.mdx
+++ b/docs/develop/java/temporal-nexus.mdx
@@ -284,8 +284,8 @@ all caller Workflows will have completion Callbacks attached to the underlying h
 The initial caller Workflow will be linked from the handler's [WorkflowExecutionStarted](/references/events#workflowexecutionstarted) event and
 additional callers will be attached to the handler's [WorkflowExecutionOptionsUpdated](/references/events#workflowexecutionoptionsupdated) event.
 
-When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks and bi-directional Links will be
-copied to the new Workflow-Execution and the previous Workflow-Execution's completion Callback will be left in the Standby state indefinitely.
+When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks will be copied to the new Workflow-Execution
+and the previous Workflow-Execution's completion Callback will be left in the Standby state indefinitely.
 
 :::
 

--- a/docs/develop/java/temporal-nexus.mdx
+++ b/docs/develop/java/temporal-nexus.mdx
@@ -17,7 +17,7 @@ import { CaptionedImage } from '@site/src/components';
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-Temporal Java SDK support for Nexus is in [Public Preview](/evaluate/development-production-features/release-stages#public-preview).
+Temporal Java SDK support for Nexus is now [Generally Available](/evaluate/development-production-features/release-stages#general-availability).
 
 :::
 
@@ -233,7 +233,7 @@ public class NexusServiceImpl {
 
 ### Develop an Asynchronous Nexus Operation handler to start a Workflow
 
-Use the `WorkflowClientOperationHandlers.fromWorkflowMethod` method, which is the easiest way to expose a Workflow as an operation.
+Use the `WorkflowRunOperation.fromWorkflowMethod` method, which is the easiest way to expose a Workflow as an operation.
 
 <!--SNIPSTART samples-java-nexus-handler {"selectedLines": ["1-5", "18-40"]}-->
 
@@ -274,6 +274,20 @@ public class NexusServiceImpl {
 <!--SNIPEND-->
 
 Workflow IDs should typically be business meaningful IDs and are used to dedupe Workflow starts. In general business meaningful IDs should be passed in the Operation input as part of the Nexus Service contract.
+
+:::tip
+
+[Pre-release feature](/evaluate/development-production-features/release-stages#pre-release): Attaching multiple Nexus callers to an underlying handler Workflow.
+
+When using `WorkflowRunOperation.fromWorkflowMethod` to start a handler Workflow with a [Workflow-Id-Conflict-Policy](/workflows#workflow-id-conflict-policy) of Use-Existing
+all caller Workflows will have completion Callbacks attached to the underlying handler Workflow.
+The initial caller Workflow will be linked from the handler's [WorkflowExecutionStarted](/references/events#workflowexecutionstarted) event and
+additional callers will be attached to the handler's [WorkflowExecutionOptionsUpdated](/references/events#workflowexecutionoptionsupdated) event.
+
+When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks and bi-directional Links will be
+copied to the new Workflow-Execution and the previous Workflow-Execution's completion Callback will be left in the Standby state indefinitely.
+
+:::
 
 ### Register a Nexus Service in a Worker
 

--- a/docs/encyclopedia/nexus-operations.mdx
+++ b/docs/encyclopedia/nexus-operations.mdx
@@ -327,3 +327,20 @@ Task Routing is the simplest way to version your service code.
 If you have a new backward-incompatible Nexus Operation Handler, for example due to a wire-level incompatible breaking change, start by using a different Service and Task Queue.
 The version may be part of the service name, for example `prod.payments.v2`.
 Callers can then migrate to the new version in their normal deployment schedule.
+
+## Attaching multiple Nexus callers to a handler Workflow {#attaching-multiple-nexus-callers}
+
+:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
+
+Using a [Conflict-Policy of Use-Existing](/workflows#workflow-id-conflict-policy) with the [New-Workflow-Run-Operation](/nexus/operations#sdk-support) SDK helper is currently a [Pre-release](/evaluate/development-production-features/release-stages#pre-release) feature.
+
+:::
+
+Nexus Operations that start a Workflow with the [New-Workflow-Run-Operation](/nexus/operations#sdk-support) SDK helper will automatically attach a completion Callback on the handler Workflow, so the Nexus caller recieves the result.
+Additional Nexus callers may attach to the same handler Workflow if the Nexus handler uses a [Conflict-Policy of Use-Existing](/workflows#workflow-id-conflict-policy).
+
+A single handler Workflow Execution has a [Callback limit](/workflows#workflow-execution-callback-limits) that governs how many Nexus callers can be attached.
+Nexus callers that exceed the limit will recieve an error.
+
+When a handler Workflow uses [Continue-As-New](/workflows#continue-as-new) the existing Nexus completion Callbacks will be copied to the new Workflow Execution
+and the previous Workflow Execution's completion Callbacks will be left in the Standby state indefinitely.

--- a/docs/encyclopedia/nexus.mdx
+++ b/docs/encyclopedia/nexus.mdx
@@ -91,3 +91,13 @@ This means you don't have to use Nexus RPC directly, only the Temporal SDK along
 Nexus supports multi-level Nexus calls, for example:
 
 - Workflow A → Nexus Operation 1 → Workflow B → Nexus Operation 2 → Workflow C
+
+## Pre-release features
+
+:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
+
+The following Nexus features are currently in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
+
+:::
+
+- [Attaching multiple Nexus callers to a handler Workflow](/nexus/operations#attaching-multiple-nexus-callers)

--- a/docs/encyclopedia/workflows.mdx
+++ b/docs/encyclopedia/workflows.mdx
@@ -448,6 +448,15 @@ These limits are set with the following [dynamic configuration keys](https://git
 - `NumPendingSignalsLimit`
 - `NumPendingCancelRequestsLimit`
 
+#### Workflow Execution Callback limits {#workflow-execution-callback-limits}
+
+There is a limit to the total number of Workflow Callbacks that may be attached to a single Workflow Execution (by default, 32 Workflow Callbacks).
+Attaching [multiple Nexus callers to a handler Workflow](/nexus/operations#attaching-multiple-nexus-callers) may exceed these limits.
+
+These limits can be set with the following [dynamic configuration keys](https://github.com/temporalio/temporal/blob/main/common/dynamicconfig/constants.go#L924) :
+
+- MaxCallbacksPerWorkflow
+
 #### Workflow Execution Nexus Operation Limits {#workflow-execution-nexus-operation-limits}
 
 There is a limit to the maximum number of Nexus Operations in a Workflow before Continue-As-New is required.

--- a/docs/evaluate/temporal-cloud/limits.mdx
+++ b/docs/evaluate/temporal-cloud/limits.mdx
@@ -303,6 +303,16 @@ It warns you after 10,240 Events or 10 MB.
 This limit applies to all Temporal Workflow Executions, whether on Temporal Cloud or other deployments.
 Read more about [Temporal Workflow Execution limits](/workflows#limits) on the [Temporal Workflow](/workflows) documentation page.
 
+### Per Workflow Callback limits
+
+**What is the maximum number of Callbacks that can be attached to a single Workflow Execution?**
+
+A single Workflow Execution can have a maximum of 32 total Callbacks.
+
+These limits may be exceeded when [multiple Nexus callers attach to the same handler Workflow](/nexus/operations#attaching-multiple-nexus-callers).
+
+See the Nexus Encyclopedia entry for [additional details](/workflows#workflow-execution-callback-limits).
+
 ### Per Workflow Nexus Operation limits {#per-workflow-nexus-operation-limits}
 
 **What is the maximum number of Nexus Operations that can be started from a single Workflow Execution?**

--- a/docs/references/events.mdx
+++ b/docs/references/events.mdx
@@ -139,6 +139,18 @@ This Event type contains last [Workflow Execution](/workflows#workflow-execution
 | memo                             | Non-indexed information to show in the Workflow.                                                              |
 | search_attributes                | Provides data for setting up a Workflow's [Search Attributes](/search-attribute).                             |
 
+### WorkflowExecutionOptionsUpdated
+
+This [Event](/workflows#event) type indicates that the Workflow options have been updated.
+The Event type contains updated options such as a versioning override or attached completion callbacks.
+
+| Field                            | Description                                                                                                            |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| versioning_override              | Versioning override upserted in this event. Ignored if nil or if unset_versioning_override is true.                    |
+| unset_versioning_override        | Versioning override removed in this event.                                                                             |
+| attached_request_id              | Request ID attached to the running workflow execution so subsequent requests with the same request ID will be deduped. |
+| attached_completion_callbacks    | Completion callbacks attached to the running workflow execution.                                                       |
+
 ### WorkflowTaskScheduled
 
 This [Event](/workflows#event) type indicates that the [Workflow Task](/tasks#workflow-task) has been scheduled.

--- a/docs/references/events.mdx
+++ b/docs/references/events.mdx
@@ -45,6 +45,7 @@ It indicates that the Temporal Service received a request to spawn the Workflow 
 | search_attributes                  | Provides data for setting up a Workflow's [Search Attributes](/search-attribute).                                                                              |
 | prev_auto_reset_points             |                                                                                                                                                                |
 | header                             | Information passed by the sender of the [Signal](/sending-messages#sending-signals) that is copied into the [Workflow Task](/tasks#workflow-task).             |
+| completion_callbacks               | Completion callbacks attached when this workflow was started.                                                                                                  |
 
 ### WorkflowExecutionCompleted
 

--- a/docs/references/failures.mdx
+++ b/docs/references/failures.mdx
@@ -261,7 +261,7 @@ A Nexus Operation Failure includes the following fields:
 - Endpoint is set to the name of the endpoint.
 - Service is set to the name of the service.
 - Operation is set to the name of the operation.
-- Operation_id is set to the id of the operation, if this is an async operation.
+- Operation_token is set if this is an async operation, which can be used to perform additional actions like cancelling the operation.
 - Scheduled_event_id is set to the caller’s event id that scheduled the operation.
 - Message is set to a generic unsuccessful error message.
 - Cause is set to the underlying Application Failure with the following fields:


### PR DESCRIPTION
## What does this PR do?
 - updates Nexus docs for attaching multiple caller workflows (pre-release feature)
 - Java SDK support for Nexus is GA!