### PR TITLE
Add num_pollers for Java SDK

### DIFF
--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -273,7 +273,7 @@ Latency of a Temporal Client gRPC long poll request.
 Current number of Worker Entities that are polling.
 
 - Type: Gauge
-- Available in: Core, Go
+- Available in: Core, Go, Java
 - Tags: `namespace`, `poller_type`, `task_queue`
 
 ### poller_start


### PR DESCRIPTION
## What does this PR do?

Add `num_pollers` for Java SDK since it is now available in the Java SDK [v1.30.0](https://github.com/temporalio/sdk-java/releases/tag/v1.30.0) 

https://github.com/temporalio/sdk-java/blob/fd648d1ca9df7ef886d930117a1e52e516c6fa8a/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java#L123

## Notes to reviewers

If we want we could call out that it is only available post `v1.30.0`, we don't for any other metric so I didn't here.

<!-- delete if n/a -->
