### PR TITLE
EDU-4199: Convert tables of instructions to tabs

### DIFF
--- a/docs/production-deployment/cloud/high-availability/enable.mdx
+++ b/docs/production-deployment/cloud/high-availability/enable.mdx
@@ -19,7 +19,7 @@ keywords:
   - term
 ---
 
-import { ToolTipTerm, DocsTable, NewDocsCell } from '@site/src/components';
+import { ToolTipTerm } from '@site/src/components';
 
 You can enable High Availability features for a new or existing Namespace by adding a replica.
 When you add a replica, Temporal Cloud begins the replication of ongoing and existing Workflow Executions.
@@ -61,38 +61,25 @@ This page explains how to enable and manage these features.
 To create a new Namespace with High Availability features, you can use the Temporal Cloud UI or the tcld command line utility.
 The following table explains how:
 
-<DocsTable
-  Columns = {[
-    "Approach",
-    "Instructions"
-  ]}
->
+<Tabs>
 
-<!-- --Web UI-- -->
+<TabItem value="webui" label="Web UI">
 
-**Web UI**
+    1. Visit Temporal Cloud in your Web browser.
+    1. During Namespace creation, specify the primary [region](/cloud/high-availability/regions) for the Namespace.
+    1. Select "Add a replica":
+       - Adding a replica in the same region enables Same-region Replication.
+       - Adding a replica in a different region (within the same continent) replicates across regions for Multi-region Replication.
+       - You cannot create a Multi-region deployment on separate continents.
 
-<NewDocsCell />
+    The web interface will present an estimated time for replication to complete.
+    This time is based on your selection and the size and scale of the Workflows in your Namespace.
 
-1. Visit Temporal Cloud in your Web browser.
-1. During Namespace creation, specify the primary [region](/cloud/high-availability/regions) for the Namespace.
-1. Select "Add a replica":
-   - Adding a replica in the same region enables Same-region Replication.
-   - Adding a replica in a different region (within the same continent) replicates across regions for Multi-region Replication.
-   - You cannot create a Multi-region deployment on separate continents.
+    Temporal Cloud sends an email alert once your Namespace is ready for use.
 
-The web interface will present an estimated time for replication to complete.
-This time is based on your selection and the size and scale of the Workflows in your Namespace.
+</TabItem>
 
-Temporal Cloud sends an email alert once your Namespace is ready for use.
-
-<NewDocsCell />
-
-<!-- --tcld-- -->
-
-**tcld**
-
-<NewDocsCell />
+<TabItem value="tcldcli" label="tcld">
 
 At the command line, enter:
 
@@ -111,7 +98,10 @@ Specify the [region codes](/cloud/high-availability/regions) as arguments to the
 
 If using API key authentication with the `--api-key` flag, you must add it directly after the tcld command and before `namespace create`.
 
-</DocsTable>
+
+</TabItem>
+
+</Tabs>
 
 :::caution
 
@@ -128,18 +118,9 @@ Adding a replica unlocks that functionality.
 
 The following table explains how:
 
-<DocsTable
-  Columns = {[
-    "Approach",
-    "Instructions"
-  ]}
->
+<Tabs>
 
-<!-- --Web UI-- -->
-
-**Web UI**
-
-<NewDocsCell />
+<TabItem value="webui" label="Web UI">
 
 1. Visit Temporal Cloud Namespaces in your Web browser.
 1. Navigate to the Namespace details page.
@@ -153,13 +134,9 @@ This time is based on your selection and the size and scale of the Workflows in 
 
 Temporal Cloud sends an email alert once your Namespace is ready for use.
 
-<NewDocsCell />
+</TabItem>
 
-<!-- --tcld-- -->
-
-**tcld**
-
-<NewDocsCell />
+<TabItem value="tcldcli" label="tcld">
 
 At the command line, enter:
 
@@ -179,7 +156,9 @@ If using API key authentication with the `--api-key` flag, you must add it direc
 
 Temporal Cloud sends an email alert once your Namespace is ready for use.
 
-</DocsTable>
+</TabItem>
+
+</Tabs>
 
 ## Change a replica location {#changing}
 
@@ -206,29 +185,16 @@ You will receive an email alert once your Namespace is ready for use.
 Removing a Namespace replica disables High Availability and automatic failover features.
 Follow these steps to disable these features and end High Availability charges:
 
-<DocsTable
-  Columns = {[
-    "Approach",
-    "Instructions"
-  ]}
->
+<Tabs>
 
-<!-- --Web UI-- -->
-
-**Web UI**
-
-<NewDocsCell />
+<TabItem value="webui" label="Web UI">
 
 1. Navigate to the Namespace details page in Temporal Cloud
 1. Select the option to "Remove Replica" on the "Region" card.
 
