### PR TITLE
Add gcp us-central1 to docs

### DIFF
--- a/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
+++ b/docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx
@@ -62,6 +62,7 @@ Set up Private Service Connect with Temporal Cloud with these steps:
   | -------------- | ------------------------------------------------------------------------------------------ |
   | `asia-south1`  | `projects/prod-d5spc2sfeshws33bg33vwdef7/regions/asia-south1/serviceAttachments/pl-7w7tw`  |
   | `europe-west3` | `projects/prod-kwy7d4faxp6qgrgd9x94du36g/regions/europe-west3/serviceAttachments/pl-acgsh` |
+  | `us-central1`  | `projects/prod-d9ch6v2ybver8d2a8fyf7qru9/regions/us-central1/serviceAttachments/pl-5xzn`   |
   | `us-east4`     | `projects/prod-y399cvr9c2b43es2w3q3e4gvw/regions/us-east4/serviceAttachments/pl-8awsy`     |
   | `us-west1`     | `projects/prod-rbe76zxxzydz4cbdz2xt5b59q/regions/us-west1/serviceAttachments/pl-94w0x`     |
 

--- a/docs/production-deployment/cloud/references/regions/gcpregions.md
+++ b/docs/production-deployment/cloud/references/regions/gcpregions.md
@@ -1,5 +1,6 @@
 | Area          | Code         | Region            | Notes                                          |
 | ------------- | ------------ | ----------------- | ---------------------------------------------- |
+| North America | us-central1  | Iowa              | Does not support<br /> Same-region Replication |
 | North America | us-west1     | Oregon            | Does not support<br /> Same-region Replication |
 | North America | us-east4     | Northern Virginia | Does not support<br /> Same-region Replication |
 | Europe        | europe-west3 | Frankfurt         | Does not support<br /> Multi-region or <br />Same-region Replication |

--- a/docs/production-deployment/cloud/references/regions/private-service.md
+++ b/docs/production-deployment/cloud/references/regions/private-service.md
@@ -1,4 +1,5 @@
 | Region                 | Private Service Connect Service Name                                                      |
 | ---------------------- | ----------------------------------------------------------------------------------------- |
 | `asia-south1`          | `projects/prod-d5spc2sfeshws33bg33vwdef7/regions/asia-south1/serviceAttachments/pl-7w7tw` |
+| `us-central1`          | `projects/prod-d9ch6v2ybver8d2a8fyf7qru9/regions/us-central1/serviceAttachments/pl-5xzn`   |
 | `us-west1   `          | `projects/prod-rbe76zxxzydz4cbdz2xt5b59q/regions/us-west1/serviceAttachments/pl-94w0x`    |


### PR DESCRIPTION
## What does this PR do?
add us-central1 to docs

## Notes to reviewers
Not sure if each of these files should be updaes or if docs/production-deployment/cloud/references/regions/private-service.md should also include all the regions in docs/evaluate/temporal-cloud/gcp-private-service-connect.mdx

