### PR TITLE
Removed activating task failure view section (for now)

### DIFF
--- a/docs/encyclopedia/detecting-workflow-failures.mdx
+++ b/docs/encyclopedia/detecting-workflow-failures.mdx
@@ -119,8 +119,5 @@ To identify Workflows with Task failures, you can use the Temporal Web UI. See [
 You can also detect Workflows with Task failures by searching for the `TemporalReportedProblems` search attribute with your observability tools.
 
 :::warning Activating Workflow Task Failure in AWS Namespaces
-
 To enable the Task Failures View for a Namespace running on AWS, you need to update the Dynamic Config for that Namespace.
-See [Activating Task Failure View for AWS Namespaces](/web-ui/#activate-task-failures-view-for-aws).
-
 :::

--- a/docs/web-ui.mdx
+++ b/docs/web-ui.mdx
@@ -147,42 +147,6 @@ Clicking on any of the links in the details opens the Workflow page for that Wor
 On this page, you will find more information about the Task that failed and remaining pending tasks.
 You can also cancel the Workflow by clicking the Request Cancellation button on this page.
 
-### Activating Task Failure View for AWS Namespaces {#activate-task-failures-view-for-aws}
-
-To enable the Task Failures View for a Namespace running on AWS, you need to update the Dynamic Config first.
-To turn the feature on for a Namespace, use the following command:
-
-``` command
-omni ocld dynamic-config namespace patch --namespace "$NS" --json '{
-     "system.numConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute": 5
-}'
-```
-
-`$NS` is the name of the Namespace where you want to set up Task Failures view. 
-`numConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute` is the number of consecutive Workflow Task Failures 
-required to trigger the `TemporalReportedProblems` search attribute. 
-The default value is 5. If adding this search attribute causes strain on the visibility system, consider increasing this number.
-
-To turn off the feature for a Namespace, set `numConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute` to 0.
-You can also deactivate the feature by removing the key:
-
-``` command
-omni ocld dynamic-config namespace remove \
-    -n "$NS" \
-    --key "system.numConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute"
-```
-
-where `$NS` is the name of the Namespace for which you wish to deactivate the feature.
-
-To determine which Namespaces in your fleet have the feature activated, use the following command:
-
-``` command
-omni ocld dc search \
-    --namespace \
-    --key-regex 'system.numConsecutiveWorkflowTaskProblemsToTriggerSearchAttribute' \
-    --all
-```
-
 ## History
 
 A Workflow Execution History is a view of the [Events](/workflow-execution/event#event) and Event fields within the


### PR DESCRIPTION
## What does this PR do?

We noticed that the commands being used in this section weren't available to external users. We're removing this for now until we get the recommendations for how to activate task failure view, then we'll add this section back.

## Notes to reviewers

This is a temp update. The section will be added back later.