-<NewDocsCell />
+</TabItem>
 
-<!-- --tcld-- -->
-
-**tcld**
-
-<NewDocsCell />
+<TabItem value="tcldcli" label="tcld">
 
 At the command line, enter:
 
@@ -240,7 +206,9 @@ tcld namespace delete-region \
 
 If using API key authentication with the `--api-key` flag, you must add it directly after the tcld command and before `namespace delete-region`
 
-</DocsTable>
+</TabItem>
+
+</Tabs>
 
 After following these instructions, Temporal Cloud deletes the replica.
 Your Namespace will no longer use High Availability features and you will no longer be charged for this feature.

--- a/docs/production-deployment/cloud/high-availability/how-to/failovers.mdx
+++ b/docs/production-deployment/cloud/high-availability/how-to/failovers.mdx
@@ -19,7 +19,7 @@ keywords:
   - term
 ---
 
-import { ToolTipTerm, DiscoverableDisclosure, DocsTable, NewDocsCell } from '@site/src/components';
+import { ToolTipTerm, DiscoverableDisclosure } from '@site/src/components';
 
 Temporal Cloud automatically initiates failovers when an incident or outage affects a Namespace with High Availability features.
 Namespace replicas duplicate data and prevent data loss during failover.
@@ -47,31 +47,18 @@ A forced failover when there is a significant replication lag has a higher likel
 You can trigger a failover manually using the Temporal&nbsp;Cloud<br />Web&nbsp;UI or the tcld CLI, depending on your preference and setup.
 The following table outlines the steps for each method:
 
-<DocsTable
-Columns = {[
-"Approach",
-"Instructions"
-]}
->
+<Tabs>
 
-<!-- --Web UI-- -->
-
-**Web UI**
-
-<NewDocsCell />
+<TabItem value="webui" label="Web UI">
 
 1. Visit the [Namespace page](https://cloud.temporal.io/namespaces) on the Temporal Cloud Web UI.
 1. Navigate to your Namespace details page and select the **Trigger a failover** option from the menu.
 1. Confirm your action.
    After confirmation, Temporal initiates the failover.
 
-<NewDocsCell />
+</TabItem>
 
-<!-- --tcld-- -->
-
-**tcld**
-
-<NewDocsCell />
+<TabItem value="tcldcli" label="tcld">
 
 To manually trigger a failover, run the following command in your terminal:
 
@@ -83,7 +70,9 @@ tcld namespace failover \
 
 If using API key authentication with the `--api-key` flag, you must add it directly after the tcld command and before `namespace failover`.
 
-</DocsTable>
+</TabItem>
+
+</Tabs>
 
 Temporal fails over the primary to the replica.
 When you're ready to fail back, follow these failover instructions to move the primary back to the original.
@@ -115,29 +104,16 @@ _This is the recommended and default option._
 
 However if you prefer to disable Temporal-initiated failovers and handle your own failovers, you can do so by following these instructions:
 
-<DocsTable
-Columns = {[
-"Approach",
-"Instructions"
-]}
->
+<Tabs>
 
-<!-- --Web UI-- -->
-
-**Web UI**
-
-<NewDocsCell />
+<TabItem value="webui" label="Web UI">
 
 1. Navigate to the Namespace detail page in Temporal Cloud.
 1. Choose the "Disable Temporal-initiated failovers" option.
 
-<NewDocsCell />
+</TabItem>
 
-<!-- --tcld-- -->
-
-**tcld**
-
-<NewDocsCell />
+<TabItem value="tcldcli" label="tcld">
 
 To disable Temporal-initiated failovers, run the following command in your terminal:
 
@@ -149,7 +125,9 @@ tcld namespace update-high-availability \
 
 If using API key authentication with the `--api-key` flag, you must add it directly after the tcld command and before `namespace update-high-availability`
 
-</DocsTable>
+</TabItem>
+
+</Tabs>
 
 Temporal Cloud disables its health-check initiated failovers.
 To restore the default behavior, unselect the option in the WebUI or change `true` to `false` in the CLI command.


### PR DESCRIPTION
@brianmacdonald-temporal and @atihkin both hated the instructions-in-tables approach.

All tables used in High Availability are now updated to use tabbed instructions: Web UI and tcld.

![image](https://github.com/user-attachments/assets/b39c07fd-8929-4b5c-8535-7ba0cb2ca416)
![image](https://github.com/user-attachments/assets/87419729-5972-4c00-8e06-c9346550482f)

versus

![image](https://github.com/user-attachments/assets/f48f6afc-7df1-45e2-9fdf-75715816001b)

