### PR TITLE
Add Korean (ko) localization support and initial translations

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -106,6 +106,10 @@ module.exports = async function createConfigAsync() {
             activeBasePath: "cloud",
             position: "left",
           },
+          {
+            type: 'localeDropdown',
+            position: 'left',
+          },
         ],
       },
       footer: {
@@ -331,6 +335,14 @@ module.exports = async function createConfigAsync() {
         },
       ],
     ],
+    i18n: {
+      defaultLocale: 'en',
+      locales: ['en', 'ko'],
+      localeConfigs: {
+        ko: { label: '한국어' }
+      },
+      path: 'i18n'
+    },    
   };
 
   function convertIndent4ToIndent2(code) {

--- a/i18n/README.md
+++ b/i18n/README.md
@@ -1,0 +1,46 @@
+# Temporal Documentation Translation Guide
+
+## 🆕 Adding a New Language
+
+1. **Update `docusaurus.config.js`:**
+   ```javascript
+   i18n: {
+     locales: ['en', 'ko', 'your-locale'],
+     localeConfigs: { 'your-locale': { label: 'Your Language' } }
+   }
+   ```
+
+2. **Generate translation templates:**
+   ```bash
+   yarn write-translations --locale [your-locale]
+   ```
+
+3. **Test locally:**
+   ```bash
+   yarn start --locale [your-locale]
+   ```
+
+## 📝 Translating Documentation
+
+To translate a document that doesn't exist yet:
+
+1. Copy the original file from `docs/` 
+2. Place it in `i18n/[locale]/docusaurus-plugin-content-docs/current/{same-path}`
+3. Translate the content (keep frontmatter `id` and technical terms unchanged)
+4. Test locally
+
+## 📁 File Structure
+
+```
+i18n/[locale]/
+├── docusaurus-theme-classic/
+│   ├── navbar.json     # Navigation menu
+│   └── footer.json     # Footer links
+└── docusaurus-plugin-content-docs/
+    ├── current.json    # Sidebar categories  
+    └── current/        # Translated MDX files
+        └── {same-path-as-docs}
+```
+
+For questions, use GitHub Issues or Community Slack #docs channel.
+Thank you for helping make Temporal docs accessible worldwide! 🌍 

--- a/i18n/ko/code.json
+++ b/i18n/ko/code.json
@@ -1,0 +1,464 @@
+{
+  "theme.admonition.note": {
+    "message": "노트",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "팁",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.danger": {
+    "message": "위험",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "정보",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.caution": {
+    "message": "주의",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.competency": {
+    "message": "core competency",
+    "description": "The default label used for the Competency admonition (:::competency)"
+  },
+  "theme.admonition.copycode": {
+    "message": "copy code",
+    "description": "The default label used for the CopyCode admonition (:::copycode)"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "페이지에 오류가 발생하였습니다.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "맨 위로 스크롤하기",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "게시물 목록",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "게시물 목록",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "블로그 게시물 목록 탐색",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "이전 페이지",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "다음 페이지",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "모든 태그 보기",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "블로그 게시물 탐색",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "이전 게시물",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "다음 게시물",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "system mode",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "밝은 모드",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "어두운 모드",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "어두운 모드와 밝은 모드 전환하기 (현재 {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "탐색 경로",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "{count} 항목",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "문서 페이지",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "이전",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "다음",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "{count}개 문서가",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} \"{tagName}\" 태그에 분류되었습니다",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "버전: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "{siteTitle} {versionLabel} 문서는 아직 정식 공개되지 않았습니다.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "{siteTitle} {versionLabel} 문서는 더 이상 업데이트되지 않습니다.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "최신 문서는 {latestVersionLink} ({versionLabel})을 확인하세요.",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "최신 버전",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "페이지 편집",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "{heading}에 대한 직접 링크",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " {date}에",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " {user}가",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "최종 수정: {atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.NotFound.title": {
+    "message": "페이지를 찾을 수 없습니다.",
+    "description": "The title of the 404 page"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "버전",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "태그:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "닫기",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.admonition.warning": {
+    "message": "경고",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "최근 블로그 문서 둘러보기",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "사이드바 분류 '{label}' 펼치기",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "사이드바 분류 '{label}' 접기",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "메인",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "언어",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "이 페이지에서",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.NotFound.p1": {
+    "message": "원하는 페이지를 찾을 수 없습니다.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "사이트 관리자에게 링크가 깨진 것을 알려주세요.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.blog.post.readMore": {
+    "message": "자세히 보기",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "{title} 에 대해 더 읽어보기",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "약 {readingTime}분",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "줄 바꿈 전환",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "복사",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "복사했습니다",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "클립보드에 코드 복사",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "홈",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "사이드바 숨기기",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "사이드바 숨기기",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "문서 사이드바",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "사이드바 닫기",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← 메인 메뉴로 돌아가기",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "사이드바 펼치거나 접기",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "사이드바 열기",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "사이드바 열기",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expand the dropdown",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Collapse the dropdown",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.SearchBar.seeAll": {
+    "message": "{count}개의 결과 확인하기"
+  },
+  "theme.SearchBar.label": {
+    "message": "검색",
+    "description": "The ARIA label and placeholder for search button"
+  },
+  "theme.SearchModal.searchBox.resetButtonTitle": {
+    "message": "검색어 초기화",
+    "description": "The label and ARIA label for search box reset button"
+  },
+  "theme.SearchModal.searchBox.cancelButtonText": {
+    "message": "취소",
+    "description": "The label and ARIA label for search box cancel button"
+  },
+  "theme.SearchModal.startScreen.recentSearchesTitle": {
+    "message": "최근",
+    "description": "The title for recent searches"
+  },
+  "theme.SearchModal.startScreen.noRecentSearchesText": {
+    "message": "최근 검색어 없음",
+    "description": "The text when no recent searches"
+  },
+  "theme.SearchModal.startScreen.saveRecentSearchButtonTitle": {
+    "message": "이 검색어를 저장",
+    "description": "The label for save recent search button"
+  },
+  "theme.SearchModal.startScreen.removeRecentSearchButtonTitle": {
+    "message": "이 검색어를 최근 검색어에서 삭제",
+    "description": "The label for remove recent search button"
+  },
+  "theme.SearchModal.startScreen.favoriteSearchesTitle": {
+    "message": "즐겨찾기",
+    "description": "The title for favorite searches"
+  },
+  "theme.SearchModal.startScreen.removeFavoriteSearchButtonTitle": {
+    "message": "이 검색어를 즐겨찾기에서 삭제",
+    "description": "The label for remove favorite search button"
+  },
+  "theme.SearchModal.errorScreen.titleText": {
+    "message": "결과를 불러올 수 없음",
+    "description": "The title for error screen of search modal"
+  },
+  "theme.SearchModal.errorScreen.helpText": {
+    "message": "인터넷 연결을 다시 확인하시기 바랍니다.",
+    "description": "The help text for error screen of search modal"
+  },
+  "theme.SearchModal.footer.selectText": {
+    "message": "로 선택",
+    "description": "The explanatory text of the action for the enter key"
+  },
+  "theme.SearchModal.footer.selectKeyAriaLabel": {
+    "message": "엔터 키",
+    "description": "The ARIA label for the Enter key button that makes the selection"
+  },
+  "theme.SearchModal.footer.navigateText": {
+    "message": "로 이동",
+    "description": "The explanatory text of the action for the Arrow up and Arrow down key"
+  },
+  "theme.SearchModal.footer.navigateUpKeyAriaLabel": {
+    "message": "화살표 위 키",
+    "description": "The ARIA label for the Arrow up key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.navigateDownKeyAriaLabel": {
+    "message": "화살표 아래 키",
+    "description": "The ARIA label for the Arrow down key button that makes the navigation"
+  },
+  "theme.SearchModal.footer.closeText": {
+    "message": "로 종료",
+    "description": "The explanatory text of the action for Escape key"
+  },
+  "theme.SearchModal.footer.closeKeyAriaLabel": {
+    "message": "Esc 키",
+    "description": "The ARIA label for the Escape key button that close the modal"
+  },
+  "theme.SearchModal.footer.searchByText": {
+    "message": "검색 제공",
+    "description": "The text explain that the search is making by Algolia"
+  },
+  "theme.SearchModal.noResultsScreen.noResultsText": {
+    "message": "검색 결과 없음",
+    "description": "The text explains that there are no results for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.suggestedQueryText": {
+    "message": "다른 추천 검색어",
+    "description": "The text for the suggested query when no results are found for the following search"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsText": {
+    "message": "검색 결과가 없는 것이 오류라고 생각되십니까?",
+    "description": "The text for the question where the user thinks there are missing results"
+  },
+  "theme.SearchModal.noResultsScreen.reportMissingResultsLinkText": {
+    "message": "알려주시기 바랍니다.",
+    "description": "The text for the link to report missing results"
+  },
+  "theme.SearchModal.placeholder": {
+    "message": "문서 검색",
+    "description": "The placeholder of the input of the DocSearch pop-up modal"
+  },
+  "theme.SearchPage.documentsFound.plurals": {
+    "message": "{count}개의 문서를 찾았습니다.",
+    "description": "Pluralized label for \"{count} documents found\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.SearchPage.existingResultsTitle": {
+    "message": "\"{query}\" 검색 결과",
+    "description": "The search page title for non-empty query"
+  },
+  "theme.SearchPage.emptyResultsTitle": {
+    "message": "문서를 검색합니다.",
+    "description": "The search page title for empty query"
+  },
+  "theme.SearchPage.inputPlaceholder": {
+    "message": "검색어를 입력하세요.",
+    "description": "The placeholder for search page input"
+  },
+  "theme.SearchPage.inputLabel": {
+    "message": "검색",
+    "description": "The ARIA label for search page input"
+  },
+  "theme.SearchPage.algoliaLabel": {
+    "message": "Algolia로 검색",
+    "description": "The ARIA label for Algolia mention"
+  },
+  "theme.SearchPage.noResultsText": {
+    "message": "검색 결과가 없습니다.",
+    "description": "The paragraph for empty search result"
+  },
+  "theme.SearchPage.fetchingNewResults": {
+    "message": "새로운 검색 결과를 불러오는 중입니다.",
+    "description": "The paragraph for fetching new search results"
+  },
+  "theme.blog.post.plurals": {
+    "message": "{count}개 게시물",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "\"{tagName}\" 태그로 연결된 {nPosts}개의 게시물이 있습니다.",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "저자",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "모든 저자 보기",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "작성자가 아직 게시글을 작성하지 않았습니다.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "색인되지 않은 문서",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "이 문서는 색인되지 않습니다. 검색 엔진이 이 문서를 색인하지 않으며, 주소를 알고 있는 사용자만 접근할 수 있습니다.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "작성 중인 페이지",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "이 페이지는 아직 작성 중입니다. 개발 환경에서만 보이며 프로덕션 빌드에서는 제외됩니다.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "다시 시도해 보세요",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "본문으로 건너뛰기",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "태그",
+    "description": "The title of the tag list page"
+  }
+}

--- a/i18n/ko/docusaurus-plugin-content-docs/current.json
+++ b/i18n/ko/docusaurus-plugin-content-docs/current.json
@@ -1,0 +1,166 @@
+{
+  "version.label": {
+    "message": "최신",
+    "description": "The label for version current"
+  },
+  "sidebar.documentation.category.Evaluate": {
+    "message": "평가하기",
+    "description": "The label for category Evaluate in sidebar documentation"
+  },
+  "sidebar.documentation.category.Features": {
+    "message": "기능",
+    "description": "The label for category Features in sidebar documentation"
+  },
+  "sidebar.documentation.category.Product release stages": {
+    "message": "제품 출시 단계",
+    "description": "The label for category Product release stages in sidebar documentation"
+  },
+  "sidebar.documentation.category.Temporal Cloud": {
+    "message": "Temporal 클라우드",
+    "description": "The label for category Temporal Cloud in sidebar documentation"
+  },
+  "sidebar.documentation.category.Security": {
+    "message": "보안",
+    "description": "The label for category Security in sidebar documentation"
+  },
+  "sidebar.documentation.category.Develop": {
+    "message": "개발하기",
+    "description": "The label for category Develop in sidebar documentation"
+  },
+  "sidebar.documentation.category.Go SDK": {
+    "message": "Go SDK",
+    "description": "The label for category Go SDK in sidebar documentation"
+  },
+  "sidebar.documentation.category.Java SDK": {
+    "message": "Java SDK",
+    "description": "The label for category Java SDK in sidebar documentation"
+  },
+  "sidebar.documentation.category.PHP SDK": {
+    "message": "PHP SDK",
+    "description": "The label for category PHP SDK in sidebar documentation"
+  },
+  "sidebar.documentation.category.Python SDK": {
+    "message": "Python SDK",
+    "description": "The label for category Python SDK in sidebar documentation"
+  },
+  "sidebar.documentation.category.TypeScript SDK": {
+    "message": "TypeScript SDK",
+    "description": "The label for category TypeScript SDK in sidebar documentation"
+  },
+  "sidebar.documentation.category..NET SDK": {
+    "message": ".NET SDK",
+    "description": "The label for category .NET SDK in sidebar documentation"
+  },
+  "sidebar.documentation.category.Deploy to production": {
+    "message": "운영환경으로 배포하기",
+    "description": "The label for category Deploy to production in sidebar documentation"
+  },
+  "sidebar.documentation.category.Get started with Cloud": {
+    "message": "클라우드로 시작하기",
+    "description": "The label for category Get started with Cloud in sidebar documentation"
+  },
+  "sidebar.documentation.category.How-to guides": {
+    "message": "How-to 가이드",
+    "description": "The label for category How-to guides in sidebar documentation"
+  },
+  "sidebar.documentation.category.Metrics": {
+    "message": "지표",
+    "description": "The label for category Metrics in sidebar documentation"
+  },
+  "sidebar.documentation.category.High Availabilty": {
+    "message": "고가용성",
+    "description": "The label for category High Availabilty in sidebar documentation"
+  },
+  "sidebar.documentation.category.References": {
+    "message": "참고",
+    "description": "The label for category References in sidebar documentation"
+  },
+  "sidebar.documentation.category.Temporal Nexus": {
+    "message": "Temporal Nexus",
+    "description": "The label for category Temporal Nexus in sidebar documentation"
+  },
+  "sidebar.documentation.category.Export": {
+    "message": "내보내기",
+    "description": "The label for category Export in sidebar documentation"
+  },
+  "sidebar.documentation.category.Audit Logging": {
+    "message": "감사 로깅",
+    "description": "The label for category Audit Logging in sidebar documentation"
+  },
+  "sidebar.documentation.category.CLI (tcld)": {
+    "message": "CLI (tcld)",
+    "description": "The label for category CLI (tcld) in sidebar documentation"
+  },
+  "sidebar.documentation.category.Self-host": {
+    "message": "Self-host",
+    "description": "The label for category Self-host in sidebar documentation"
+  },
+  "sidebar.documentation.category.CLI (temporal)": {
+    "message": "CLI (temporal)",
+    "description": "The label for category CLI (temporal) in sidebar documentation"
+  },
+  "sidebar.documentation.category.Troubleshooting": {
+    "message": "Troubleshooting",
+    "description": "The label for category Troubleshooting in sidebar documentation"
+  },
+  "sidebar.documentation.category.Encyclopedia": {
+    "message": "백과사전",
+    "description": "The label for category Encyclopedia in sidebar documentation"
+  },
+  "sidebar.documentation.category.Workflows": {
+    "message": "Workflows",
+    "description": "The label for category Workflows in sidebar documentation"
+  },
+  "sidebar.documentation.category.Workflow Execution": {
+    "message": "Workflow Execution",
+    "description": "The label for category Workflow Execution in sidebar documentation"
+  },
+  "sidebar.documentation.category.Activities": {
+    "message": "Activities",
+    "description": "The label for category Activities in sidebar documentation"
+  },
+  "sidebar.documentation.category.Detecting application failures": {
+    "message": "애플리케이션 장애 감지",
+    "description": "The label for category Detecting application failures in sidebar documentation"
+  },
+  "sidebar.documentation.category.Workers": {
+    "message": "Workers",
+    "description": "The label for category Workers in sidebar documentation"
+  },
+  "sidebar.documentation.category.Event History": {
+    "message": "이벤트 히스토리",
+    "description": "The label for category Event History in sidebar documentation"
+  },
+  "sidebar.documentation.category.Workflow Message Passing": {
+    "message": "Workflow 메시지 전달 ",
+    "description": "The label for category Workflow Message Passing in sidebar documentation"
+  },
+  "sidebar.documentation.category.Child Workflows": {
+    "message": "하위 Workflows",
+    "description": "The label for category Child Workflows in sidebar documentation"
+  },
+  "sidebar.documentation.category.Visibility": {
+    "message": "가시성",
+    "description": "The label for category Visibility in sidebar documentation"
+  },
+  "sidebar.documentation.category.Temporal Service": {
+    "message": "Temporal Service",
+    "description": "The label for category Temporal Service in sidebar documentation"
+  },
+  "sidebar.documentation.category.Namespaces": {
+    "message": "네임스페이스",
+    "description": "The label for category Namespaces in sidebar documentation"
+  },
+  "sidebar.documentation.category.Data Conversion": {
+    "message": "데이터 변환",
+    "description": "The label for category Data Conversion in sidebar documentation"
+  },
+  "sidebar.documentation.link.Change-log": {
+    "message": "변경 로그",
+    "description": "The label for link Change-log in sidebar documentation, linking to https://temporal.io/change-log"
+  },
+  "sidebar.documentation.link.Get started": {
+    "message": "시작하기",
+    "description": "The label for link Get started in sidebar documentation, linking to https://learn.temporal.io/getting_started/"
+  }
+}

--- a/i18n/ko/docusaurus-plugin-content-docs/current/evaluate/why-temporal.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/evaluate/why-temporal.mdx
@@ -1,0 +1,64 @@
+---
+id: why-temporal
+title: 왜 Temporal인가요?
+sidebar_label: 왜 Temporal인가요?
+description: Temporal은 지속성 실행, 단순화된 코드 구조, 강력한 모니터링 도구를 제공하여 개발자의 워크플로우 신뢰성, 생산성, 상태 가시성을 향상시킵니다.
+toc_max_heading_level: 4
+keywords:
+  - temporal
+  - evaluate-temporal
+  - why-temporal
+tags:
+  - Temporal
+  - Durable Execution
+---
+
+# 왜 Temporal인가요?
+
+Temporal은 개발자가 분산 애플리케이션을 구축하면서 직면하는 많은 문제를 해결합니다.
+하지만 대부분의 문제는 다음 세 가지 주제로 귀결됩니다:
+
+- 안정적인 분산 애플리케이션
+- 생산적인 개발 패러다임과 코드 구조
+- 분산 애플리케이션 상태의 가시성
+
+:::tip Temporal 실제 동작 보기
+다음 동영상을 시청하여 Temporal이 프로세스 충돌부터 접근 불가능한 API까지 다양한 장애로부터 주문 처리 시스템이 어떻게 복구되는지 확인해보세요.
+
+<div style={{ display: 'flex', justifyContent: 'center' }}>
+    <iframe width="560" height="315"
+        src="https://www.youtube.com/embed/dNVmRfWsNkM?si=cfwAJgr2zaoro97P"
+        title="YouTube video player"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+        referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+:::
+
+## 안정적인 실행
+
+**Temporal은 어떻게 애플리케이션을 안정적으로 만드나요?**
+
+Temporal은 개발자가 생산성을 희생하지 않고도 안정적이고 확장 가능한 애플리케이션을 구축하고 운영할 수 있도록 도와줍니다.
+시스템의 설계는 애플리케이션의 주 함수가 시작되면, 몇 분이든 몇 시간이든 며칠이든 몇 주든 심지어 몇 년이 걸리더라도 완료될 때까지 실행됨을 보장합니다.
+Temporal은 이것을 _지속성 실행(Durable Execution)_ 이라고 부릅니다.
+
+## 코드 구조
+
+**Temporal은 소프트웨어 개발자를 위해 애플리케이션 코드를 어떻게 단순화하나요?**
+
+장애 처리의 부담을 애플리케이션에서 플랫폼으로 이동시킴으로써, 애플리케이션 개발자가 작성하고 테스트하고 유지보수해야 할 코드가 줄어듭니다.
+Temporal의 프로그래밍 모델은 개발자에게 비즈니스 로직을 분산 코드베이스보다 훨씬 개발하기 쉬운 일관된 _워크플로우_ 로 표현할 수 있는 방법을 제공합니다.
+
+선호하는 프로그래밍 언어에 가장 적합한 SDK를 선택하고 비즈니스 로직 작성을 시작하세요.
+좋아하는 IDE, 라이브러리, 도구를 개발 프로세스에 통합하세요.
+Temporal은 또한 다중 언어 및 관용적 프로그래밍을 지원하여 개발자가 다양한 프로그래밍 언어의 장점을 활용하고 Temporal을 기존 코드베이스에 통합할 수 있도록 합니다.
+개발자는 큐나 복잡한 상태 머신을 관리할 필요 없이 이 모든 것을 달성할 수 있습니다.
+
+## 상태 가시성
+
+**Temporal은 어떻게 애플리케이션의 상태를 더 쉽게 볼 수 있게 해주나요?**
+
+Temporal은 개발자가 필요할 때마다 애플리케이션의 상태를 볼 수 있도록 하는 즉시 사용 가능한 도구를 제공합니다.
+Temporal CLI를 통해 개발자는 Temporal 애플리케이션을 효과적으로 관리, 모니터링, 디버깅할 수 있습니다.
+브라우저 기반 웹 UI를 사용하면 프로덕션 문제를 빠르게 격리하고 디버깅하며 해결할 수 있습니다.

--- a/i18n/ko/docusaurus-plugin-content-docs/current/index.mdx
+++ b/i18n/ko/docusaurus-plugin-content-docs/current/index.mdx
@@ -1,0 +1,14 @@
+---
+id: index
+title: Temporal 플랫폼 문서
+sidebar_label: 문서 홈
+description: Temporal의 포괄적인 문서를 탐색하여 Workflow-as-Code 솔루션으로 안정적이고 내결함성이 있는 워크플로우를 구축, 확장 및 관리하세요.
+---
+
+<head>
+  <title>Temporal 플랫폼 문서</title>
+</head>
+
+import { Intro } from '@site/src/components';
+
+<Intro /> 

--- a/i18n/ko/docusaurus-theme-classic/footer.json
+++ b/i18n/ko/docusaurus-theme-classic/footer.json
@@ -1,0 +1,78 @@
+{
+  "link.item.label.Github": {
+    "message": "Github",
+    "description": "The label of footer link with label=Github linking to https://github.com/temporalio"
+  },
+  "link.item.label.Twitter": {
+    "message": "Twitter",
+    "description": "The label of footer link with label=Twitter linking to https://twitter.com/temporalio"
+  },
+  "link.item.label.YouTube": {
+    "message": "YouTube",
+    "description": "The label of footer link with label=YouTube linking to https://www.youtube.com/c/Temporalio"
+  },
+  "link.item.label.About the docs": {
+    "message": "About the docs",
+    "description": "The label of footer link with label=About the docs linking to https://github.com/temporalio/documentation/blob/master/README.md"
+  },
+  "link.item.label.Temporal Cloud": {
+    "message": "Temporal Cloud",
+    "description": "The label of footer link with label=Temporal Cloud linking to https://temporal.io/cloud"
+  },
+  "link.item.label.Meetups": {
+    "message": "Meetups",
+    "description": "The label of footer link with label=Meetups linking to https://temporal.io/community#events"
+  },
+  "link.item.label.Workshops": {
+    "message": "Workshops",
+    "description": "The label of footer link with label=Workshops linking to https://temporal.io/community#workshops"
+  },
+  "link.item.label.Support forum": {
+    "message": "Support forum",
+    "description": "The label of footer link with label=Support forum linking to https://community.temporal.io/"
+  },
+  "link.item.label.Ask an expert": {
+    "message": "Ask an expert",
+    "description": "The label of footer link with label=Ask an expert linking to https://pages.temporal.io/ask-an-expert"
+  },
+  "link.item.label.Learn Temporal": {
+    "message": "Learn Temporal",
+    "description": "The label of footer link with label=Learn Temporal linking to https://learn.temporal.io"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to https://temporal.io/blog"
+  },
+  "link.item.label.Use cases": {
+    "message": "Use cases",
+    "description": "The label of footer link with label=Use cases linking to https://temporal.io/use-cases"
+  },
+  "link.item.label.Newsletter signup": {
+    "message": "Newsletter signup",
+    "description": "The label of footer link with label=Newsletter signup linking to https://pages.temporal.io/newsletter-subscribe"
+  },
+  "link.item.label.Security": {
+    "message": "Security",
+    "description": "The label of footer link with label=Security linking to /security"
+  },
+  "link.item.label.Privacy policy": {
+    "message": "Privacy policy",
+    "description": "The label of footer link with label=Privacy policy linking to https://temporal.io/global-privacy-policy"
+  },
+  "link.item.label.Terms of service": {
+    "message": "Terms of service",
+    "description": "The label of footer link with label=Terms of service linking to https://docs.temporal.io/pdf/temporal-tos-2021-07-24.pdf"
+  },
+  "link.item.label.We're hiring": {
+    "message": "We're hiring",
+    "description": "The label of footer link with label=We're hiring linking to https://temporal.io/careers"
+  },
+  "copyright": {
+    "message": "Copyright © 2025</span> Temporal Technologies Inc.</div><noscript><iframe src=\"https://www.googletagmanager.com/ns.html?id=GTM-TSXFPF2\"\n        height=\"0\" width=\"0\" style=\"display:none;visibility:hidden\"></iframe></noscript>",
+    "description": "The footer copyright"
+  },
+  "logo.alt": {
+    "message": "Temporal logo",
+    "description": "The alt text of footer logo"
+  }
+}

--- a/i18n/ko/docusaurus-theme-classic/navbar.json
+++ b/i18n/ko/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,26 @@
+{
+  "logo.alt": {
+    "message": "Temporal 로고",
+    "description": "The alt text of navbar logo"
+  },
+  "item.label.Home": {
+    "message": "홈",
+    "description": "Navbar item with label Home"
+  },
+  "item.label.Start learning": {
+    "message": "학습 시작하기",
+    "description": "Navbar item with label Start learning"
+  },
+  "item.label.Start building": {
+    "message": "구축 시작하기",
+    "description": "Navbar item with label Start building"
+  },
+  "item.label.Code Exchange": {
+    "message": "코드 익스체인지",
+    "description": "Navbar item with label Code Exchange"
+  },
+  "item.label.Temporal Cloud": {
+    "message": "Temporal 클라우드",
+    "description": "Navbar item with label Temporal Cloud"
+  }
+}

--- a/src/components/elements/SdkLogos.js
+++ b/src/components/elements/SdkLogos.js
@@ -1,4 +1,5 @@
 import React from "react";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 const supportedTech = [
   {
@@ -45,12 +46,12 @@ const supportedTech = [
   },
 ];
 
-const displayTechListItems = () => {
+const displayTechListItems = (useBaseUrl) => {
   return supportedTech.map((tech) => {
     return (
       <li className="list-logo" key={tech.alt}>
         <a href={tech.link}>
-          <img className={`${tech.class} pr-1 transition hover:scale-110 code-logo`} src={tech.image} alt={tech.alt} />
+          <img className={`${tech.class} pr-1 transition hover:scale-110 code-logo`} src={useBaseUrl(tech.image)} alt={tech.alt} />
         </a>
       </li>
     );
@@ -60,7 +61,7 @@ const displayTechListItems = () => {
 export const SdkLogos = () => {
   return (
     <div className="supported-tech tailwindcss">
-      <ul className="landing-card-list-b logos mb-4">{displayTechListItems()}</ul>
+      <ul className="landing-card-list-b logos mb-4">{displayTechListItems(useBaseUrl)}</ul>
     </div>
   );
 };


### PR DESCRIPTION
## What does this PR do?

This PR adds initial Korean localization support to the Temporal documentation with the following changes:

1. Basic i18n Configuration:
   - Add Korean locale configuration in docusaurus.config.js
   - Set up language routing for Korean (/ko/)
   - Add language selector to the navigation bar

2. Initial Korean UI Translations:
   - Add navigation bar translations
   - Add common UI string translations
   - Translate main documentation index page
   - Translate 'Why Temporal?' page as an example content

3. Technical Improvements:
   - Enhance SdkLogos component to properly handle multilingual image paths
   - Add useBaseUrl hook for localized image handling

## Notes to reviewers

- The Translations guide is placed in i18n/README.md
- Special attention to review the SdkLogos component changes to ensure proper image handling across all language versions
- This PR sets up the foundation for further Korean content translations
- The initial translations can serve as examples for future Korean documentation work