### PR TITLE
CLI: Fix auto-gen comment placement

### DIFF
--- a/docs/cli/batch.mdx
+++ b/docs/cli/batch.mdx
@@ -4,18 +4,16 @@ sidebar_label: batch
 description: Use Temporal CLI to manage multiple Workflow Executions with Batch Jobs that can Cancel, Signal, or Terminate Workflows. Filter and monitor Batch Jobs effectively.
 toc_max_heading_level: 4
 keywords:
-
-- batch
-- batch describe
-- batch list
-- batch terminate
-- cli reference
-- cli-feature
-- command-line-interface-cli
-- temporal cli
-  tags:
-- Temporal CLI
-
+  - batch
+  - batch describe
+  - batch list
+  - batch terminate
+  - cli reference
+  - cli-feature
+  - command-line-interface-cli
+  - temporal cli
+tags:
+  - Temporal CLI
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/batch.mdx
+++ b/docs/cli/batch.mdx
@@ -1,3 +1,4 @@
+---
 id: batch
 title: Temporal CLI batch command reference
 sidebar_label: batch

--- a/docs/cli/batch.mdx
+++ b/docs/cli/batch.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: batch
 title: Temporal CLI batch command reference
 sidebar_label: batch
@@ -19,6 +17,8 @@ keywords:
 - Temporal CLI
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## describe
 

--- a/docs/cli/config.mdx
+++ b/docs/cli/config.mdx
@@ -1,3 +1,4 @@
+---
 id: config
 title: Temporal CLI config command reference
 sidebar_label: config

--- a/docs/cli/config.mdx
+++ b/docs/cli/config.mdx
@@ -4,20 +4,18 @@ sidebar_label: config
 description: Temporal CLI 'config' commands allow the getting, setting, deleting, and listing of configuration properties for connecting to Temporal.
 toc_max_heading_level: 4
 keywords:
-
-- cli reference
-- command-line-interface-cli
-- configuration
-- config
-- config delete
-- config get
-- config list
-- config set
-- environment
-- temporal cli
-  tags:
-- Temporal CLI
-
+  - cli reference
+  - command-line-interface-cli
+  - configuration
+  - config
+  - config delete
+  - config get
+  - config list
+  - config set
+  - environment
+  - temporal cli
+tags:
+  - Temporal CLI
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/config.mdx
+++ b/docs/cli/config.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: config
 title: Temporal CLI config command reference
 sidebar_label: config
@@ -21,6 +19,8 @@ keywords:
 - Temporal CLI
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## delete
 

--- a/docs/cli/env.mdx
+++ b/docs/cli/env.mdx
@@ -4,20 +4,18 @@ sidebar_label: env
 description: Temporal CLI 'env' commands allow the configuration, setting, deleting, and listing of environmental properties, making it easy to manage Temporal Server instances.
 toc_max_heading_level: 4
 keywords:
-
-- cli reference
-- command-line-interface-cli
-- configuration
-- env
-- env delete
-- env get
-- env list
-- env set
-- environment
-- temporal cli
-  tags:
-- Temporal CLI
-
+  - cli reference
+  - command-line-interface-cli
+  - configuration
+  - env
+  - env delete
+  - env get
+  - env list
+  - env set
+  - environment
+  - temporal cli
+tags:
+  - Temporal CLI
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/env.mdx
+++ b/docs/cli/env.mdx
@@ -1,3 +1,4 @@
+---
 id: env
 title: Temporal CLI env command reference
 sidebar_label: env

--- a/docs/cli/env.mdx
+++ b/docs/cli/env.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: env
 title: Temporal CLI env command reference
 sidebar_label: env
@@ -21,6 +19,8 @@ keywords:
 - Temporal CLI
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## delete
 

--- a/docs/cli/operator.mdx
+++ b/docs/cli/operator.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: operator
 title: Temporal CLI operator command reference
 sidebar_label: operator
@@ -39,6 +37,8 @@ keywords:
 - Temporal CLI
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## cluster
 

--- a/docs/cli/operator.mdx
+++ b/docs/cli/operator.mdx
@@ -4,38 +4,36 @@ sidebar_label: operator
 description: Operator commands in Temporal allow actions on Namespaces, Search Attributes, Clusters and Nexus Endpoints using specific subcommands. Execute with "temporal operator [command] [subcommand] [options]".
 toc_max_heading_level: 4
 keywords:
