### PR TITLE
EDU-4374: Change redirect for tctl content from /cli to /tctl-v1

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -27,7 +27,7 @@
     },
     {
       "source": "/system-tools/:path*",
-      "destination": "/cli",
+      "destination": "/tctl-v1",
       "permanent": true
     },
     {


### PR DESCRIPTION
Moves tctl redirects back from Temporal CLI and to the deprecated (but accessible) tctl-v1 pages as some users continue to use this content after deprecation