### PR TITLE
add link for workflowcheck README in Go SDK landing page

### DIFF
--- a/docs/develop/go/index.mdx
+++ b/docs/develop/go/index.mdx
@@ -65,6 +65,12 @@ Set up the testing suite and test Workflows and Activities.
 - [Testing Workflows](/develop/go/testing-suite#test-workflows)
 - [How to Replay a Workflow Execution](/develop/go/testing-suite#replay)
 
+## [workflowcheck Determinism Checker]
+
+Use the `workflowcheck` tool to check the determinism of your Workflow Definitions.
+
+- [workflowcheck README](https://github.com/temporalio/sdk-go/tree/master/contrib/tools/workflowcheck/README.md)
+
 ## [Failure detection feature guide](/develop/go/failure-detection)
 
 Explore how your application can detect failures using timeouts and automatically attempt to mitigate them with retries.


### PR DESCRIPTION
## What does this PR do?

workflowcheck is only mentioned in on a page in learn.temporal.io, for now add a link to the tool's README. 

## Notes to reviewers

<!-- delete if n/a -->
