### PR TITLE
EDU-4195: Audit site for semantically broken Markdown links and fix

### DIFF
--- a/docs/evaluate/temporal-cloud/pricing.mdx
+++ b/docs/evaluate/temporal-cloud/pricing.mdx
@@ -395,7 +395,7 @@ Use the resulting Storage and compute measurements to project your production sc
 
 The examples below provide general estimates based on workload size.
 You can also use our calculator on the pricing page to build your estimate.
-Our team is always happy to [help you estimate costs] (https://pages.temporal.io/contact-us) for your specific workloads and requirements.
+Our team is always happy to [help you estimate costs](https://pages.temporal.io/contact-us) for your specific workloads and requirements.
 
 | Workload size | Cost (monthly) | Characteristics                            | Actions                                            | Typical use cases                                                                                             |
 | ------------- | -------------- | ------------------------------------------ | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |

--- a/docs/tctl-v1/workflow.mdx
+++ b/docs/tctl-v1/workflow.mdx
@@ -2063,7 +2063,7 @@ There are three allowed values:
 
 - [AllowDuplicateFailedOnly](/workflows#workflow-id-reuse-policy)
 - [AllowDuplicate](/workflows#workflow-id-reuse-policy)
-- [RejectDuplicate] (/concepts/what-is-a-workflow-id-reuse-policy)
+- [RejectDuplicate](/workflows#workflow-id-reuse-policy)
 
 **Examples**
 


### PR DESCRIPTION
Finds links formatted as `[text] (link)` with a space breaking Markdown formatting.

Also fix outdated link to concepts because that section no longer exists and one of the typos predates a lot of IA work