### PR TITLE
Fix broken links in best-practices

### DIFF
--- a/docs/best-practices/index.mdx
+++ b/docs/best-practices/index.mdx
@@ -37,11 +37,11 @@ This section is intended for:
 
 ## Available Guides
 
-**[Managing a Namespace](managing-namespace)**
+**[Managing a Namespace](/best-practices/managing-namespace)**
 Best practices for configuring, managing, and optimizing Temporal Namespaces.
 
-**[Managing Temporal Cloud Access Control](cloud-access-control)**
+**[Managing Temporal Cloud Access Control](/best-practices/cloud-access-control)**
 Guidelines for implementing proper access control and user management in Temporal Cloud.
 
-**[Security Controls for Temporal Cloud](security-controls)**
+**[Security Controls for Temporal Cloud](/best-practices/security-controls)**
 Comprehensive security practices for protecting your Temporal Cloud deployment.


### PR DESCRIPTION
The available guides section in 'best-practices' had broken links.

## What does this PR do?
Fixes the broken link in the 'Available Guides' section in best-practices page.

## Notes to reviewers
The links miss the `/best-practices/` part of the URL and are referencing on the base URL.

**Note:** 
1. The `navigation buttons` on the bottom are pointing to the correct page link.
2. One thing I am confused with though is, when you open the page for the first time , hovering over the link shows the correct link but clicking on the link takes to the broken page.


### Screenshot of the issue
<img width="1840" height="1191" alt="image" src="https://github.com/user-attachments/assets/c06db33d-8ab2-4cd5-8aae-0a17b59cd38f" />

<img width="959" height="520" alt="image" src="https://github.com/user-attachments/assets/d0c5b889-816d-498f-b95d-e382054f3788" />

