### PR TITLE
Fix environment variable for terraform-provider configuration

### DIFF
--- a/docs/production-deployment/cloud/terraform-provider.mdx
+++ b/docs/production-deployment/cloud/terraform-provider.mdx
@@ -57,7 +57,7 @@ Export your environment variable for secure access to the API Keys.
 
 ```bash
 # replace <your-secret-key> with the "secretKey": output from tcld apikey create command
-export TEMPORAL_API_KEY=<your-secret-key>
+export TEMPORAL_CLOUD_API_KEY=<your-secret-key>
 ```
 
 :::tip ENVIRONMENT VARIABLES
@@ -72,7 +72,7 @@ Export your environment variable for secure access to the API Keys.
 
 ```bash
 # replace <your-secret-key> with the "secretKey": output from tcld apikey create command
-set TEMPORAL_API_KEY=<your-secret-key>
+set TEMPORAL_CLOUD_API_KEY=<your-secret-key>
 ```
 
 :::tip ENVIRONMENT VARIABLES


### PR DESCRIPTION
## What does this PR do?
Corrects the environment variable name in the terraform-provider instructions and makes it consistent with the documentation over at the [terraform registry](https://registry.terraform.io/providers/temporalio/temporalcloud/latest/docs#provider-configuration).

`TEMPORAL_API_KEY` is not picked up by the provider.

## Notes to reviewers

<!-- delete if n/a -->
