### PR TITLE
cleanup Nexus encyclopedia flow

### DIFF
--- a/docs/encyclopedia/nexus-endpoints.mdx
+++ b/docs/encyclopedia/nexus-endpoints.mdx
@@ -49,7 +49,3 @@ The Temporal Nexus [EndpointSpec](https://github.com/temporalio/api/blob/2a5b395
 ## Deploying a Nexus Endpoint
 
 Adding a Nexus Endpoint to the [Nexus Registry](/nexus/registry) deploys the Endpoint in the Temporal Service, so it is available at runtime to serve Nexus requests.
-
-## Terraform support in Temporal Cloud
-
-The [Terraform provider for Temporal Cloud](/production-deployment/cloud/terraform-provider#manage-temporal-cloud-nexus-endpoints-with-terraform) supports managing Nexus Endpoints.

--- a/docs/encyclopedia/nexus-registry.mdx
+++ b/docs/encyclopedia/nexus-registry.mdx
@@ -126,3 +126,15 @@ In Temporal Cloud, access to the Nexus Registry is controlled with the following
   - Namespace Admin permission on the Endpoint's target Namespace
 
   See [Nexus Security in Temporal Cloud](/cloud/nexus/security) for more information.
+
+## Terraform and Ops API support
+
+Nexus Endpoint provisioning and lifecycle management may be automated with Terraform or the Ops API.
+
+:::tip RESOURCES
+
+- [Terraform support](/production-deployment/cloud/terraform-provider#manage-temporal-cloud-nexus-endpoints-with-terraform) for Temporal Cloud.
+- [Cloud Ops API](/ops) for Temporal Cloud.
+- [Operator API](https://github.com/temporalio/api/blob/master/temporal/api/operatorservice/v1/service.proto) for self-hosted deployments.
+
+:::


### PR DESCRIPTION
## What does this PR do?
- moved Terraform/Ops API info from Nexus Endpoint page to the bottom of the Nexus Registry page for better flow.
- adds a link to the OperatorService API for self-hosted deployments