### PR TITLE
re-add web ui page under encyclopedia

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -747,6 +747,7 @@ module.exports = {
             "encyclopedia/data-conversion/key-management",
           ],
         },
+        "web-ui",
       ],
     },
     "glossary",


### PR DESCRIPTION
Noticed WebUI page was unlinked but still available, figured it got dropped by a re-org a while back, I've re-added it under encyclopedia which should be unobtrusive.