### PR TITLE
fix variable name type

### DIFF
--- a/docs/develop/go/error-handling.mdx
+++ b/docs/develop/go/error-handling.mdx
@@ -31,7 +31,7 @@ if err != nil {
 	var applicationErr *ApplicationError
 	if errors.As(err, &applicationErr) {
 		// retrieve error message
-		fmt.Println(applicationError.Error())
+		fmt.Println(applicationErr.Error())
 
 		// handle Activity errors (created via NewApplicationError() API)
 		var detailMsg string // assuming Activity return error by NewApplicationError("message", true, "string details")


### PR DESCRIPTION


## What does this PR do?

This PR fixes a typo in the documentation for golang activity error handling.

The variable is `applicationErr` and the type is `ApplicationError`.  This changes the reference from `applicationError` to `applicationErr`