### PR TITLE
Update private connectivty testing steps to include API keys

### DIFF
--- a/docs/evaluate/temporal-cloud/aws-privatelink.mdx
+++ b/docs/evaluate/temporal-cloud/aws-privatelink.mdx
@@ -122,7 +122,7 @@ When connecting, you must override the TLS server name to target your Namespaceâ
 
 - Temporal SDKs, by setting the endpoint server address argument to the PrivateLink endpoint (`<DNS associated with VPC endpoint>:7233`) and using the TLS configuration options to override the TLS server name.
 
-When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`):
+When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`) using one of the following methods:
 
 - The Temporal CLI, using `--tls-server-name` parameter to override the TLS server name and the `--tls` flag to enforce the use of TLS. For example:
 
@@ -135,7 +135,7 @@ When using [API keys for namespace authentication](/cloud/api-keys#namespace-aut
       --tls
   ```
 
-- Non-Temporal tools like grpcURL, setting the `authorization` and `temporal-namespace` headers, and the `-servername` parameter to override the TLS server name. Forexample:
+- Non-Temporal tools like grpcURL, setting the `authorization` and `temporal-namespace` headers, and the `-servername` parameter to override the TLS server name. For example:
 
   ```
   grpcurl \

--- a/docs/evaluate/temporal-cloud/aws-privatelink.mdx
+++ b/docs/evaluate/temporal-cloud/aws-privatelink.mdx
@@ -120,15 +120,28 @@ When connecting, you must override the TLS server name to target your Namespaceâ
       temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
   ```
 
-- Temporal SDKs, by setting the endpoint server address argument to the PrivateLink endpoint (`<DNS associated with VPC endpoint>:7233`) and using the TLS configuration options to override the TLS server name.
+- Temporal SDKs, by setting the endpoint server address argument to the Private Service Connect endpoint (`<IP address of the PSC endpoint>:7233`) and using the TLS configuration options to override the TLS server name.
 
 When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`):
 
+- The Temporal CLI, using `--tls-server-name` parameter to override the TLS server name and the `--tls` flag to enforce the use of TLS. For example:
+
   ```
   temporal workflow count \
-      --address <DNS associated with VPC endpoint>:7233 \
+      --address <IP address of the PSC endpoint>:7233 \
       --namespace <namespace> \
       --api-key <api_key> \
       --tls-server-name <region>.<cloud_provider>.temporal.io \
       --tls
+  ```
+
+- Non-Temporal tools like grpcURL, setting the `authorization` and `temporal-namespace` headers, and the `-servername` parameter to override the TLS server name. Forexample:
+
+  ```
+  grpcurl \
+      -H "authorization: Bearer <api_key>" \
+      -H "temporal-namespace: <namespace>.<account>" \
+      -servername <region>.<cloud_provider>.api.temporal.io:7233 \
+      <DNS ASSOCIATED WITH VPC ENDPOINT> \
+      temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
   ```

