### PR TITLE
fix typo in CNAME note on region DNS

### DIFF
--- a/docs/production-deployment/cloud/high-availability/failovers.mdx
+++ b/docs/production-deployment/cloud/high-availability/failovers.mdx
@@ -61,7 +61,7 @@ In most scenarios, we recommend you let Temporal handle failovers for you.
 After failover, be aware of the following points:
 
 - When working with Multi-region Namespaces, your CNAME may change.
-  For example, it may switch from aws-us-west-1.region.tmprl.com to aws-us-east-1.region.tmprl.com.
+  For example, it may switch from aws-us-west-1.region.tmprl.cloud to aws-us-east-1.region.tmprl.cloud.
   This change doesn't affect same-region Namespaces.
 
 - Your Namespace endpoint _will not change_.


### PR DESCRIPTION
## What does this PR do?

Fixes the note about regional DNS to use `.cloud` TLD instead of `.com`.

## Notes to reviewers

<!-- delete if n/a -->