### PR TITLE
clarify workflow pricing docs

### DIFF
--- a/docs/evaluate/temporal-cloud/actions.mdx
+++ b/docs/evaluate/temporal-cloud/actions.mdx
@@ -30,8 +30,9 @@ The following result in an action on Temporal Cloud:
 ## Workflows
 
 - **Workflow started**.
-  Occurs via client start, [Continue-As-New](/workflow-execution/continue-as-new), [Child Workflow](/child-workflows) start. Also occurs with [Update-With-Start](/sending-messages#update-with-start) if the Workflow was not already started.
+  Occurs via client start, [Continue-As-New](/workflow-execution/continue-as-new), [Child Workflow](/child-workflows) start.
   If a Workflow start fails, an Action is not recorded.
+  De-duplicated Workflow starts that share a Workflow ID do _not_ count as an Action.
 - **Workflow reset**.
   Occurs when a [Workflow](/workflows) is reset.
   (Actions that occur before a [Reset](/workflow-execution/event#reset) are counted even if they are no longer visible in [Event History](/workflow-execution/event#event-history).)
@@ -51,6 +52,8 @@ The following result in an action on Temporal Cloud:
   De-duplicated Updates that share an Update ID do _not_ count as an Action.
 - **Side Effect recorded**.
   For a mutable [Side Effect](/workflow-execution/event#side-effect), an Action occurs only when the value changes.
+- **Workflow Execution Options updated.** An Actions occurs for every [Workflow-Execution-Options-Updated](/references/events#workflowexecutionoptionsupdated) event.
+  This includes attaching a Workflow completion callback or modifying a Workflow versioning override.
 
 ## Child Workflows
 


### PR DESCRIPTION
## What does this PR do?
- clarifies Workflow start pricing does not charge for de-duplicated Workflow starts with the same Workflow ID
- adds Workflow Execution Options update pricing