### PR TITLE
fix: drop nonexistent `--fields` flag from `temporal workflow list` doc

### DIFF
--- a/docs/cli/index.mdx
+++ b/docs/cli/index.mdx
@@ -403,7 +403,7 @@ $ temporal workflow describe --workflow-id 123
 For more detailed output in JSON format, use the following command:
 
 ```shell
-$ temporal workflow list --fields long --output json
+$ temporal workflow list --output json
 
 [
   {
@@ -426,7 +426,7 @@ $ temporal workflow list --fields long --output json
 Filter out Workflows based on Workflow Type with [jq](https://stedolan.github.io/jq/):
 
 ```shell
-$ temporal workflow list --fields long --output json | jq '.[].type.name'
+$ temporal workflow list --output json | jq '.[].type.name'
 
 "OtherWorkflow"
 "MyWorkflow"
@@ -436,7 +436,7 @@ $ temporal workflow list --fields long --output json | jq '.[].type.name'
 To count the number of Workflows, use the following command:
 
 ```shell
-$ temporal workflow list --fields long --output json | jq '.[].type.name' | uniq -c
+$ temporal workflow list --output json | jq '.[].type.name' | uniq -c
 
    1 "OtherWorkflow"
    2 "MyWorkflow"


### PR DESCRIPTION
## What does this PR do?

## Notes to reviewers

<!-- delete if n/a -->