### PR TITLE
Update deep research sample links to Braintrust cookbook

### DIFF
--- a/docs/develop/python/integrations/braintrust.mdx
+++ b/docs/develop/python/integrations/braintrust.mdx
@@ -37,7 +37,7 @@ The Temporal Python SDK integration with Braintrust is currently in
 :::
 
 All code snippets in this guide are taken from the
-[deep research sample](https://github.com/temporalio/samples-python/tree/main/braintrust). Refer to the sample for the
+[deep research sample](https://github.com/braintrustdata/braintrust-cookbook/blob/main/examples/TemporalDeepResearch/TemporalDeepResearch.mdx). Refer to the sample for the
 complete code and run it locally.
 
 ## Prerequisites
@@ -249,7 +249,7 @@ except Exception as e:
 
 ## Example: Deep Research Agent
 
-The [deep research sample](https://github.com/temporalio/samples-python/tree/main/braintrust) demonstrates a complete AI
+The [deep research sample](https://github.com/braintrustdata/braintrust-cookbook/blob/main/examples/TemporalDeepResearch/TemporalDeepResearch.mdx) demonstrates a complete AI
 agent that:
 
 - Plans research strategies


### PR DESCRIPTION
## What does this PR do?

Updates the deep research sample links in the Braintrust integration documentation to point to the Braintrust cookbook instead of temporalio/samples-python.

**Before:**
- `https://github.com/temporalio/samples-python/tree/main/braintrust`

**After:**
- `https://github.com/braintrustdata/braintrust-cookbook/blob/main/examples/TemporalDeepResearch/TemporalDeepResearch.mdx`

## Notes to reviewers

This updates two link references in `docs/develop/python/integrations/braintrust.mdx`:
1. The introductory reference to the sample code
2. The "Example: Deep Research Agent" section reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)