### PR TITLE
Fixing a typo about multi-cloud replication being GA

### DIFF
--- a/docs/production-deployment/cloud/high-availability/enable.mdx
+++ b/docs/production-deployment/cloud/high-availability/enable.mdx
@@ -12,7 +12,7 @@ import { ToolTipTerm } from '@site/src/components';
 
 Same-region Replication and Multi-cloud Replication are in [Public Preview](/evaluate/development-production-features/release-stages#public-preview).
 
-Multi-cloud Replication is in [General Availability](/evaluate/development-production-features/release-stages#general-availability)
+Multi-region Replication is in [General Availability](/evaluate/development-production-features/release-stages#general-availability)
 
 :::
 


### PR DESCRIPTION
Multi-cloud Replication is still in preview, as per the previous comment.

Multi-region Replication is GA.