### PR TITLE
remove extra accent character from create search attribute command

### DIFF
--- a/docs/production-deployment/self-hosted-guide/visibility.mdx
+++ b/docs/production-deployment/self-hosted-guide/visibility.mdx
@@ -773,7 +773,7 @@ To create custom Search Attributes in your self-hosted Temporal Service Visibili
 For example, to create a Search Attribute called `CustomSA` of type `Keyword`, run the following command:
 
 ```
-temporal operator search-attribute create --name="CustomSA" --type="Keyword"`
+temporal operator search-attribute create --name="CustomSA" --type="Keyword"
 ```
 
 Note that if you use a SQL database with advanced Visibility capabilities, you are required to specify a Namespace when creating a custom Search Attribute.


### PR DESCRIPTION
There was an extra accent on this command at the end.

This pr simply removes that unnecessary accent
