### PR TITLE
Correct num_pollers for Go

### DIFF
--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -102,7 +102,7 @@ Some keys may not be available in every SDK, and Histogram metrics may have diff
 | [long_request](#long_request)                                                           | Service Client | Counter     | Core, Go, Java |
 | [long_request_failure](#long_request_failure)                                           | Service Client | Counter     | Core, Go, Java |
 | [long_request_latency](#long_request_latency)                                           | Service Client | Histogram   | Core, Go, Java |
-| [num_pollers](#num_pollers)                                                             | Worker         | Gauge       | Core           |
+| [num_pollers](#num_pollers)                                                             | Worker         | Gauge       | Core, Go       |
 | [poller_start](#poller_start)                                                           | Worker         | Counter     | Go, Java       |
 | [request](#request)                                                                     | Service Client | Counter     | Core, Go, Java |
 | [request_failure](#request_failure)                                                     | Service Client | Counter     | Core, Go, Java |
@@ -273,7 +273,7 @@ Latency of a Temporal Client gRPC long poll request.
 Current number of Worker Entities that are polling.
 
 - Type: Gauge
-- Available in: Core
+- Available in: Core, Go
 - Tags: `namespace`, `poller_type`, `task_queue`
 
 ### poller_start


### PR DESCRIPTION
## What does this PR do?
Corrects `num_pollers` for Go. The docs don't mention that this metric is available in Go. It has been available in [Go](https://github.com/temporalio/sdk-go/commit/86b0ef6559ed811e50a2c220bae5a25c408a33ca) for over 3 years 

closes https://github.com/temporalio/documentation/issues/3575
<!-- delete if n/a -->
