### PR TITLE
add visibility default ordering

### DIFF
--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -39,7 +39,7 @@ List Filters support the following operators:
 - **`IN`**
 - **STARTS_WITH**
 
-:::note ORDER BY notes
+:::note
 
 The **ORDER BY** operator is currently not supported in Temporal Cloud.
 


### PR DESCRIPTION
## What does this PR do?
Explains the default ordering of the visibility queries as a callout.

## Notes to reviewers
`RunID` is mostly sorted by `ASC`, except for ElasticSearch where it's not specified. I chose to omit this in the document, but left it as a comment. I'm on the fence about leaving it or not.
- [ElasticSearch](https://github.com/temporalio/temporal/blob/190cce800950c0e1c9c1eba491c9642ec4a3f148/common/persistence/visibility/store/elasticsearch/visibility_store.go#L107-L110)
- [mysql](https://github.com/temporalio/temporal/blob/98faaf48fe9c13cde36416af14e4083341e33389/common/persistence/visibility/store/sql/query_converter_mysql.go#L269-L271)
- [Postgres](https://github.com/temporalio/temporal/blob/98faaf48fe9c13cde36416af14e4083341e33389/common/persistence/visibility/store/sql/query_converter_postgresql.go#L272-L274)
- [sqlite](https://github.com/temporalio/temporal/blob/0836b0fff0bbd6637ea1723f7e5a675519029354/common/persistence/visibility/store/sql/query_converter_sqlite.go#L281-L283)


JIRA https://temporalio.atlassian.net/browse/EDU-4496