### PR TITLE
Revamp Java/PHP/TS Continue-as-New documentation

### DIFF
--- a/docs/develop/java/continue-as-new.mdx
+++ b/docs/develop/java/continue-as-new.mdx
@@ -55,7 +55,7 @@ ClusterManagerResult run(ClusterManagerInput input);
 ````
 The test hook in the above snippet is covered [below](#how-to-test).
 
-Inside your Workflow, call the [`continue_as_new()`](https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#continueAsNew(io.temporal.workflow.ContinueAsNewOptions,java.lang.Object...)) function with the same type.
+Inside your Workflow, call the [`continueAsNew()`](https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#continueAsNew(io.temporal.workflow.ContinueAsNewOptions,java.lang.Object...)) function with the same type.
 This stops the Workflow right away and starts a new one.
 
 <div class="copycode-notice-container">

--- a/docs/develop/java/continue-as-new.mdx
+++ b/docs/develop/java/continue-as-new.mdx
@@ -2,58 +2,111 @@
 id: continue-as-new
 title: Continue-As-New - Java SDK
 sidebar_label: Continue-As-New
-toc_max_heading_level: 4
+description: Learn how to use Temporal's Continue-As-New in Java to manage large Event Histories by atomically creating new Workflow Executions with the same Workflow Id and fresh parameters.
+toc_max_heading_level: 2
 keywords:
-  - continue-as-new
+  - continue-as-new workflow
+  - restart workflow
+  - fresh event history
+  - avoid large event histories
+  - temporal java continue-as-new
 tags:
   - Workflows
   - continue-as-new
   - Java SDK
   - Temporal SDKs
-description: Learn how to use Continue-As-New with the Java SDK to manage Workflow Executions efficiently in Temporal, ensuring optimal Event History management and flexible Workflow transitions.
 ---
 
-This page shows how to Continue-As-New using the Java SDK.
+This page answers the following questions for Java developers:
 
-[Continue-As-New](/workflow-execution/continue-as-new) enables a Workflow Execution to close successfully and create a new Workflow Execution in a single atomic operation if the number of Events in the Event History is becoming too large.
-The Workflow Execution spawned from the use of Continue-As-New has the same Workflow Id, a new Run Id, and a fresh Event History and is passed all the appropriate parameters.
+- [What is Continue-As-New?](#what)
+- [How to Continue-As-New?](#how)
+- [When is it right to Continue-as-New?](#when)
+- [How to test Continue-as-New?](#how-to-test)
 
-Temporal SDK allows you to use [Continue-As-New](/workflow-execution/continue-as-new) in various ways.
+## What is Continue-As-New? {#what}
 
-To continue execution of the same Workflow that is currently running, use:
+[Continue-As-New](/workflow-execution/continue-as-new) lets a Workflow Execution close successfully and creates a new Workflow Execution.
+You can think of it as a checkpoint when your Workflow gets too long or approaches certain scaling limits.
+
+The new Workflow Execution is in the same [chain](/workflow-execution#workflow-execution-chain); it keeps the same Workflow Id but gets a new Run Id and a fresh Event History.
+It also receives your Workflow's usual parameters.
+
+## How to Continue-As-New using the Java SDK {#how}
+
+First, design your Workflow parameters so that you can pass in the "current state" when you Continue-As-New into the next Workflow run.
+This state is typically set to `None` for the original caller of the Workflow.
+
+<div class="copycode-notice-container">
+  <a href="https://github.com/temporalio/samples-java/blob/main/core/src/main/java/io/temporal/samples/safemessagepassing/ClusterManagerWorkflow.java">
+    View the source code
+  </a>{' '}
+  in the context of the rest of the application code.
+</div>
+```java
+class ClusterManagerInput {
+  private final Optional<ClusterManagerState> state;
+  private final boolean testContinueAsNew;
+}
+
+@WorkflowMethod
+ClusterManagerResult run(ClusterManagerInput input);
+
+````
+The test hook in the above snippet is covered [below](#how-to-test).
+
+Inside your Workflow, call the [`continue_as_new()`](https://javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#continueAsNew(io.temporal.workflow.ContinueAsNewOptions,java.lang.Object...)) function with the same type.
+This stops the Workflow right away and starts a new one.
+
+<div class="copycode-notice-container">
+  <a href="https://github.com/temporalio/samples-java/blob/main/core/src/main/java/io/temporal/samples/safemessagepassing/ClusterManagerWorkflowImpl.java">
+    View the source code
+  </a>{' '}
+  in the context of the rest of the application code.
+</div>
+```java
+Workflow.continueAsNew(
+  new ClusterManagerInput(Optional.of(state), input.isTestContinueAsNew()));
+````
+
+### Considerations for Workflows with Message Handlers {#with-message-handlers}
+
+If you use Updates or Signals, don't call Continue-as-New from the handlers.
+Instead, wait for your handlers to finish in your main Workflow before you run `continue_as_new`.
+See the [`all_handlers_finished`](message-passing#wait-for-message-handlers) example for guidance.
+
+## When is it right to Continue-as-New using the Java SDK? {#when}
+
+Use Continue-as-New when your Workflow might hit [Event History Limits](/workflow-execution/event#event-history).
+
+Temporal tracks your Workflow's progress against these limits to let you know when you should Continue-as-New.
+Call `Workflow.getInfo().isContinueAsNewSuggested()` to check if it's time.
+
+## How to test Continue-as-New using the Java SDK {#how-to-test}
+
+Testing Workflows that naturally Continue-as-New may be time-consuming and resource-intensive.
+Instead, add a test hook to check your Workflow's Continue-as-New behavior faster in automated tests.
+
+For example, when `testContinueAsNew == true`, this sample creates a test-only variable called `maxHistoryLength` and sets it to a small value.
+A helper method in the Workflow checks it each time it considers using Continue-as-New:
+
+<div class="copycode-notice-container">
+  <a href="https://github.com/temporalio/samples-java/blob/main/core/src/main/java/io/temporal/samples/safemessagepassing/ClusterManagerWorkflowImpl.java">
+    View the source code
+  </a>{' '}
+  in the context of the rest of the application code.
+</div>
 
 ```java
-Workflow.continueAsNew(input1, ...);
+private boolean shouldContinueAsNew() {
+  if (Workflow.getInfo().isContinueAsNewSuggested()) {
+    return true;
+  }
+  // This is just for ease-of-testing.  In production, we trust temporal to tell us when to
+  // continue as new.
+  if (maxHistoryLength > 0 && Workflow.getInfo().getHistoryLength() > maxHistoryLength) {
+    return true;
+  }
+  return false;
+}
 ```
-
-To continue execution of a currently running Workflow as a completely different Workflow Type, use `Workflow.newContinueAsNewStub()`.
-For example, in a Workflow class called `YourWorkflow`, we can create a Workflow stub with a different type, and call its Workflow method to continue execution as that type:
-
-```java
-MyOtherWorkflow continueAsNew = Workflow.newContinueAsNewStub(MyOtherWorkflow.class);
-coninueAsNew.greet(input);
-```
-
-To provide `ContinueAsNewOptions` options in `Workflow.newContinueAsNewStub()` use:
-
-```java
-ContinueAsNewOptions options = ContinueAsNewOptions.newBuilder()
-        .setTaskQueue("newTaskQueueName")
-        .build();
-
-MyOtherWorkflow continueAsNew = Workflow.newContinueAsNewStub(MyOtherWorkflow.class, options);
-// ...
-continueAsNew.greet(input);
-```
-
-Providing these options allows you to continue Workflow Execution as a new Workflow run, with a different Workflow Type, and on a different Task Queue.
-
-Java Workflow reference: [https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/package-summary.html](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/package-summary.html)
-
-:::warning Using Continue-as-New and Updates
-
-- Temporal _does not_ support Continue-as-New functionality within Update handlers.
-- Complete all handlers _before_ using Continue-as-New.
-- Use Continue-as-New from your main Workflow Definition method, just as you would complete or fail a Workflow Execution.
-
-:::

--- a/docs/develop/php/continue-as-new.mdx
+++ b/docs/develop/php/continue-as-new.mdx
@@ -2,50 +2,121 @@
 id: continue-as-new
 title: Continue-As-New - PHP SDK
 sidebar_label: Continue-As-New
-slug: /develop/php/continue-as-new
+description: Learn how to use Temporal's Continue-As-New in PHP to manage large Event Histories by atomically creating new Workflow Executions with the same Workflow Id and fresh parameters.
 toc_max_heading_level: 2
 keywords:
-  - continue-as-new
+  - continue-as-new workflow
+  - restart workflow
+  - fresh event history
+  - avoid large event histories
+  - temporal php continue-as-new
 tags:
   - Workflows
   - continue-as-new
   - PHP SDK
   - Temporal SDKs
-description: Learn how to use Continue-As-New to manage large Event Histories in Workflow Execution by creating a new execution with the same Workflow Id but a fresh Event History.
 ---
 
-## How to Continue-As-New {#continue-as-new}
+This page answers the following questions for PHP developers:
 
-[Continue-As-New](/workflow-execution/continue-as-new) enables a Workflow Execution to close successfully and create a new Workflow Execution in a single atomic operation if the number of Events in the Event History is becoming too large.
-The Workflow Execution spawned from the use of Continue-As-New has the same Workflow Id, a new Run Id, and a fresh Event History and is passed all the appropriate parameters.
+- [What is Continue-As-New?](#what)
+- [How to Continue-As-New?](#how)
+- [When is it right to Continue-as-New?](#when)
+- [How to test Continue-as-New?](#how-to-test)
 
-Workflows that need to rerun periodically could naively be implemented as a big **while** loop with a sleep where the entire logic of the Workflow is inside the body of the **while** loop.
-The problem with this approach is that the history for that Workflow will keep growing to a point where it reaches the maximum size enforced by the service.
+## What is Continue-As-New? {#what}
 
-**ContinueAsNew** is the low level construct that enables implementing such Workflows without the risk of failures down the road.
-The operation atomically completes the current execution and starts a new execution of the Workflow with the same **Workflow Id**.
-The new execution will not carry over any history from the old execution.
+[Continue-As-New](/workflow-execution/continue-as-new) lets a Workflow Execution close successfully and creates a new Workflow Execution.
+You can think of it as a checkpoint when your Workflow gets too long or approaches certain scaling limits.
 
-To trigger this behavior, use `Workflow::continueAsNew` or `Workflow::newContinueAsNewStub` method:
+The new Workflow Execution is in the same [chain](/workflow-execution#workflow-execution-chain); it keeps the same Workflow Id but gets a new Run Id and a fresh Event History.
+It also receives your Workflow's usual parameters.
+
+## How to Continue-As-New using the PHP SDK {#how}
+
+First, design your Workflow parameters so that you can pass in the "current state" when you Continue-As-New into the next Workflow run.
+This state is typically set to `None` for the original caller of the Workflow.
+
+<div class="copycode-notice-container">
+  <a href="https://github.com/temporalio/samples-php/blob/master/app/src/SafeMessageHandlers/MessageHandlerWorkflowInterface.php">
+    View the source code
+  </a>{' '}
+  in the context of the rest of the application code.
+</div>
+```php
+final class ClusterManagerInput {
+    public function __construct(
+        public ?ClusterManagerState $state = null,
+        public bool $testContinueAsNew = false,
+    ) {}
+}
+
+#[Workflow\WorkflowInterface]
+interface MessageHandlerWorkflowInterface
+{
+    #[Workflow\WorkflowMethod]
+    public function run(ClusterManagerInput $input);
+}
+
+````
+The test hook in the above snippet is covered [below](#how-to-test).
+
+Inside your Workflow, call the [`continueAsNew()`](https://php.temporal.io/classes/Temporal-Workflow.html#method_continueAsNew) function with the same type.
+This stops the Workflow right away and starts a new one.
+
+<div class="copycode-notice-container">
+  <a href="https://github.com/temporalio/samples-php/blob/master/app/src/SafeMessageHandlers/MessageHandlerWorkflow.php">
+    View the source code
+  </a>{' '}
+  in the context of the rest of the application code.
+</div>
+```php
+Workflow::continueAsNew(
+    Workflow::getInfo()->type->name,
+    [new ClusterManagerInput($this->state, $input->testContinueAsNew)],
+);
+````
+
+### Considerations for Workflows with Message Handlers {#with-message-handlers}
+
+If you use Updates or Signals, don't call Continue-as-New from the handlers.
+Instead, wait for your handlers to finish in your main Workflow before you run `continue_as_new`.
+See the [`all_handlers_finished`](message-passing#wait-for-message-handlers) example for guidance.
+
+## When is it right to Continue-as-New using the PHP SDK? {#when}
+
+Use Continue-as-New when your Workflow might hit [Event History Limits](/workflow-execution/event#event-history).
+
+Temporal tracks your Workflow's progress against these limits to let you know when you should Continue-as-New.
+Call `Workflow::getInfo()->shouldContinueAsNew` to check if it's time.
+
+## How to test Continue-as-New using the PHP SDK {#how-to-test}
+
+Testing Workflows that naturally Continue-as-New may be time-consuming and resource-intensive.
+Instead, add a test hook to check your Workflow's Continue-as-New behavior faster in automated tests.
+
+For example, when `testContinueAsNew == true`, this sample creates a test-only variable called `$this->maxHistoryLength` and sets it to a small value.
+A helper method in the Workflow checks it each time it considers using Continue-as-New:
+
+<div class="copycode-notice-container">
+  <a href="https://github.com/temporalio/samples-php/blob/master/app/src/SafeMessageHandlers/MessageHandlerWorkflow.php">
+    View the source code
+  </a>{' '}
+  in the context of the rest of the application code.
+</div>
 
 ```php
-#[Workflow\WorkflowMethod]
-public function periodic(string $name, int $value = 0)
+private function shouldContinueAsNew(): bool
 {
-    for ($i = 0; $i < 100; $i++) {
-        // do something
-        $value++;
+    if (Workflow::getInfo()->shouldContinueAsNew) {
+        return true;
     }
 
-    // maintain $value counter between runs
-    return Workflow::newContinueAsNewStub(self::class)->periodic($name, $value);
+    // This is just for ease-of-testing.  In production, we trust temporal to tell us when to continue as new.
+    if ($this->maxHistoryLength !== null && Workflow::getInfo()->historyLength > $this->maxHistoryLength) {
+        return true;
+    }
+
+    return false;
 }
 ```
-
-:::warning Using Continue-as-New and Updates
-
-- Temporal _does not_ support Continue-as-New functionality within Update handlers.
-- Complete all handlers _before_ using Continue-as-New.
-- Use Continue-as-New from your main Workflow Definition method, just as you would complete or fail a Workflow Execution.
-
-:::

--- a/docs/develop/php/continue-as-new.mdx
+++ b/docs/develop/php/continue-as-new.mdx
@@ -54,8 +54,8 @@ final class ClusterManagerInput {
 #[Workflow\WorkflowInterface]
 interface MessageHandlerWorkflowInterface
 {
-    #[Workflow\WorkflowMethod]
-    public function run(ClusterManagerInput $input);
+#[Workflow\WorkflowMethod]
+public function run(ClusterManagerInput $input);
 }
 
 ````

--- a/docs/develop/typescript/continue-as-new.mdx
+++ b/docs/develop/typescript/continue-as-new.mdx
@@ -1,48 +1,79 @@
 ---
 id: continue-as-new
-title: Continue-As-New - TypeScript SDK
+title: Continue-As-New - Typescript SDK
 sidebar_label: Continue-As-New
+description: Learn how to use Temporal's Continue-As-New in Typescript to manage large Event Histories by atomically creating new Workflow Executions with the same Workflow Id and fresh parameters.
 toc_max_heading_level: 2
 keywords:
-  - continue-as-new
+  - continue-as-new workflow
+  - restart workflow
+  - fresh event history
+  - avoid large event histories
+  - temporal typescript continue-as-new
 tags:
   - Workflows
   - continue-as-new
-  - TypeScript SDK
+  - Typescript SDK
   - Temporal SDKs
-description: Continue-As-New helps manage large Event Histories by initiating a new Workflow Execution with the same Workflow Id and fresh parameters, ensuring efficient Workflow management.
 ---
 
-[Continue-As-New](/workflow-execution/continue-as-new) enables a Workflow Execution to close successfully and create a new Workflow Execution in a single atomic operation if the number of Events in the Event History is becoming too large.
-The Workflow Execution spawned from the use of Continue-As-New has the same Workflow Id, a new Run Id, and a fresh Event History and is passed all the appropriate parameters.
+This page answers the following questions for Typescript developers:
 
-To cause a Workflow Execution to [Continue-As-New](/workflow-execution/continue-as-new), the Workflow function should return the result of the [`continueAsNew`](https://typescript.temporal.io/api/namespaces/workflow#continueasnew).
+- [What is Continue-As-New?](#what)
+- [How to Continue-As-New?](#how)
+- [When is it right to Continue-as-New?](#when)
+- [How to test Continue-as-New?](#how-to-test)
 
-<!--SNIPSTART typescript-continue-as-new-workflow -->
+## What is Continue-As-New? {#what}
 
-[continue-as-new/src/workflows.ts](https://github.com/temporalio/samples-typescript/blob/main/continue-as-new/src/workflows.ts)
+[Continue-As-New](/workflow-execution/continue-as-new) lets a Workflow Execution close successfully and creates a new Workflow Execution.
+You can think of it as a checkpoint when your Workflow gets too long or approaches certain scaling limits.
 
-```ts
-import { continueAsNew, log, sleep } from '@temporalio/workflow';
+The new Workflow Execution is in the same [chain](/workflow-execution#workflow-execution-chain); it keeps the same Workflow Id but gets a new Run Id and a fresh Event History.
+It also receives your Workflow's usual parameters.
 
-export async function loopingWorkflow(iteration = 0): Promise<void> {
-  if (iteration === 10) {
-    return;
-  }
-  log.info('Running Workflow iteration', { iteration });
-  await sleep(1000);
-  // Must match the arguments expected by `loopingWorkflow`
-  await continueAsNew<typeof loopingWorkflow>(iteration + 1);
-  // Unreachable code, continueAsNew is like `process.exit` and will stop execution once called.
+## How to Continue-As-New using the Typescropt SDK {#how}
+
+First, design your Workflow parameters so that you can pass in the "current state" when you Continue-As-New into the next Workflow run.
+This state is typically set to `None` for the original caller of the Workflow.
+
+<div class="copycode-notice-container">
+  <a href="https://github.com/temporalio/samples-typescript/blob/main/message-passing/safe-message-handlers/src/workflows.ts">
+    View the source code
+  </a>{' '}
+  in the context of the rest of the application code.
+</div>
+```typescript
+export interface ClusterManagerInput {
+  state?: ClusterManagerState;
 }
-```
 
-<!--SNIPEND-->
+export async function clusterManagerWorkflow(input: ClusterManagerInput = {}): Promise<ClusterManagerStateSummary> {
+````
+The test hook in the above snippet is covered [below](#how-to-test).
 
-:::warning Using Continue-as-New and Updates
+Inside your Workflow, call the [`ContinueAsNew()`](https://typescript.temporal.io/api/classes/workflow.ContinueAsNew) function with the same type.
+This stops the Workflow right away and starts a new one.
 
-- Temporal _does not_ support Continue-as-New functionality within Update handlers.
-- [Complete all handlers](/develop/typescript/message-passing#wait-for-message-handlers) _before_ using Continue-as-New.
-- Use Continue-as-New from your main Workflow Definition method, just as you would complete or fail a Workflow Execution.
+<div class="copycode-notice-container">
+  <a href="https://github.com/temporalio/samples-typescript/blob/main/message-passing/safe-message-handlers/src/workflows.ts">
+    View the source code
+  </a>{' '}
+  in the context of the rest of the application code.
+</div>
+```typescript
+return await wf.continueAsNew<typeof clusterManagerWorkflow>({ state: manager.getState() });
+````
 
-:::
+### Considerations for Workflows with Message Handlers {#with-message-handlers}
+
+If you use Updates or Signals, don't call Continue-as-New from the handlers.
+Instead, wait for your handlers to finish in your main Workflow before you run `continue_as_new`.
+See the [`allHandlersFinished`](message-passing#wait-for-message-handlers) example for guidance.
+
+## When is it right to Continue-as-New using the Typescript SDK? {#when}
+
+Use Continue-as-New when your Workflow might hit [Event History Limits](/workflow-execution/event#event-history).
+
+Temporal tracks your Workflow's progress against these limits to let you know when you should Continue-as-New.
+Call `wf.workflowInfo().continueAsNewSuggested` to check if it's time.

--- a/docs/develop/typescript/continue-as-new.mdx
+++ b/docs/develop/typescript/continue-as-new.mdx
@@ -49,6 +49,7 @@ export interface ClusterManagerInput {
 }
 
 export async function clusterManagerWorkflow(input: ClusterManagerInput = {}): Promise<ClusterManagerStateSummary> {
+
 ````
 The test hook in the above snippet is covered [below](#how-to-test).
 


### PR DESCRIPTION
## What does this PR do?
Update language specific CaN docs, similar to #3579

## Notes to reviewers
Docs should match Go and Python, just with the sample code and links specific to the language.

TS sample was missing the last bit of testing CaN with `shouldContinueAsNew`, so skipped that part of the doc.



