### PR TITLE
added 2 year default to the two notes on the `Generate API Key` button

### DIFF
--- a/docs/production-deployment/cloud/get-started/api-keys.mdx
+++ b/docs/production-deployment/cloud/get-started/api-keys.mdx
@@ -453,5 +453,5 @@ If you lose it, generate a new one.
 
 **Q: What is the `Generate API Key` button on the Namespace page?**
 
-A: The `Generate API Key` button on a Namespace page generates an API key with `Admin` permissions for the given Namespace.
+A: The `Generate API Key` button on a Namespace page generates an API key with `Admin` permissions for the given Namespace and the maximum expiration time, which is 2 years.
 For additional details, refer to [Namespace Scoped Service Accounts](/cloud/service-accounts#scoped).

--- a/docs/production-deployment/cloud/get-started/service-accounts.mdx
+++ b/docs/production-deployment/cloud/get-started/service-accounts.mdx
@@ -185,7 +185,7 @@ As with regular Service Accounts, Namespace Scoped Service Accounts can be creat
 Currently, creating a Namespace Scoped Service Account from the Temporal Cloud UI happens on an individual [Namespace](/cloud/namespaces#manage-namespaces) page.
 If the current Namespace has API key authentication enabled, then there will be a `Generate API Key` button as a banner on the top of the Namespace page or in the `Authentication` section.
 
-By clicking on the `Generate API Key` button, a Namespace Scoped Service Account will be automatically created for the given Namespace (if one does not already exist) and an associated API key will be displayed.
+By clicking on the `Generate API Key` button, a Namespace Scoped Service Account will be automatically created for the given Namespace (if one does not already exist) and an associated API key will be displayed. This key will have the maximum expiration time, which is 2 years.
 
 The resulting Namespace Scoped Service Account will be named `<namespace>-service-account` and will have an `Admin` Namespace Permission by default.
 


### PR DESCRIPTION
## What does this PR do?

Adds a note that when the `Generate API Key` button in the UI is clicked, the expiration time is the default max, which is 2 years. 

## Notes to reviewers

This is in response to a customer ticket