### PR TITLE
Change patching docs to use namespace retention instead of workflow completion

### DIFF
--- a/docs/develop/dotnet/versioning.mdx
+++ b/docs/develop/dotnet/versioning.mdx
@@ -46,7 +46,7 @@ To understand why Patching is useful, it's helpful to first demonstrate cutting 
 ### Workflow cutovers
 
 Since incompatible changes only affect open Workflow Executions of the same type, you can avoid determinism errors by creating a whole new Workflow when making changes.
-To do this, you can copy the Workflow Definition function, giving it a different name, and make sure that both names are registered with your Workers.
+To do this, you can copy the Workflow Definition function, giving it a different name, and register both names with your Workers.
 
 For example, you would duplicate `SayHelloWorkflow` as `SayHelloWorkflowV2`:
 
@@ -128,7 +128,7 @@ Patching is a three step process:
 
 1. Use [Patched](https://dotnet.temporal.io/api/Temporalio.Workflows.Workflow.html#Temporalio_Workflows_Workflow_Patched_System_String_) to patch in new code and run it alongside the old code.
 2. Remove the old code and apply [DeprecatePatch](https://dotnet.temporal.io/api/Temporalio.Workflows.Workflow.html#Temporalio_Workflows_Workflow_DeprecatePatch_System_String_).
-3. Once you're confident that all old Workflows have finished executing, remove `DeprecatePatch`.
+3. Once all old Workflows have left retention, remove `DeprecatePatch`.
 
 ### Patching in new code {#using-patched-for-workflow-history-markers}
 
@@ -163,7 +163,7 @@ public class MyWorkflow
 
 ### Deprecating patches {#deprecated-patches}
 
-After ensuring that all Workflows started with `PrePatchActivity` code have finished, you can [deprecate the patch](https://dotnet.temporal.io/api/Temporalio.Workflows.Workflow.html#Temporalio_Workflows_Workflow_DeprecatePatch_System_String_).
+After all Workflows started with `PrePatchActivity` code have left retention, you can [deprecate the patch](https://dotnet.temporal.io/api/Temporalio.Workflows.Workflow.html#Temporalio_Workflows_Workflow_DeprecatePatch_System_String_).
 
 Deprecated patches serve as a bridge between the final stage of the patching process and the final state that no longer has patches. They function similarly to regular patches by adding a marker to the Workflow History. However, this marker won't cause a replay failure when the Workflow code doesn't produce it.
 
@@ -188,7 +188,7 @@ public class MyWorkflow
 
 ### Removing a patch {#deploy-postpatchactivity}
 
-You can safely deploy `PostPatchActivity` once all Workflows labeled my-patch or earlier are finished, based on the previously mentioned assertion.
+You can safely deploy `PostPatchActivity` once all Workflows labeled my-patch or earlier have left retention, based on the previously mentioned assertion.
 
 ```csharp
 [Workflow]

--- a/docs/develop/go/versioning.mdx
+++ b/docs/develop/go/versioning.mdx
@@ -35,7 +35,7 @@ To understand why Patching is useful, it's helpful to first demonstrate cutting 
 ### Workflow cutovers
 
 Since incompatible changes only affect open Workflow Executions of the same type, you can avoid determinism errors by creating a whole new Workflow when making changes.
-To do this, you can copy the Workflow Definition function, giving it a different name, and make sure that both names are registered with your Workers.
+To do this, you can copy the Workflow Definition function, giving it a different name, and register both names with your Workers.
 
 For example, you would duplicate `PizzaWorkflow` as `PizzaWorkflowV2`:
 
@@ -133,7 +133,7 @@ A Workflow that has already passed this `GetVersion()` call before it was introd
 A Workflow that was run with `maxSupported` set to 1 returns 1.
 New Workflows return 2.
 
-After you are sure that all of the Workflow Executions prior to version 1 have completed, you can remove the code for that version:
+After all the Workflow Executions prior to version 1 have left retention, you can remove the code for that version:
 
 ```go
 v := workflow.GetVersion(ctx, "Step1", 1, 2)
@@ -146,7 +146,7 @@ if v == 1 {
 
 You'll note that `minSupported` has changed from `DefaultVersion` to `1`.
 If an older version of the Workflow Execution history is replayed on this code, it fails because the minimum expected version is 1.
-After you are sure that all of the Workflow Executions for version 1 have completed, you can remove version 1 so that your code looks like the following:
+After all the Workflow Executions for version 1 have left retention, you can remove version 1 so that your code looks like the following:
 
 ```go
 _ := workflow.GetVersion(ctx, "Step1", 2, 2)
@@ -164,7 +164,7 @@ You need to preserve only the first call to `GetVersion()` for each `changeID`.
 All subsequent calls to `GetVersion()` with the same change Id are safe to remove.
 If necessary, you can remove the first `GetVersion()` call, but you need to ensure the following:
 
-- All executions with an older version are completed.
+- All executions with an older version have left retention.
 - You can no longer use `Step1` for the changeId. If you need to make changes to that same part in
   the future, such as change from ActivityD to ActivityE, you would need to use a different changeId
   like `Step1-fix2`, and start minVersion from DefaultVersion again. The code would look like the

--- a/docs/develop/java/versioning.mdx
+++ b/docs/develop/java/versioning.mdx
@@ -36,7 +36,7 @@ To understand why Patching is useful, it's helpful to first demonstrate cutting 
 ### Workflow cutovers
 
 Since incompatible changes only affect open Workflow Executions of the same type, you can avoid determinism errors by creating a whole new Workflow when making changes.
-To do this, you can copy the Workflow Definition function, giving it a different name, and make sure that both names are registered with your Workers.
+To do this, you can copy the Workflow Definition function, giving it a different name, and register both names with your Workers.
 
 For example, you would duplicate `PizzaWorkflow` as `PizzaWorkflowV2`:
 
@@ -148,7 +148,7 @@ public void processFile(Arguments args) {
 
 When `workflow.GetVersion()` is run for the new Workflow Execution, it records a marker in the Event History so that all future calls to `GetVersion` for this change id — `checksumAdded` in the example — on this Workflow Execution will always return the given version number, which is `1` in the example.
 
-After you are sure that all of the Workflow Executions prior to version 1 have completed, you can remove the code for that version.
+After all the Workflow Executions prior to version 1 have left retention, you can remove the code for that version.
 
 ```java
 public void processFile(Arguments args) {

--- a/docs/develop/php/versioning.mdx
+++ b/docs/develop/php/versioning.mdx
@@ -44,7 +44,7 @@ To understand why Patching is useful, it's helpful to first demonstrate cutting 
 ### Workflow cutovers
 
 Since incompatible changes only affect open Workflow Executions of the same type, you can avoid determinism errors by creating a whole new Workflow when making changes.
-To do this, you can copy the Workflow Definition function, giving it a different name, and make sure that both names are registered with your Workers.
+To do this, you can copy the Workflow Definition function, giving it a different name, and register both names with your Workers.
 
 For example, you would duplicate `MyWorkflow` as `MyWorkflowV2V2`:
 
@@ -147,7 +147,7 @@ A Workflow that has already passed this `getVersion()` call before it was introd
 A Workflow that was run with `maxSupported` set to 1 returns 1.
 New Workflows return 2.
 
-After you are sure that all of the Workflow Executions prior to version 1 have completed, you can remove the code for that version:
+After all the Workflow Executions prior to version 1 have left retention, you can remove the code for that version:
 
 ```php
     #[WorkflowMethod]
@@ -164,7 +164,7 @@ After you are sure that all of the Workflow Executions prior to version 1 have c
 
 You'll note that `minSupported` has changed from `DEFAULT_VERSION` to `1`.
 If an older version of the Workflow Execution history is replayed on this code, it fails because the minimum expected version is 1.
-After you are sure that all of the Workflow Executions for version 1 have completed, you can remove version 1 so that your code looks like the following:
+After all the Workflow Executions for version 1 have left retention, you can remove version 1 so that your code looks like the following:
 
 ```php
     #[WorkflowMethod]

--- a/docs/develop/python/versioning.mdx
+++ b/docs/develop/python/versioning.mdx
@@ -47,7 +47,7 @@ To understand why Patching is useful, it's helpful to first demonstrate cutting 
 ### Workflow cutovers
 
 Since incompatible changes only affect open Workflow Executions of the same type, you can avoid determinism errors by creating a whole new Workflow when making changes.
-To do this, you can copy the Workflow Definition function, giving it a different name, and make sure that both names are registered with your Workers.
+To do this, you can copy the Workflow Definition function, giving it a different name, and register both names with your Workers.
 
 For example, you would duplicate `PizzaWorkflow` as `PizzaWorkflowV2`:
 
@@ -181,9 +181,9 @@ class MyWorkflow:
 
 ### Deprecating patches {#deprecated-patches}
 
-After ensuring that all Workflows started with `pre_patch_activity` code have finished, you can [deprecate the patch](https://python.temporal.io/temporalio.workflow.html#deprecate_patch).
+After ensuring that all Workflows started with `pre_patch_activity` code have left retention, you can [deprecate the patch](https://python.temporal.io/temporalio.workflow.html#deprecate_patch).
 
-Once you're confident that your Workflows are no longer running the pre-patch code paths, you can deploy your code with `deprecate_patch()`.
+Once your Workflows are no longer running the pre-patch code paths, you can deploy your code with `deprecate_patch()`.
 These Workers will be running the most up-to-date version of the Workflow code, which no longer requires the patch.
 Deprecated patches serve as a bridge between the final stage of the patching process and the final state that no longer has patches. They function similarly to regular patches by adding a marker to the Workflow History. However, this marker won't cause a replay failure when the Workflow code doesn't produce it.
 
@@ -209,7 +209,7 @@ class MyWorkflow:
 
 ### Removing a patch {#deploy-new-code}
 
-Once you're sure that you will no longer need to [Query](/develop/python/message-passing#send-query) or Replay any of your pre-patch Workflows, you can then safely deploy Workers that no longer use either the `patched()` or `deprecate_patch()` calls:
+Once your pre-patch Workflows have left retention, you can then safely deploy Workers that no longer use either the `patched()` or `deprecate_patch()` calls:
 
 <div className="copycode-notice-container">
   <a href="https://github.com/temporalio/documentation/blob/main/sample-apps/python/version_your_workflows/workflow_4_patch_complete_dacx.py">

--- a/docs/develop/ruby/versioning.mdx
+++ b/docs/develop/ruby/versioning.mdx
@@ -41,7 +41,7 @@ To understand why Patching is useful, it's helpful to first demonstrate cutting 
 ### Workflow cutovers
 
 Since incompatible changes only affect open Workflow Executions of the same type, you can avoid determinism errors by creating a whole new Workflow when making changes.
-To do this, you can copy the Workflow Definition function, giving it a different name, and make sure that both names are registered with your Workers.
+To do this, you can copy the Workflow Definition function, giving it a different name, and register both names with your Workers.
 
 For example, you would duplicate `MyWorkflow` as `MyWorkflowV2`:
 
@@ -148,9 +148,9 @@ end
 
 ### Deprecating patches {#deprecated-patches}
 
-After ensuring that all Workflows started with `v1` code have finished, you can [deprecate the patch](https://ruby.temporal.io/Temporalio/Workflow.html#deprecate_patch-class_method).
+After ensuring that all Workflows started with `v1` code have left retention, you can [deprecate the patch](https://ruby.temporal.io/Temporalio/Workflow.html#deprecate_patch-class_method).
 
-Once you're confident that your Workflows are no longer running the pre-patch code paths, you can deploy your code with `deprecate_patch()`.
+Once your Workflows are no longer running the pre-patch code paths, you can deploy your code with `deprecate_patch()`.
 These Workers will be running the most up-to-date version of the Workflow code, which no longer requires the patch.
 The `deprecate_patch()` function works similarly to the `patched()` function by recording a marker in the Workflow history.
 This marker does not fail replay when Workflow code does not emit it.
@@ -172,7 +172,7 @@ end
 
 ### Removing a patch {#deploy-new-code}
 
-Once you're sure that you will no longer need to [Query](/develop/ruby/message-passing#send-query) or Replay any of your pre-patch Workflows, you can then safely deploy Workers that no longer use either the `patched()` or `deprecate_patch()` calls:
+Once the pre-patch Workflows have left retention, you can then safely deploy Workers that no longer use either the `patched()` or `deprecate_patch()` calls:
 
 Patching allows you to make changes to currently running Workflows.
 It is a powerful method for introducing compatible changes without introducing non-determinism errors.

--- a/docs/develop/typescript/versioning.mdx
+++ b/docs/develop/typescript/versioning.mdx
@@ -37,7 +37,7 @@ To understand why Patching is useful, it's helpful to first demonstrate cutting 
 ### Workflow cutovers
 
 Since incompatible changes only affect open Workflow Executions of the same type, you can avoid determinism errors by creating a whole new Workflow when making changes.
-To do this, you can copy the Workflow Definition function, giving it a different name, and make sure that both names are registered with your Workers.
+To do this, you can copy the Workflow Definition function, giving it a different name, and register both names with your Workers.
 
 For example, you would duplicate `PizzaWorkflow` as `PizzaWorkflowV2`:
 
@@ -123,9 +123,9 @@ export async function myWorkflow(): Promise<void> {
 
 ### Deprecating patches {#deprecated-patches}
 
-After ensuring that all Workflows started with `v1` code have finished, you can [deprecate the patch](https://typescript.temporal.io/api/namespaces/workflow#deprecatepatch).
+After ensuring that all Workflows started with `v1` code have left retention, you can [deprecate the patch](https://typescript.temporal.io/api/namespaces/workflow#deprecatepatch).
 
-Once you're confident that your Workflows are no longer running the pre-patch code paths, you can deploy your code with `deprecatePatch()`.
+Once your Workflows are no longer running the pre-patch code paths, you can deploy your code with `deprecatePatch()`.
 These Workers will be running the most up-to-date version of the Workflow code, which no longer requires the patch.
 Deprecated patches serve as a bridge between the final stage of the patching process and the final state that no longer has patches. They function similarly to regular patches by adding a marker to the Workflow History. However, this marker won't cause a replay failure when the Workflow code doesn't produce it.
 
@@ -142,7 +142,7 @@ export async function myWorkflow(): Promise<void> {
 
 ### Removing a patch {#deploy-new-code}
 
-Once you're sure that you will no longer need to [Query](/develop/typescript/message-passing#send-query) or Replay any of your pre-patch Workflows, you can then safely deploy Workers that no longer use either the `patched()` or `deprecatePatch()` calls:
+Once your pre-patch Workflows have left retention, you can then safely deploy Workers that no longer use either the `patched()` or `deprecatePatch()` calls:
 
 Patching allows you to make changes to currently running Workflows.
 It is a powerful method for introducing compatible changes without introducing non-determinism errors.


### PR DESCRIPTION
## What does this PR do?

The patching docs have been recommending that users can remove their patches when workflows complete or don't need to be queried, but I think it should be when they leave retention. My reasoning is that when users click a workflow in the UI, it replays. Because of that, if users remove the patch before the WFs have left retention, they may click the workflow, making it replay, and throw NDEs in alerting systems