### PR TITLE
Fix small typo in Temporal Cloud security model

### DIFF
--- a/docs/evaluate/temporal-cloud/security.mdx
+++ b/docs/evaluate/temporal-cloud/security.mdx
@@ -59,7 +59,7 @@ Namespaces do not share data processing or data storage across regional boundari
 
 ### Private Connectivity
 
-Temporal Cloud supports private connectivity to enable you to connects to Temporal Cloud from a segregated cluster.
+Temporal Cloud supports private connectivity to enable you to connect to Temporal Cloud from a segregated cluster.
 You can find more details per cloud:
 
 - [AWS PrivateLink](aws-privatelink.mdx)


### PR DESCRIPTION
This PR aims to fix a small typo in the Temporal Cloud security model documentation describing private connectivity.