### PR TITLE
Remove worker versioning redirect

### DIFF
--- a/docs/encyclopedia/workers/worker-versioning.mdx
+++ b/docs/encyclopedia/workers/worker-versioning.mdx
@@ -1,5 +1,5 @@
 ---
-id: worker-versioning-concepts
+id: worker-versioning
 title: Worker Versioning
 sidebar_label: Worker Versioning
 description: Learn the concepts behind Worker Versioning and the details behind how it works.

--- a/sidebars.js
+++ b/sidebars.js
@@ -714,7 +714,7 @@ module.exports = {
             'encyclopedia/workers/task-routing-worker-sessions',
             'encyclopedia/workers/sticky-execution',
             'encyclopedia/workers/worker-shutdown',
-            'encyclopedia/workers/worker-versioning-concepts',
+            'encyclopedia/workers/worker-versioning',
           ],
         },
         {


### PR DESCRIPTION
## What does this PR do?

- This removes the worker versioning redirect so that the encyclopedia page will come up first.
- Updates the description of the worker versioning encyclopedia page