### PR TITLE
bump .NET Nexus dev guide min SDK version to 1.9.0

### DIFF
--- a/docs/develop/dotnet/temporal-nexus.mdx
+++ b/docs/develop/dotnet/temporal-nexus.mdx
@@ -48,7 +48,7 @@ This documentation uses source code derived from the [.NET Nexus sample](https:/
 Prerequisites:
 
 - [Install the latest Temporal CLI](https://learn.temporal.io/getting_started/dotnet/dev_environment/#set-up-a-local-temporal-service-for-development-with-temporal-cli) (v1.3.0 or higher recommended)
-- [Install the latest Temporal .NET SDK](https://learn.temporal.io/getting_started/dotnet/dev_environment/#install-the-temporal-net-sdk) (v1.0.0 or higher)
+- [Install the latest Temporal .NET SDK](https://learn.temporal.io/getting_started/dotnet/dev_environment/#install-the-temporal-net-sdk) (v1.9.0 or higher)
 
 The first step in working with Temporal Nexus involves starting a Temporal server with Nexus enabled.
 


### PR DESCRIPTION
## What does this PR do?
- bumps min version of Temporal .NET SDK in dev guide