### PR TITLE
Updated references to legacy worker versioning implementation

### DIFF
--- a/docs/develop/go/versioning.mdx
+++ b/docs/develop/go/versioning.mdx
@@ -26,7 +26,11 @@ With Versioning, you can modify your Workflow Definition so that new executions 
 There are two primary Versioning methods that you can use:
 
 - [Versioning with Patching](#patching). This method works by adding branches to your code tied to specific revisions. It applies a code change to new Workflow Executions while avoiding disruptive changes to in-progress ones.
-- [Worker Versioning](/production-deployment/worker-deployments/worker-versioning). The Worker Versioning feature allows you to tag your Workers and programmatically roll them out in versioned deployments, so that old Workers can run old code paths and new Workers can run new code paths. If you were using this method experimentally prior to summer 2025, refer to the [Worker Versioning Legacy](worker-versioning-legacy) docs.
+- [Worker Versioning](/production-deployment/worker-deployments/worker-versioning). The Worker Versioning feature allows you to tag your Workers and programmatically roll them out in versioned deployments, so that old Workers can run old code paths and new Workers can run new code paths.
+
+:::danger
+Support for the experimental Worker Versioning method before 2025 will be removed from Temporal Server in March 2026. Refer to the [latest Worker Versioning docs](/worker-versioning) for guidance. You can still refer to the [Worker Versioning Legacy](worker-versioning-legacy) docs if needed. 
+:::
 
 ## Versioning with Patching {#patching}
 

--- a/docs/develop/java/versioning.mdx
+++ b/docs/develop/java/versioning.mdx
@@ -27,7 +27,11 @@ With Versioning, you can modify your Workflow Definition so that new executions 
 There are two primary Versioning methods that you can use:
 
 - [Versioning with Patching](#patching). This method works by adding branches to your code tied to specific revisions. It applies a code change to new Workflow Executions while avoiding disruptive changes to in-progress ones.
-- [Worker Versioning](/production-deployment/worker-deployments/worker-versioning). The Worker Versioning feature allows you to tag your Workers and programmatically roll them out in versioned deployments, so that old Workers can run old code paths and new Workers can run new code paths. If you were using this method experimentally prior to summer 2025, refer to the [Worker Versioning Legacy](worker-versioning-legacy) docs.
+- [Worker Versioning](/production-deployment/worker-deployments/worker-versioning). The Worker Versioning feature allows you to tag your Workers and programmatically roll them out in versioned deployments, so that old Workers can run old code paths and new Workers can run new code paths.
+
+:::danger
+Support for the experimental Worker Versioning method before 2025 will be removed from Temporal Server in March 2026. Refer to the [latest Worker Versioning docs](/worker-versioning) for guidance. You can still refer to the [Worker Versioning Legacy](worker-versioning-legacy) docs if needed. 
+:::
 
 ## Versioning with Patching {#patching}
 

--- a/docs/develop/python/versioning.mdx
+++ b/docs/develop/python/versioning.mdx
@@ -38,7 +38,11 @@ With Versioning, you can modify your Workflow Definition so that new executions 
 There are two primary Versioning methods that you can use:
 
 - [Versioning with Patching](#patching). This method works by adding branches to your code tied to specific revisions. It applies a code change to new Workflow Executions while avoiding disruptive changes to in-progress ones.
-- [Worker Versioning](/production-deployment/worker-deployments/worker-versioning). The Worker Versioning feature allows you to tag your Workers and programmatically roll them out in versioned deployments, so that old Workers can run old code paths and new Workers can run new code paths. If you were using this method experimentally prior to summer 2025, refer to the [Worker Versioning Legacy](worker-versioning-legacy) docs.
+- [Worker Versioning](/production-deployment/worker-deployments/worker-versioning). The Worker Versioning feature allows you to tag your Workers and programmatically roll them out in versioned deployments, so that old Workers can run old code paths and new Workers can run new code paths.
+
+:::danger
+Support for the experimental Worker Versioning method before 2025 will be removed from Temporal Server in March 2026. Refer to the [latest Worker Versioning docs](/worker-versioning) for guidance. You can still refer to the [Worker Versioning Legacy](worker-versioning-legacy) docs if needed. 
+:::
 
 ## Versioning with Patching {#patching}
 

--- a/docs/develop/typescript/versioning.mdx
+++ b/docs/develop/typescript/versioning.mdx
@@ -28,7 +28,11 @@ With Versioning, you can modify your Workflow Definition so that new executions 
 There are two primary Versioning methods that you can use:
 
 - [Versioning with Patching](#patching). This method works by adding branches to your code tied to specific revisions. It applies a code change to new Workflow Executions while avoiding disruptive changes to in-progress ones.
-- [Worker Versioning](/production-deployment/worker-deployments/worker-versioning). The Worker Versioning feature allows you to tag your Workers and programmatically roll them out in versioned deployments, so that old Workers can run old code paths and new Workers can run new code paths. If you were using this method experimentally prior to summer 2025, refer to the [Worker Versioning Legacy](worker-versioning-legacy) docs.
+- [Worker Versioning](/production-deployment/worker-deployments/worker-versioning). The Worker Versioning feature allows you to tag your Workers and programmatically roll them out in versioned deployments, so that old Workers can run old code paths and new Workers can run new code paths.
+
+:::danger
+Support for the experimental Worker Versioning method before 2025 will be removed from Temporal Server in March 2026. Refer to the [latest Worker Versioning docs](/worker-versioning) for guidance. You can still refer to the [Worker Versioning Legacy](worker-versioning-legacy) docs if needed. 
+:::
 
 ## Versioning with Patching {#patching}
 

--- a/docs/encyclopedia/workers/worker-versioning.mdx
+++ b/docs/encyclopedia/workers/worker-versioning.mdx
@@ -41,6 +41,8 @@ When a Worker starts polling for Workflow and Activity Tasks, it reports its Dep
 
 Using **Workflow Pinning**, you can declare each Workflow type to have a **Versioning Behavior**, either Pinned or Auto-Upgrade.
 
+To learn more about implementing Worker Versioning, see our [Worker Versioning in production](production-deployment/worker-deployments/worker-versioning) page.
+
 ### Pinned Workflows {#pinned}
 
 A **Pinned** Workflow is guaranteed to complete on a single Worker Deployment Version. You can mark a Workflow Type as pinned when you register it by adding an additional Pinned parameter. If you need to move a pinned Workflow to a new version, use [`temporal workflow update-options`](https://docs.temporal.io/cli/workflow#update-options).

--- a/docs/encyclopedia/workflow/workflow-definition.mdx
+++ b/docs/encyclopedia/workflow/workflow-definition.mdx
@@ -268,7 +268,7 @@ A versioning strategy is even more important if your Workflow Executions live lo
 Temporal offers two Versioning strategies:
 
 - [Versioning with patching](#workflow-patching): make sure your code changes are compatible across versions of your Workflow.
-- [Worker Versioning](#worker-versioning): keep Workers tied to specific code revisions, so that old Workers can run old code paths and new Workers can run new code paths. (Note: If you were using this method experimentally prior to 2025, refer to the [Worker Versioning Legacy](/encyclopedia/worker-versioning-legacy) docs, but note that these are planned for deprecation.)
+- [Worker Versioning](#worker-versioning): keep Workers tied to specific code revisions, so that old Workers can run old code paths and new Workers can run new code paths. (**Note:** Support for the experimental method prior to 2025 will be removed from Temporal Server in March 2026. Refer to the [latest Worker Versioning docs](/worker-versioning) for guidance.)
 
 You can use either strategy, or a combination.
 
@@ -289,7 +289,7 @@ To test, see [Safe Deployments](/develop/safe-deployments.mdx).
 
 #### Worker Versioning {#worker-versioning}
 
-To learn more about Worker Versioning, see our [Worker Versioning](production-deployment/worker-deployments/worker-versioning) page.
+To learn more about Worker Versioning, see our [Worker Versioning in production](production-deployment/worker-deployments/worker-versioning) page.
 
 ### Handling unreliable Worker Processes {#unreliable-worker-processes}
 


### PR DESCRIPTION
## What does this PR do?

- Changes the message for legacy Worker Versioning implementation to note that it will be deprecated in March 2026
- Removes the legacy pages from the search results

## Notes to reviewers

<!-- delete if n/a -->