### PR TITLE
Update api-keys.mdx

### DIFF
--- a/docs/production-deployment/cloud/get-started/api-keys.mdx
+++ b/docs/production-deployment/cloud/get-started/api-keys.mdx
@@ -368,8 +368,6 @@ In addition to the API key, the following client options are required:
 - `--namespace`: Provide the `namespace.accountId` from the top of the Namespace page in the UI.
   - Use the format `<namespace_id>.<account_id>`.
   - This can be set using an environment variable.
-- `--tls`: Use for a secure connection with the appropriate options.
-  - This can be set using an environment variable.
 
 For example, to connect to Temporal Cloud from the CLI using an environment variable for the API key:
 
@@ -377,8 +375,7 @@ For example, to connect to Temporal Cloud from the CLI using an environment vari
 export TEMPORAL_API_KEY=<key-secret>
 temporal workflow list \
     --address <endpoint> \
-    --namespace <namespace_id>.<account_id> \
-    --tls
+    --namespace <namespace_id>.<account_id>
 ```
 
 :::tip ENVIRONMENT VARIABLES


### PR DESCRIPTION
## What does this PR do?
Updates api-keys documentation to the remove the --tls flag
This is no longer needed when using api keys to connect to Temporal cloud

