### PR TITLE
fix: update SAML sign-on URL for Entra

### DIFF
--- a/docs/production-deployment/cloud/saml.mdx
+++ b/docs/production-deployment/cloud/saml.mdx
@@ -75,6 +75,18 @@ To use Entra ID as your SAML IdP, create a Microsoft Entra ID Enterprise applica
    https://login.tmprl.cloud/login/callback?connection=f45a2-saml
    ```
 
+1. In **Sign on URL**, enter the following login url, including your Account Id where indicated:
+
+   ```bash
+   https://cloud.temporal.io/login/saml?connection=ACCOUNT_ID-saml
+   ```
+
+   A correctly formed login URL looks like this:
+
+   ```bash
+   https://cloud.temporal.io/login/saml?connection=f45a2-saml
+   ```
+
 1. You can leave the other fields blank.
    Near the top of the pane, select **Save**.
 1. In the **Attributes & Claims** section, select **Edit**.


### PR DESCRIPTION
## What does this PR do?
Adds a sign-on URL step for Entra SAML setup. This allows IDP initiated login to work, without this configuration, IDP initiated login will not work. 

## Notes to reviewers

<!-- delete if n/a -->