--- a/docs/evaluate/temporal-cloud/aws-privatelink.mdx
+++ b/docs/evaluate/temporal-cloud/aws-privatelink.mdx
@@ -128,10 +128,10 @@ When using [API keys for namespace authentication](/cloud/api-keys#namespace-aut
 
   ```
   temporal workflow count \
-      --address <IP address of the PSC endpoint>:7233 \
-      --namespace <namespace> \
+      --address <DNS associated with VPC endpoint>:7233 \
+      --namespace <namespace>.<account> \
       --api-key <api_key> \
-      --tls-server-name <region>.<cloud_provider>.temporal.io \
+      --tls-server-name <region>.<cloud_provider>.api.temporal.io \
       --tls
   ```
 
@@ -141,7 +141,7 @@ When using [API keys for namespace authentication](/cloud/api-keys#namespace-aut
   grpcurl \
       -H "authorization: Bearer <api_key>" \
       -H "temporal-namespace: <namespace>.<account>" \
-      -servername <region>.<cloud_provider>.api.temporal.io:7233 \
-      <DNS ASSOCIATED WITH VPC ENDPOINT> \
+      -servername <region>.<cloud_provider>.api.temporal.io \
+      <DNS ASSOCIATED WITH VPC ENDPOINT>:7233 \
       temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
   ```

--- a/docs/evaluate/temporal-cloud/aws-privatelink.mdx
+++ b/docs/evaluate/temporal-cloud/aws-privatelink.mdx
@@ -121,3 +121,14 @@ When connecting, you must override the TLS server name to target your Namespaceâ
   ```
 
 - Temporal SDKs, by setting the endpoint server address argument to the PrivateLink endpoint (`<DNS associated with VPC endpoint>:7233`) and using the TLS configuration options to override the TLS server name.
+
+When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`):
+
+  ```
+  temporal workflow count \
+      --address <DNS associated with VPC endpoint>:7233 \
+      --namespace <namespace> \
+      --api-key <api_key> \
+      --tls-server-name <region>.<cloud_provider>.temporal.io \
+      --tls
+  ```

--- a/docs/evaluate/temporal-cloud/aws-privatelink.mdx
+++ b/docs/evaluate/temporal-cloud/aws-privatelink.mdx
@@ -120,7 +120,7 @@ When connecting, you must override the TLS server name to target your Namespaceâ
       temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
   ```
 
-- Temporal SDKs, by setting the endpoint server address argument to the Private Service Connect endpoint (`<IP address of the PSC endpoint>:7233`) and using the TLS configuration options to override the TLS server name.
+- Temporal SDKs, by setting the endpoint server address argument to the PrivateLink endpoint (`<DNS associated with VPC endpoint>:7233`) and using the TLS configuration options to override the TLS server name.
 
 When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`):
 

--- a/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
+++ b/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
@@ -112,3 +112,14 @@ When connecting, you must override the TLS server name to target your Namespaceâ
   ```
 
 - Temporal SDKs, by setting the endpoint server address argument to the Private Service Connect endpoint (`<IP address of the PSC endpoint>:7233`) and using the TLS configuration options to override the TLS server name.
+
+When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`):
+
+  ```
+  temporal workflow count \
+      --address <IP address of the PSC endpoint>:7233 \
+      --namespace <namespace> \
+      --api-key <api_key> \
+      --tls-server-name <region>.<cloud_provider>.temporal.io \
+      --tls
+  ```

--- a/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
+++ b/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
@@ -120,9 +120,9 @@ When using [API keys for namespace authentication](/cloud/api-keys#namespace-aut
   ```
   temporal workflow count \
       --address <IP address of the PSC endpoint>:7233 \
-      --namespace <namespace> \
+      --namespace <namespace>.<account> \
       --api-key <api_key> \
-      --tls-server-name <region>.<cloud_provider>.temporal.io \
+      --tls-server-name <region>.<cloud_provider>.api.temporal.io \
       --tls
   ```
 
@@ -132,7 +132,7 @@ When using [API keys for namespace authentication](/cloud/api-keys#namespace-aut
   grpcurl \
       -H "authorization: Bearer <api_key>" \
       -H "temporal-namespace: <namespace>.<account>" \
-      -servername <region>.<cloud_provider>.api.temporal.io:7233 \
-      <IP address of the PSC endpoint> \
+      -servername <region>.<cloud_provider>.api.temporal.io \
+      <IP address of the PSC endpoint>:7233 \
       temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
   ```

--- a/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
+++ b/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
@@ -115,6 +115,8 @@ When connecting, you must override the TLS server name to target your Namespaceâ
 
 When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`):
 
+- The Temporal CLI, using `--tls-server-name` parameter to override the TLS server name and the `--tls` flag to enforce the use of TLS. For example:
+
   ```
   temporal workflow count \
       --address <IP address of the PSC endpoint>:7233 \
@@ -122,4 +124,15 @@ When using [API keys for namespace authentication](/cloud/api-keys#namespace-aut
       --api-key <api_key> \
       --tls-server-name <region>.<cloud_provider>.temporal.io \
       --tls
+  ```
+
+- Non-Temporal tools like grpcURL, setting the `authorization` and `temporal-namespace` headers, and the `-servername` parameter to override the TLS server name. Forexample:
+
+  ```
+  grpcurl \
+      -H "authorization: Bearer <api_key>" \
+      -H "temporal-namespace: <namespace>.<account>" \
+      -servername <region>.<cloud_provider>.api.temporal.io:7233 \
+      <IP address of the PSC endpoint> \
+      temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo
   ```

--- a/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
+++ b/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
@@ -113,7 +113,7 @@ When connecting, you must override the TLS server name to target your Namespaceâ
 
 - Temporal SDKs, by setting the endpoint server address argument to the Private Service Connect endpoint (`<IP address of the PSC endpoint>:7233`) and using the TLS configuration options to override the TLS server name.
 
-When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`):
+When using [API keys for namespace authentication](/cloud/api-keys#namespace-authentication), the TLS server name must be set to the Namespace's gRPC endpoint (`<region>.<cloud_provider>.api.temporal.io`) using one of the following methods:
 
 - The Temporal CLI, using `--tls-server-name` parameter to override the TLS server name and the `--tls` flag to enforce the use of TLS. For example:
 
@@ -126,7 +126,7 @@ When using [API keys for namespace authentication](/cloud/api-keys#namespace-aut
       --tls
   ```
 
-- Non-Temporal tools like grpcURL, setting the `authorization` and `temporal-namespace` headers, and the `-servername` parameter to override the TLS server name. Forexample:
+- Non-Temporal tools like grpcURL, setting the `authorization` and `temporal-namespace` headers, and the `-servername` parameter to override the TLS server name. For example:
 
   ```
   grpcurl \


### PR DESCRIPTION
The current documentation only has instructions for testing PrivateLink/PSC when using mTLS authentication. This PR adds instructions for testing with API keys.