### PR TITLE
IP address warning

### DIFF
--- a/docs/production-deployment/cloud/connectivity/index.mdx
+++ b/docs/production-deployment/cloud/connectivity/index.mdx
@@ -27,6 +27,8 @@ Temporal Cloud supports private connectivity to namespaces via AWS PrivateLink o
 
 Namespace access is always securely authenticated via [API keys](/cloud/api-keys#overview) or [mTLS](/cloud/certificates), regardless of how you choose to connect.
 
+For information about IP address stability and allowlisting, see [IP addresses](/cloud/connectivity/ip-addresses).
+
 ### Required steps
 
 To use private connectivity with Temporal Cloud:

--- a/docs/production-deployment/cloud/connectivity/ip-addresses.mdx
+++ b/docs/production-deployment/cloud/connectivity/ip-addresses.mdx
@@ -1,0 +1,42 @@
+---
+id: ip-addresses
+title: IP Addresses
+sidebar_label: IP Addresses
+slug: /cloud/connectivity/ip-addresses
+description: Temporal Cloud IP addresses
+tags:
+  - Connectivity
+  - Production
+  - Security
+  - Temporal Cloud
+keywords:
+  - address
+  - allowlist
+  - cidr
+  - explanation
+  - failover
+  - ip
+  - namespaces
+  - private services connect
+  - privatelink
+  - psc
+  - whitelist
+---
+
+## Temporal Cloud IP addresses
+
+The specific IP addresses for Temporal Cloud resources are subject to change at any time. Temporal Cloud resources may use any IPs within the IP ranges published by the relevant cloud provider.
+
+If you need to limit outbound access from your client network, we recommend using [AWS PrivateLink or GCP Private Services Connect](/cloud/connectivity#private-network-connectivity-for-namespaces) instead of IP allowlisting.
+
+:::warning Do not allowlist specific IP addresses
+
+**Temporal Cloud IPs are not static and may change without notice.** 
+
+Do not allowlist specific IP addresses you see Temporal Cloud services using at a point in time, as this **will cause an outage** when those IPs change. Your clients will not be able to connect to Temporal Cloud.
+
+If you have to allowlist IP ranges, you must allowlist the entire cloud provider IP range:
+- [AWS IP address ranges](https://ip-ranges.amazonaws.com/ip-ranges.json)
+- [GCP IP address ranges](https://www.gstatic.com/ipranges/cloud.json)
+
+:::

--- a/sidebars.js
+++ b/sidebars.js
@@ -397,6 +397,7 @@ module.exports = {
               items: [
                 "production-deployment/cloud/connectivity/aws-connectivity",
                 "production-deployment/cloud/connectivity/gcp-connectivity",
+                "production-deployment/cloud/connectivity/ip-addresses",
               ],
             },
             "production-deployment/cloud/rpo-rto",


### PR DESCRIPTION
## What does this PR do?

Explicitly states that Temporal Cloud IP addresses are not stable.

<img width="306" height="160" alt="image" src="https://github.com/user-attachments/assets/c61524ff-fb25-4887-a0d7-694caaa6f807" />

<img width="2186" height="1318" alt="Google Chrome-IP Addresses  Temporal Platform Documentation-2025-09-17 at 10 39 32@2x" src="https://github.com/user-attachments/assets/39218f48-5912-4fe7-9ce5-4ea0384007c5" />
