### PR TITLE
Allow '@' in Temporal Cloud search attribute name

### DIFF
--- a/docs/evaluate/temporal-cloud/limits.mdx
+++ b/docs/evaluate/temporal-cloud/limits.mdx
@@ -185,7 +185,7 @@ There is a limit to the number of custom Search Attributes per attribute type pe
 When creating custom Search Attributes in Temporal Cloud, the attribute names must adhere to the following constraints:
 
 - Maximum characters: 64
-- Allowed characters: `[a-zA-Z0-9.,:-_\/ ]`.
+- Allowed characters: `[a-zA-Z0-9.,:-_\/@ ]`.
 
 For more information on custom Search Attributes see [Custom Search Attributes limits](/search-attribute#custom-search-attribute).
 


### PR DESCRIPTION
## What does this PR do?

Add '@' to the allowed characters in a Temporal Cloud search attribute name. This is a very recent change to Temporal Cloud.

## Notes to reviewers

- [x] ~Wait to merge until the change is deployed to Temporal Cloud~
