### PR TITLE
Consolidate event history docs and modernize Continue as New encyclopedia

### DIFF
--- a/docs/develop/python/continue-as-new.mdx
+++ b/docs/develop/python/continue-as-new.mdx
@@ -81,7 +81,7 @@ See the [`all_handlers_finished`](message-passing#wait-for-message-handlers) exa
 
 ## When is it right to Continue-as-New using the Python SDK? {#when}
 
-Use Continue-as-New when your Workflow might hit [Event History Limits](/workflow-execution/event#event-history).
+Use Continue-as-New when your Workflow might hit degraded performance or [Event History Limits](/workflow-execution/event#event-history).
 
 Temporal tracks your Workflow's progress against these limits to let you know when you should Continue-as-New.
 Call `workflow.info().is_continue_as_new_suggested()` to check if it's time.

--- a/docs/encyclopedia/workflow/workflow-execution/continue-as-new.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/continue-as-new.mdx
@@ -15,17 +15,18 @@ tags:
 
 This page discusses [Continue-As-New](#continue-as-new) and how to tell [when](#when) you would want to use it.
 
+## What is Continue-As-New? {#continue-as-new}
+
 Continue-As-New allows you to checkpoint your Workflow's state and start a fresh Workflow.
 
 There are two main problems this practice can prevent:
 
-- A Workflow Execution with a long, or large [Event History](workflow-execution#event-history), such as one calling many activities, may bog down and have performance issues.
-  It could even generate more events than allowed by the [Event History limits](/encyclopedia/workflow/workflow-execution/events#event-history-limits).
+- A Workflow Execution with a long, or large [Event History](/workflow-execution/event#event-history), such as one calling many activities, may bog down and have performance issues.
+  It could even generate more events than allowed by the [Event History limits](/workflow-execution/event#event-history-limits).
 - A Workflow Execution can hit [Workflow Versioning](/workflow-definition#workflow-versioning) problems if it started running on an older version of your code.
 
-## What is Continue-As-New? {#continue-as-new}
-
-Continue-As-New lets you checkpoint the latest relevant state in a Workflow Execution and pass it to a new Execution in the [Execution Chain](/workflow-execution#workflow-execution-chain).
+Pass your latest relevant state into Continue-As-New.
+This checkpoints it and passes it to a new Execution in the [Execution Chain](/workflow-execution#workflow-execution-chain).
 This state is passed in through your Workflow's parameters.
 The parameters are typically optional and left unset by the original caller of the Workflow.
 

--- a/docs/encyclopedia/workflow/workflow-execution/continue-as-new.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/continue-as-new.mdx
@@ -13,41 +13,44 @@ tags:
   - Workflows
 ---
 
-This page discusses [Continue-As-New](#continue-as-new).
+This page discusses [Continue-As-New](#continue-as-new) and how to tell [when](#when) you would want to use it.
 
-A Workflow Execution may run for an arbitrarily long period of time, during which it could potentially generate more events than allowed by the Event History.
-The Continue-As-New feature offers a potential solution for this, since it enables the progress to continue in a subsequent Workflow Execution with a fresh Event History.
-You can repeat this as often as needed, which means that your Workflow can effectively run in perpetuity.
+Continue-As-New allows you to checkpoint your Workflow's state and start a fresh Workflow.
+
+There are two main problems this practice can prevent:
+
+- A Workflow Execution with a long, or large [Event History](workflow-execution#event-history), such as one calling many activities, may bog down and have performance issues.
+  It could even generate more events than allowed by the [Event History limits](/encyclopedia/workflow/workflow-execution/events#event-history-limits).
+- A Workflow Execution can hit [Workflow Versioning](/workflow-definition#workflow-versioning) problems if it started running on an older version of your code.
 
 ## What is Continue-As-New? {#continue-as-new}
 
-Continue-As-New is a mechanism by which the latest relevant state is passed to a new Workflow Execution, with a fresh Event History.
+Continue-As-New lets you checkpoint the latest relevant state in a Workflow Execution and pass it to a new Execution in the [Execution Chain](/workflow-execution#workflow-execution-chain).
+This state is passed in through your Workflow's parameters.
+The parameters are typically optional and left unset by the original caller of the Workflow.
 
-:::caution
+The new Workflow Execution has the same Workflow Id, but a different Run Id, and starts its own Event History.
 
-As a precautionary measure, the Workflow Execution's Event History is limited to [51,200 Events](https://github.com/temporalio/temporal/blob/e3496b1c51bfaaae8142b78e4032cc791de8a76f/service/history/configs/config.go#L382) or [50 MB](https://github.com/temporalio/temporal/blob/e3496b1c51bfaaae8142b78e4032cc791de8a76f/service/history/configs/config.go#L380) and will warn you after 10,240 Events or 10 MB.
+You can repeat Continue-As-New as often as needed, which means that your Workflow can run in perpetuity.
+Workflows that do this are often called Entity Workflows because they represent durable objects, not just processes.
 
-:::
+- [How to Continue-As-New using the Go SDK](/develop/go/continue-as-new#how)
+- [How to Continue-As-New using the Java SDK](/develop/java/continue-as-new#how)
+- [How to Continue-As-New using the PHP SDK](/develop/php/continue-as-new#how)
+- [How to Continue-As-New using the Python SDK](/develop/python/continue-as-new#how)
+- [How to Continue-As-New using the TypeScript SDK](/develop/typescript/continue-as-new#how)
+- [How to Continue-As-New using the .NET SDK](/develop/dotnet/continue-as-new#how)
 
-To prevent a Workflow Execution Event History from exceeding this limit and failing, use Continue-As-New to start a new Workflow Execution with a fresh Event History.
+## When is it right to Continue-As-New? {#when}
 
-All values passed to a Workflow Execution through parameters or returned through a result value are recorded into the Event History.
-The Temporal Service stores the full Event History of a Workflow Execution for the duration of a Namespace's retention period.
-A Workflow Execution that periodically executes many Activities has the potential of hitting the size limit.
+To prevent scalability problems, periodically check Continue As New Suggested in your Workflow.\
+Temporal will tell your Workflow when it's approaching performance or scalability problems.
 
-A very large Event History can adversely affect the performance of a Workflow Execution.
-For example, in the case of a Workflow Worker failure, the full Event History must be pulled from the Temporal Service and given to another Worker via a Workflow Task.
-If the Event history is very large, it may take some time to load it.
+To help prevent versioning problems for long-running Workflows, you may also want to Continue-as-New after a certain amount of time has elapsed. This will make sure every Workflow began on a recent version of your source code.
 
-The Continue-As-New feature enables developers to complete the current Workflow Execution and start a new one atomically.
-
-The new Workflow Execution has the same Workflow Id, but a different Run Id, and has its own Event History.
-
-In the case of [Temporal Cron Jobs](/cron-job), Continue-As-New is actually used internally for the same effect.
-
-- [How to Continue-As-New using the Go SDK](/develop/go/continue-as-new)
-- [How to Continue-As-New using the Java SDK](/develop/java/continue-as-new)
-- [How to Continue-As-New using the PHP SDK](/develop/php/continue-as-new)
-- [How to Continue-As-New using the Python SDK](/develop/python/continue-as-new)
-- [How to Continue-As-New using the TypeScript SDK](/develop/typescript/continue-as-new)
-- [How to Continue-As-New using the .NET SDK](/develop/dotnet/continue-as-new)
+- [Determine when to Continue-As-New using the Go SDK](/develop/go/continue-as-new#when)
+- [Determine when to Continue-As-New using the Java SDK](/develop/java/continue-as-new#when)
+- [Determine when to Continue-As-New using the PHP SDK](/develop/php/continue-as-new#when)
+- [Determine when to Continue-As-New using the Python SDK](/develop/python/continue-as-new#when)
+- [Determine when to Continue-As-New using the TypeScript SDK](/develop/typescript/continue-as-new#when)
+- [Determine when to Continue-As-New using the .NET SDK](/develop/dotnet/continue-as-new#when)

--- a/docs/encyclopedia/workflow/workflow-execution/event.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/event.mdx
@@ -77,7 +77,7 @@ The Workflow Execution is terminated when the Event History:
 - contains more than 2000 Updates.
 - contains more than 10000 Signals.
 
-You can use the [Continue-As-New](/workflow-execution/continue-as-new) feature to close the current Workflow Execution and create a new Workflow Execution.
+To avoid hitting these limits, you can use the [Continue-As-New](/workflow-execution/continue-as-new) feature to close the current Workflow Execution and create a new one.
 
 ### Event loop {#event-loop}
 

--- a/docs/encyclopedia/workflow/workflow-execution/event.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/event.mdx
@@ -77,6 +77,8 @@ The Workflow Execution is terminated when the Event History:
 - contains more than 2000 Updates.
 - contains more than 10000 Signals.
 
+You can use the [Continue-As-New](/workflow-execution/continue-as-new) feature to close the current Workflow Execution and create a new Workflow Execution.
+
 ### Event loop {#event-loop}
 
 A Workflow Execution is made up of a sequence of [Events](#event) called an [Event History](#event-history).
@@ -90,19 +92,11 @@ Events are created by the Temporal Service in response to either Commands or act
 
 **Is there a limit to how long Workflows can run?**
 
-No, there is no time constraint on how long a Workflow Execution can be Running.
+No, there is no time constraint on how long a Workflow Execution can run.
 
-However, Workflow Executions intended to run indefinitely should be written with some care.
-The Temporal Service stores the complete Event History for the entire lifecycle of a Workflow Execution.
-The Temporal Service logs a warning after 10Ki (10,240) Events and periodically logs additional warnings as new Events are added.
-If the Event History exceeds 50Ki (51,200) Events, the Workflow Execution is terminated.
+However, Workflow Executions intended to run indefinitely should be written with some care as they can run into [Event History limits](#event-history-limits).
 
-To prevent _runaway_ Workflow Executions, you can use the Workflow Execution Timeout, the Workflow Run Timeout, or both.
-A Workflow Execution Timeout can be used to limit the duration of Workflow Execution Chain, and a Workflow Run Timeout can be used to limit the duration an individual Workflow Execution (Run).
-
-You can use the [Continue-As-New](/workflow-execution/continue-as-new) feature to close the current Workflow Execution and create a new Workflow Execution in a single atomic operation.
-The Workflow Execution spawned from Continue-As-New has the same Workflow Id, a new Run Id, and a fresh Event History and is passed all the appropriate parameters.
-For example, it may be reasonable to use Continue-As-New once per day for a long-running Workflow Execution that is generating a large Event History.
+They can also hit [Workflow Versioning](/workflow-definition#workflow-versioning) problems. As such, it can be a good idea to [Continue-As-New](/workflow-execution/continue-as-new) periodically to make sure that all of your running Workflows began on recent versions of your code.
 
 ## What is a Reset? {#reset}
 


### PR DESCRIPTION
## What does this PR do?

* Removes duplicate references to event history length.
* Removes extraneous other documentation that is better addressed in other places.
* Adds advice about versioning long-running workflows.
* Modernizes continue-as-new overview to harmonize with the new per-SDK docs.
* Tweaks python continue-as-new docs to give better advice.

## Notes to reviewers

## Test plan

`yarn start`
http://localhost:3000/workflow-execution/continue-as-new
Click on things
http://localhost:3000/workflow-execution/event#event-history-limits
Click on things


<!-- delete if n/a -->
