### PR TITLE
fix gtag console error

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -254,11 +254,11 @@ module.exports = async function createConfigAsync() {
           theme: {
             customCss: require.resolve("./src/css/custom.css"),
           },
-          // gtag: {
-          //   trackingID: "GTM-TSXFPF2",
-          //   // Optional fields.
-          //   anonymizeIP: false, // Should IPs be anonymized?
-          // },
+          gtag: {
+            trackingID: "GTM-TSXFPF2",
+            // Optional fields.
+            anonymizeIP: false, // Should IPs be anonymized?
+          },
           // Will be passed to @docusaurus/plugin-content-sitemap
           sitemap: {
             // Per v2.0.0-alpha.72 cacheTime is now deprecated


### PR DESCRIPTION
## What does this PR do?

Today in prod:
<img width="1104" height="328" alt="Google Chrome-Temporal Cloud guide  Temporal Platform Documentation-2025-07-27 at 14 13 47@2x" src="https://github.com/user-attachments/assets/bcdcac88-bbea-4631-a419-bf3a71830ef6" />

This PR adds a gtag value to the docusaurus config that matches the config in static/scripts/googletag.js, which prevents the error.

If we're not using Google Tag Manager any more, we should remove both the docusaurus config and the googletag.js file to remove the error.