### PR TITLE
Updated doc to use ts instead of js on snippet

### DIFF
--- a/docs/develop/typescript/timers.mdx
+++ b/docs/develop/typescript/timers.mdx
@@ -88,7 +88,7 @@ You can invert this to create a reminder pattern where the promise resolves _if_
 Be careful when racing a chained `sleep`.
 This might cause bugs because the chained `.then` will still continue to execute.
 
-```js
+```ts
 await Promise.race([
   sleep('5s').then(() => (status = 'timed_out')),
   somethingElse.then(() => (status = 'processed')),

--- a/docs/encyclopedia/workflow/schedule.mdx
+++ b/docs/encyclopedia/workflow/schedule.mdx
@@ -97,7 +97,7 @@ Other Spec features:
 **Time bounds:** Provide an absolute start or end time (or both) with a Spec to ensure that no actions are taken before the start time or after the end time.
 
 **Exclusions:** A Spec can contain exclusions in the form of zero or more calendar expressions.
-This can be used to express scheduling like "each Monday at noon except for holidays.
+This can be used to express scheduling like "each Monday at noon except for holidays".
 You'll have to provide your own set of exclusions and include it in each schedule; there are no pre-defined sets.
 (This feature isn't currently exposed in the Temporal CLI or the Temporal Web UI.)
 


### PR DESCRIPTION
## What does this PR do?

## Notes to reviewers

[This page](https://docs.temporal.io/develop/typescript/timers) had some weird formatting on this code snippet.
<img width="874" height="656" alt="Screenshot 2025-08-11 at 09 18 05" src="https://github.com/user-attachments/assets/b0196dfe-b390-409e-b5fc-f7cdafa87cef" />

Changing the block to `ts` makes it look like this:
<img width="878" height="384" alt="Screenshot 2025-08-11 at 09 18 50" src="https://github.com/user-attachments/assets/525cf293-d3a2-4d59-a1b1-e0474505cbbf" />

