### PR TITLE
Restore plugin description in self-hosted security guide

### DIFF
--- a/docs/production-deployment/self-hosted-guide/security.mdx
+++ b/docs/production-deployment/self-hosted-guide/security.mdx
@@ -148,7 +148,7 @@ For more details on configuration with Docker, refer to [Temporal UI Config](htt
 
 ## Temporal Service plugins {#plugins}
 
-The Temporal Service supports some pluggable
+The Temporal Service supports some pluggable components.
 
 ### What is a ClaimMapper Plugin? {#claim-mapper}
 


### PR DESCRIPTION
This PR restores a sentence that was [accidentally truncated](https://github.com/temporalio/documentation/compare/5dcd43e00e09ebb3829577ea16e7da17060e10d6..df02edae3ba05b204ec92ad3c48df46a00effb24#diff-449089f2c4389eb7cd149fe08c1639fe0969a9be45e919abcab5f2e0c948b73cR116) with https://github.com/temporalio/documentation/pull/3453 in the self-hosted security guide:

https://github.com/temporalio/documentation/blob/5dcd43e00e09ebb3829577ea16e7da17060e10d6/docs/production-deployment/self-hosted-guide/security.mdx?plain=1#L116

https://github.com/temporalio/documentation/blob/df02edae3ba05b204ec92ad3c48df46a00effb24/docs/production-deployment/self-hosted-guide/security.mdx?plain=1#L116


