### PR TITLE
clarify Python and Java Worker Versioning imports

### DIFF
--- a/docs/production-deployment/worker-deployments/worker-versioning.mdx
+++ b/docs/production-deployment/worker-deployments/worker-versioning.mdx
@@ -121,6 +121,11 @@ w := worker.New(c, myTaskQueue, worker.Options{
 </SdkTabs.Go>
 <SdkTabs.Java>
 ```java
+import io.temporal.worker.WorkerOptions;
+import io.temporal.common.VersioningBehavior;
+import io.temporal.common.WorkerDeploymentVersion;
+import io.temporal.worker.WorkerDeploymentOptions;
+
 WorkerOptions options =
     WorkerOptions.newBuilder()
         .setDeploymentOptions(
@@ -149,8 +154,8 @@ Worker(
         use_worker_versioning=True,
         default_versioning_behavior=VersioningBehavior.AUTO_UPGRADE
     ),
-
 )
+
 ````
 </SdkTabs.Python>
 <SdkTabs.TypeScript>

--- a/docs/production-deployment/worker-deployments/worker-versioning.mdx
+++ b/docs/production-deployment/worker-deployments/worker-versioning.mdx
@@ -134,6 +134,9 @@ WorkerOptions options =
 </SdkTabs.Java>
 <SdkTabs.Python>
 ```python
+from temporalio.common import WorkerDeploymentVersion, VersioningBehavior
+from temporalio.worker import Worker, WorkerDeploymentConfig
+
 Worker(
     client,
     task_queue="mytaskqueue",
@@ -148,7 +151,6 @@ Worker(
     ),
 
 )
-
 ````
 </SdkTabs.Python>
 <SdkTabs.TypeScript>

--- a/docs/production-deployment/worker-deployments/worker-versioning.mdx
+++ b/docs/production-deployment/worker-deployments/worker-versioning.mdx
@@ -135,6 +135,7 @@ WorkerOptions options =
                 .setDefaultVersioningBehavior(VersioningBehavior.AUTO_UPGRADE)
                 .build())
         .build();
+
 ```
 </SdkTabs.Java>
 <SdkTabs.Python>


### PR DESCRIPTION
Python and Java need a lot of non-obvious imports to configure Versioned Workers, here they are