### PR TITLE
add redirect for performance-bottlenecks

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1949,6 +1949,11 @@
       "source": "/cloud/pricing#multi-region",
       "destination": "/cloud/pricing#high-availability-features",
       "permanent": true
+    },
+    {
+      "source": "/production-deployment/cloud/metrics/performance-bottlenecks",
+      "destination": "/troubleshooting/performance-bottlenecks",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?
The old link https://docs.temporal.io/production-deployment/cloud/metrics/performance-bottlenecks that was published was move to https://docs.temporal.io/troubleshooting/performance-bottlenecks.

Added a redirect.
