### PR TITLE
Update safe-deployments.mdx

### DIFF
--- a/docs/develop/safe-deployments.mdx
+++ b/docs/develop/safe-deployments.mdx
@@ -73,7 +73,6 @@ if args.mode == 'verify':
     histories = workflows.map_histories()
     replayer = Replayer(
         workflows=my_workflows,
-        activities=my_activities,
     )
     await replayer.replay_workflows(histories)
     return


### PR DESCRIPTION
Replayer does not take an `activities` parameter.
Removing that from the sample code to avoid confusion.

## What does this PR do?

Improves the Replayer example by removing an unsupported param

## Notes to reviewers

<!-- delete if n/a -->
