### PR TITLE
Updated Java Poller Auto-scaling example

### DIFF
--- a/docs/develop/worker-performance.mdx
+++ b/docs/develop/worker-performance.mdx
@@ -230,7 +230,7 @@ These options define the maximum count of pollers performing poll requests on Wo
 w := worker.New(c, "my-task-queue", worker.Options{
   WorkflowTaskPollerBehavior: worker.NewPollerBehaviorAutoscaling(worker.PollerBehaviorAutoscalingOptions{}),
   ActivityTaskPollerBehavior: worker.NewPollerBehaviorAutoscaling(worker.PollerBehaviorAutoscalingOptions{}),
-  NexusTaskPollerBehavior: worker.NewPollerBehaviorAutoscaling(),
+  NexusTaskPollerBehavior: worker.NewPollerBehaviorAutoscaling(worker.PollerBehaviorAutoscalingOptions{}),
 })
 ```
 </SdkTabs.Go>


### PR DESCRIPTION
## What does this PR do?

This corrects the implementation for the default settings for Poller Auto-scaling in the Java example. `PollerBehaviorAutoscaling` is a class in Java so the default is `new PollerBehaviorAutoscaling()`.