### PR TITLE
chore: add a shim to avoid gtm runtime error

### DIFF
--- a/static/scripts/googletag.js
+++ b/static/scripts/googletag.js
@@ -1,3 +1,8 @@
+// --- SHIM: define gtag early so GTM tags won't throw ---
+window.dataLayer = window.dataLayer || [];
+window.gtag = window.gtag || function(){ window.dataLayer.push(arguments); };
+window.gtag('js', new Date());
+
 (function (w, d, s, l, i) {
   w[l] = w[l] || [];
   w[l].push({"gtm.start": new Date().getTime(), event: "gtm.js"});


### PR DESCRIPTION
## What does this PR do?

- This PR adds a few shim lines to define the gtag variable early so it doesn't through build errors. This does not interfere with anything else we have going on and should not affect Amplitude. I will verify this in Amplitude before merging

## Notes to reviewers

<!-- delete if n/a -->
