### PR TITLE
worker-versioning: fix Go whitespace

### DIFF
--- a/docs/production-deployment/worker-deployments/worker-versioning.mdx
+++ b/docs/production-deployment/worker-deployments/worker-versioning.mdx
@@ -398,12 +398,12 @@ To do this, utilize pinning in your tests, following the examples below:
 <SdkTabs.Go>
 ```go
 workflowOptions := client.StartWorkflowOptions{
-ID:        "MyWorkflowId",
-	TaskQueue: "MyTaskQueue",
-       VersioningOverride = client.VersioningOverride{
-Behavior: workflow.VersioningBehaviorPinned,
-PinnedVersion: "$MY_TEST_DEPLOYMENT_VERSION",
-	}
+  ID:        "MyWorkflowId",
+  TaskQueue: "MyTaskQueue",
+  VersioningOverride: client.VersioningOverride{
+    Behavior:      workflow.VersioningBehaviorPinned,
+    PinnedVersion: "$MY_TEST_DEPLOYMENT_VERSION",
+  },
 }
 // c is an initialized Client
 we, err := c.ExecuteWorkflow(context.Background(), workflowOptions, HelloWorld, "Hello")


### PR DESCRIPTION
## What does this PR do?
fix some whitespace in the Go codeblock

## Notes to reviewers

<!-- delete if n/a -->