### PR TITLE
Add Ruby hearbeats docs

### DIFF
--- a/docs/production-deployment/cloud/worker-health.mdx
+++ b/docs/production-deployment/cloud/worker-health.mdx
@@ -26,6 +26,10 @@ keywords:
   - workflow task execution size
   - temporal worker resources
 ---
+import { LANGUAGE_TAB_GROUP, getLanguageLabel } from '@site/src/constants/languageTabs';
+import SdkTabs from '@site/src/components';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
 
 This page is a guide to monitoring a Temporal Worker fleet and covers the following scenarios:
 


### PR DESCRIPTION
## What does this PR do?
Adds docs for Ruby Worker heartbeats. Moves to using a tab design and linking to existing docs more aggressively.

## Notes to reviewers

<!-- delete if n/a -->