### PR TITLE
Fixed navbar styles

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1049,15 +1049,27 @@ h1 {
   margin-right: 40px;
 }
 
+.navbar__items--right {
+  flex-direction: row-reverse;
+}
+
+@media (max-width: 1241px) {
+  .navbar__link {
+    display: none;
+  }
+
+  a[href^="/ai-cookbook"] {
+    display: inline;
+  }
+}
+
 @media only screen and (min-width: 1400px) {
   .navbar__items--right {
-    width: 35vw;
-    flex-direction: row-reverse;
     justify-content: space-between;
   }
 
   .DocSearch {
-    width: 30vw;
+    width: fit-content;
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

With the addition of the AI Cookbook link in the navbar, the search button was overlapping links. This should clean up the navbar across all screen sizes.

https://github.com/user-attachments/assets/28538f8d-1452-4a72-98ac-8120e2e6038c