### PR TITLE
update intro docs to allow for API keys + reduce duplication

### DIFF
--- a/docs/production-deployment/cloud/get-started/certificates.mdx
+++ b/docs/production-deployment/cloud/get-started/certificates.mdx
@@ -2,7 +2,7 @@
 id: certificates
 title: Manage certificates
 sidebar_label: Manage certificates
-description: Temporal Cloud uses mTLS, requiring CA certificates for secure communication. Keep certificates updated to avoid disruptions in Workflow Execution. Manage and update certificates easily via the Temporal Cloud UI or tcld tool.
+description: Temporal Cloud supports mTLS, which requires CA certificates for secure communication. Keep certificates updated to avoid disruptions in Workflow Execution. Manage and update certificates easily via the Temporal Cloud UI or tcld tool.
 slug: /cloud/certificates
 toc_max_heading_level: 4
 keywords:
@@ -17,11 +17,9 @@ tags:
   - Temporal Cloud
 ---
 
-[Temporal Cloud](https://temporal.io/cloud) requires security certificates for secure access and communication.
+[Temporal Cloud](https://temporal.io/cloud) supports both mTLS and [API key](/cloud/api-keys) authentication for namespace access.
 
-Temporal Cloud access is secured by the mutual Transport Layer Security (mTLS) protocol, which requires a CA certificate from the user.
-
-A [Worker Process](/workers#worker-process) requires a CA certificate and private key to connect to Temporal Cloud.
+When using mTLS authentication, each [Worker Process](/workers#worker-process) uses a CA certificate and private key to connect to Temporal Cloud.
 Temporal Cloud does not require an exchange of secrets; only the certificates produced by private keys are used for verification.
 
 :::caution Don't let your certificates expire
@@ -101,7 +99,9 @@ Follow the instructions to [upload the CA certificate](/cloud/certificates#updat
 
 ### Option 2: You don't have certificate management infrastructure
 
-If you don't have an existing certificate management infrastructure, issue the CA and end-entity certificates using [tcld](#use-tcld-to-generate-certificates) or open source tools such as [certstrap](#use-certstrap-to-generate-certificates).
+If you don't have an existing certificate management infrastructure, we recommend using API keys for authentication instead. API keys are generally easier to manage than mTLS certs if you're not using certificate management infrastructure otherwise.
+
+If you still want to use mTLS, issue the CA and end-entity certificates using [tcld](#use-tcld-to-generate-certificates) or open source tools such as [certstrap](#use-certstrap-to-generate-certificates).
 
 #### Use tcld to generate certificates
 
@@ -223,7 +223,7 @@ Follow the instructions to [upload the CA certificate](/cloud/certificates#updat
 
 ## How to control authorization for Temporal Cloud Namespaces {#control-authorization}
 
-Because Temporal Cloud uses mTLS for authorization, we recommend that an end-entity certificate be scoped to a specific Namespace.
+We recommend that an end-entity certificate be scoped to a specific Namespace to enforce the principle of least privilege.
 Temporal Cloud requires full CA chains, so you can achieve authorization in two ways.
 
 ### Option 1: Issue a separate root certificate for each Namespace

--- a/docs/production-deployment/cloud/get-started/index.mdx
+++ b/docs/production-deployment/cloud/get-started/index.mdx
@@ -3,71 +3,47 @@ id: index
 title: Get started with Temporal Cloud
 sidebar_label: Get started
 slug: /cloud/get-started/
-description: Get started with Temporal Cloud. Sign up, verify your Account Owner or Global Admin role, set up CA certificates, create a Namespace, invite users, and connect your Temporal Client and Workers.
+description: Get started with Temporal Cloud. Sign up, verify your Account Owner or Global Admin role, set up authentication, create a Namespace, invite users, and connect your Temporal Client and Workers.
 toc_max_heading_level: 3
 keywords:
   - introduction
   - temporal cloud
 tags:
   - Temporal Cloud
-  - Certificates
+  - Authentication
   - API
 ---
 
 import { DiscoverableDisclosure } from '@site/src/components';
 
-Getting started with Temporal Cloud involves a few key steps to ensure your environment is set up correctly.
-However you're using Temporal, begin the process by covering essential tasks, such as account setup, Namespace creation, authentication configuration, and Worker deployment.
+Getting started with Temporal Cloud involves a few key steps:
 
-You’ll find links here to help you configure your Temporal Cloud account, authenticate your Clients and Workers, and set up the necessary infrastructure to get your Workflows running efficiently.
+1. [Sign up for Temporal Cloud](#sign-up-for-temporal-cloud)
+1. [Create a Namespace](#create-a-namespace)
+1. [Set up your Clients and Workers](#set-up-your-clients-and-workers)
+1. [Run your first Workflow](#run-your-first-workflow)
+1. [Invite your team](#invite-your-team)
 
 ## Sign up for Temporal Cloud
 
 To create a Temporal Cloud account, you can:
 
-- Sign up [on our site](https://temporal.io/get-cloud); or
+- Sign up [directly](https://cloud.temporal.io/); or
 - Subscribe at the AWS Marketplace for [Temporal Cloud Pay-As-You-Go](https://aws.amazon.com/marketplace/pp/prodview-xx2x66m6fp2lo).
   Signing up through the AWS Marketplace is similar to signing up directly on the Temporal Cloud site, but billing goes through your AWS account.
 - To purchase Temporal Cloud on the Google Cloud Marketplace, please contact our team at sales@temporal.io.
 
 For information about Temporal Cloud Pricing, see our [Pricing Page](/cloud/pricing).
 
-## Accept Account Owner permissions
+## Create a Namespace
 
-After sign-up, you will receive email from Temporal welcoming you to your new Temporal account.
-Your email address is now the first [Account Owner](/cloud/users#account-level-roles) for your account.
+See [Managing Namespaces](/cloud/namespaces#create-a-namespace) to create your first namespace.
 
-**An Account Owner**:
+Temporal Cloud supports either [API key](/cloud/api-keys) or [mTLS](/cloud/certificates) authentication for each namespace. If you're not sure which to use, we recommend using [API keys](/cloud/api-keys) because they're easier to manage and rotate for most teams. If your organization already has private key infrastructure (PKI) and is familiar with cert management, then [mTLS](/cloud/certificates) is an excellent choice.
 
-- Has full administrative permissions across the account, including users, usage, and billing
-- Has Namespace Admin permissions on all Namespaces in the account
+## Set up your Clients and Workers
 
-## Establish your authentication credentials
-
-Temporal Cloud supports both TLS and API key authentication.
-The following two sections explain these approaches.
-
-### TLS authentication and certificates
-
-For TLS authentication, you must provide your own CA certificates.
-These certificates are used to create a Namespace, which in turn used grants Temporal Clients and Workers access to it.
-For certificate requirements, see the following:
-
-- [Requirements for CA certificates](/cloud/certificates#certificate-requirements)
-- [Issue root CA and end-entity certificates](/cloud/certificates#issue-certificates)
-
-### API keys
-
-To enable and use API key access, see the following:
-
-- [API key overview](/cloud/api-keys#overview)
-- [API key best practices](/cloud/api-keys#best-practices)
-- [Troubleshoot your API key use](/cloud/api-keys#troubleshooting)
-- [API keys: Frequently Asked Questions](/cloud/api-keys#faqs)
-
-### Authentication and SDKs {#auth-and-sdks}
-
-Each SDK has a way to use your CA certificates and private keys to authenticate and authorize access to your Temporal Cloud Namespace.
+See our guides for connecting each SDK to your Temporal Cloud Namespace:
 
 - [Connect to Temporal Cloud in Go](/develop/go/temporal-client#connect-to-temporal-cloud)
 - [Connect to Temporal Cloud in Java](/develop/java/temporal-client#connect-to-temporal-cloud)
@@ -75,38 +51,25 @@ Each SDK has a way to use your CA certificates and private keys to authenticate 
 - [Connect to Temporal Cloud in TypeScript](/develop/typescript/core-application#connect-to-temporal-cloud)
 - [Connect to Temporal Cloud in .NET](/develop/dotnet/temporal-client#connect-to-temporal-cloud)
 - [Connect to Temporal Cloud in PHP](/develop/php/temporal-client#connect-to-temporal-cloud)
+- [Connect to Temporal Cloud in Ruby](/develop/ruby/temporal-client#connect-to-temporal-cloud)
 
-## Create a Namespace
 
-If you don’t have a Namespace yet--or want to create an additional one--[create a Namespace in Temporal Cloud](/cloud/namespaces#create-a-namespace) using the Temporal Cloud UI or the `tcld` CLI.
-If using mTLS authentication, don't forget to follow the step that has you add the CA certificate to the Namespace.
+## Run your first Workflow
 
-<DiscoverableDisclosure prompt="" label="Namespace Setup - Details">
+See our guides for starting a workflow using each SDK:
 
-import NamespaceContent from '@site/docs/production-deployment/cloud/get-started/namespace-creation.mdx'
+- [Start a workflow in Go](/develop/go/temporal-client#start-workflow-execution)
+- [Start a workflow in Java](/develop/java/temporal-client#start-workflow-execution)
+- [Start a workflow in Python](/develop/python/temporal-client#start-workflow-execution)
+- [Start a workflow in TypeScript](/develop/typescript/core-application#start-workflow-execution)
+- [Start a workflow in .NET](/develop/dotnet/temporal-client#start-workflow)
+- [Start a workflow in PHP](/develop/php/temporal-client#start-workflow-execution)
+- [Start a workflow in Ruby](/develop/ruby/temporal-client#start-workflow)
 
-<NamespaceContent />
+## Invite your team
 
-</DiscoverableDisclosure>
+See [Managing users](/cloud/users) to add other users and assign them roles.
 
-## Invite users
+You can also use [Service Accounts](/cloud/service-accounts) to represent machine identities.
 
-Adding a user to your Temporal Cloud Account dispatches an email invite, which users must accept to join.
-To add users, see [How to invite users to your Temporal Cloud account](/cloud/users#invite-users).
-
-<DiscoverableDisclosure prompt="" label="Invite Users - Details">
-
-import InvitationContent from '@site/docs/production-deployment/cloud/get-started/user-invite.mdx'
-
-<InvitationContent />
-
-</DiscoverableDisclosure>
-
-## Connect to Temporal Cloud
-
-After having updated your Temporal Client and your Workers to [use your Temporal Cloud Namespace credentials](#auth-and-sdks), you can deploy your Workers, so they are ready to execute your Workflows and Activities:
-
-### SDK-specific Worker configuration
-
-- [Run a Temporal Cloud Worker in Go](/develop/go/core-application#run-a-temporal-cloud-worker)
-- [Run a Temporal Cloud Worker in TypeScript](/develop/typescript/core-application#run-a-temporal-cloud-worker)
+Since you created the account when you signed up, your email address is the first [Account Owner](/cloud/users#account-level-roles) for your account.


### PR DESCRIPTION
## What does this PR do?

- Updated some language to make it clearer that certs are not required (API keys can also be used for namespace auth)
- Simplifies /cloud/get-started/ to highlight the basic steps and link out to each area, rather than duplicating content (which was out of date)