### PR TITLE
Min Server for bug-free Worker Versioning is v1.29.1

### DIFF
--- a/docs/production-deployment/worker-deployments/worker-versioning.mdx
+++ b/docs/production-deployment/worker-deployments/worker-versioning.mdx
@@ -62,7 +62,7 @@ Minimum versions:
 Self-hosted users:
 
 - Minimum Temporal CLI version [v1.4.1](https://github.com/temporalio/cli/releases/tag/v1.4.1)
-- Minimum Temporal Server version: [v1.28.0](https://github.com/temporalio/temporal/releases/tag/v1.28.0)
+- Minimum Temporal Server version: [v1.29.1](https://github.com/temporalio/temporal/releases/tag/v1.29.1)
 - Minimum Temporal UI Version [v2.38.0](https://github.com/temporalio/ui/releases/tag/v2.38.0)
   :::
 


### PR DESCRIPTION
## What does this PR do?
Bumps minimum required OSS server for worker versioning to v1.29.1

## Notes to reviewers
v1.29.1 fixes a bug in versioned workflow retry. In OSS versions less than this, retried versioned workflows will be stuck since they will be incorrectly treated as unversioned.

<!-- delete if n/a -->