-
-- cli reference
-- cluster
-- cluster health
-- cluster list
-- cluster remove
-- cluster upsert
-- command-line-interface-cli
-- describe
-- namespace
-- namespace create
-- namespace delete
-- namespace describe
-- namespace list
-- nexus
-- nexus endpoint
-- nexus endpoint create
-- nexus endpoint delete
-- nexus endpoint get
-- nexus endpoint list
-- nexus endpoint update
-- operator
-- search attribute
-- search attribute create
-- search attribute list
-- search attribute remove
-- system
-- temporal cli
-- update
-  tags:
-- Temporal CLI
-
+  - cli reference
+  - cluster
+  - cluster health
+  - cluster list
+  - cluster remove
+  - cluster upsert
+  - command-line-interface-cli
+  - describe
+  - namespace
+  - namespace create
+  - namespace delete
+  - namespace describe
+  - namespace list
+  - nexus
+  - nexus endpoint
+  - nexus endpoint create
+  - nexus endpoint delete
+  - nexus endpoint get
+  - nexus endpoint list
+  - nexus endpoint update
+  - operator
+  - search attribute
+  - search attribute create
+  - search attribute list
+  - search attribute remove
+  - system
+  - temporal cli
+  - update
+tags:
+  - Temporal CLI
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/operator.mdx
+++ b/docs/cli/operator.mdx
@@ -1,3 +1,4 @@
+---
 id: operator
 title: Temporal CLI operator command reference
 sidebar_label: operator

--- a/docs/cli/schedule.mdx
+++ b/docs/cli/schedule.mdx
@@ -1,3 +1,4 @@
+---
 id: schedule
 title: Temporal CLI schedule command reference
 sidebar_label: schedule

--- a/docs/cli/schedule.mdx
+++ b/docs/cli/schedule.mdx
@@ -4,25 +4,23 @@ sidebar_label: schedule
 description: Temporal's Schedule commands allow users to create, update, and manage Workflow Executions seamlessly for automation, supporting commands for creation, backfill, deletion, and more.
 toc_max_heading_level: 4
 keywords:
-
-- backfill
-- cli reference
-- command-line-interface-cli
-- schedule
-- schedule backfill
-- schedule create
-- schedule delete
-- schedule describe
-- schedule list
-- schedule toggle
-- schedule trigger
-- schedule update
-- temporal cli
-- updates
-  tags:
-- Temporal CLI
-- Schedules
-
+  - backfill
+  - cli reference
+  - command-line-interface-cli
+  - schedule
+  - schedule backfill
+  - schedule create
+  - schedule delete
+  - schedule describe
+  - schedule list
+  - schedule toggle
+  - schedule trigger
+  - schedule update
+  - temporal cli
+  - updates
+tags:
+  - Temporal CLI
+  - Schedules
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/schedule.mdx
+++ b/docs/cli/schedule.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: schedule
 title: Temporal CLI schedule command reference
 sidebar_label: schedule
@@ -26,6 +24,8 @@ keywords:
 - Schedules
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## backfill
 

--- a/docs/cli/server.mdx
+++ b/docs/cli/server.mdx
@@ -1,3 +1,4 @@
+---
 id: server
 title: Temporal CLI server command reference
 sidebar_label: server

--- a/docs/cli/server.mdx
+++ b/docs/cli/server.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: server
 title: Temporal CLI server command reference
 sidebar_label: server
@@ -17,6 +15,8 @@ keywords:
 - Development Server
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## start-dev
 

--- a/docs/cli/server.mdx
+++ b/docs/cli/server.mdx
@@ -4,16 +4,14 @@ sidebar_label: server
 description: Manage your Temporal Server easily with CLI commands. Start a local server using `temporal server start-dev` and access the Web UI at http://localhost:8233. Customize with multiple options.
 toc_max_heading_level: 4
 keywords:
-
-- cli reference
-- command-line-interface-cli
-- server
-- server start-dev
-- temporal cli
-  tags:
-- Temporal CLI
-- Development Server
-
+  - cli reference
+  - command-line-interface-cli
+  - server
+  - server start-dev
+  - temporal cli
+tags:
+  - Temporal CLI
+  - Development Server
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/task-queue.mdx
+++ b/docs/cli/task-queue.mdx
@@ -4,16 +4,14 @@ sidebar_label: task-queue
 description: Temporal Task Queue commands facilitate operations like describing poller info, displaying partitions, fetching compatible Build IDs, and determining Build ID reachability for effective Workflow and Activity management.
 toc_max_heading_level: 4
 keywords:
-
-- cli reference
-- command-line-interface-cli
-- list partitions
-- task queue
-- task queue describe
-- temporal cli
-  tags:
-- Temporal CLI
-
+  - cli reference
+  - command-line-interface-cli
+  - list partitions
+  - task queue
+  - task queue describe
+  - temporal cli
+tags:
+  - Temporal CLI
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/task-queue.mdx
+++ b/docs/cli/task-queue.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: task-queue
 title: Temporal CLI task-queue command reference
 sidebar_label: task-queue
@@ -17,6 +15,8 @@ keywords:
 - Temporal CLI
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## describe
 

--- a/docs/cli/task-queue.mdx
+++ b/docs/cli/task-queue.mdx
@@ -1,3 +1,4 @@
+---
 id: task-queue
 title: Temporal CLI task-queue command reference
 sidebar_label: task-queue

--- a/docs/cli/worker.mdx
+++ b/docs/cli/worker.mdx
@@ -1,3 +1,4 @@
+---
 id: worker
 title: Temporal CLI worker command reference
 sidebar_label: worker

--- a/docs/cli/worker.mdx
+++ b/docs/cli/worker.mdx
@@ -4,12 +4,10 @@ sidebar_label: worker
 description: Learn how to read or modify state associated with a Worker, such as Worker Deployments.
 toc_max_heading_level: 4
 keywords:
-
-- worker
-- worker deployment
-  tags:
-- Temporal CLI
-
+  - worker
+  - worker deployment
+tags:
+  - Temporal CLI
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/worker.mdx
+++ b/docs/cli/worker.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: worker
 title: Temporal CLI worker command reference
 sidebar_label: worker
@@ -13,6 +11,8 @@ keywords:
 - Temporal CLI
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## deployment
 

--- a/docs/cli/workflow.mdx
+++ b/docs/cli/workflow.mdx
@@ -1,3 +1,4 @@
+---
 id: workflow
 title: Temporal CLI workflow command reference
 sidebar_label: workflow

--- a/docs/cli/workflow.mdx
+++ b/docs/cli/workflow.mdx
@@ -4,43 +4,41 @@ sidebar_label: workflow
 description: Temporal Workflow commands enable operations on Workflow Executions, such as cancel, count, delete, describe, execute, list, update-options, query, reset, reset-batch, show, signal, stack, start, terminate, trace, and update, enhancing efficiency and control.
 toc_max_heading_level: 4
 keywords:
-
-- call stack
-- cancellation
-- child workflows
-- cli reference
-- command-line-interface-cli
-- event history
-- query
-- resets-feature
-- signals
-- signals-feature
-- stack trace
-- temporal cli
-- termination
-- workflow
-- workflow cancel
-- workflow count
-- workflow delete
-- workflow describe
-- workflow execute
-- workflow execution
-- workflow list
-- workflow metadata
-- workflow query
-- workflow reset
-- workflow reset-batch
-- workflow show
-- workflow signal
-- workflow stack
-- workflow start
-- workflow terminate
-- workflow trace
-- workflow update-options
-  tags:
-- Temporal CLI
-- Workflows
-
+  - call stack
+  - cancellation
+  - child workflows
+  - cli reference
+  - command-line-interface-cli
+  - event history
+  - query
+  - resets-feature
+  - signals
+  - signals-feature
+  - stack trace
+  - temporal cli
+  - termination
+  - workflow
+  - workflow cancel
+  - workflow count
+  - workflow delete
+  - workflow describe
+  - workflow execute
+  - workflow execution
+  - workflow list
+  - workflow metadata
+  - workflow query
+  - workflow reset
+  - workflow reset-batch
+  - workflow show
+  - workflow signal
+  - workflow stack
+  - workflow start
+  - workflow terminate
+  - workflow trace
+  - workflow update-options
+tags:
+  - Temporal CLI
+  - Workflows
 ---
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}

--- a/docs/cli/workflow.mdx
+++ b/docs/cli/workflow.mdx
@@ -1,5 +1,3 @@
-## {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
-
 id: workflow
 title: Temporal CLI workflow command reference
 sidebar_label: workflow
@@ -44,6 +42,8 @@ keywords:
 - Workflows
 
 ---
+{/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
+This file is generated from https://github.com/temporalio/cli/blob/main/temporalcli/commandsgen/commands.yml */}
 
 ## cancel
 


### PR DESCRIPTION
## What does this PR do?
Moved the top-of-file comment to below the header, this was causing formatting issues. CLI fix is https://github.com/temporalio/cli/pull/842, but we want a quicker fix before waiting for the next CLI release

## Notes to reviewers

<!-- delete if n/a -->
