### PR TITLE
fix(sidebar): made scrolling to current page work

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,7 +24,7 @@ module.exports = async function createConfigAsync() {
         },
       },
     ],
-    clientModules: ['./src/client/remote-amplitude-analytics.js'],
+    clientModules: ['./src/client/remote-amplitude-analytics.js', './src/client/scrollSidebarToActivePage.ts'],
     themeConfig: {
       colorMode: {
         defaultMode: 'dark',

--- a/sidebars.js
+++ b/sidebars.js
@@ -5,7 +5,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Evaluate',
-      collapsed: false,
+      collapsed: true,
       link: {
         type: 'doc',
         id: 'evaluate/index',
@@ -80,7 +80,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Develop',
-      collapsed: false,
+      collapsed: true,
       link: {
         type: 'doc',
         id: 'develop/index',
@@ -527,7 +527,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Deploy to production',
-      collapsed: false,
+      collapsed: true,
       link: {
         type: 'doc',
         id: 'production-deployment/index',

--- a/src/client/scrollSidebarToActivePage.ts
+++ b/src/client/scrollSidebarToActivePage.ts
@@ -1,0 +1,55 @@
+// src/clientModules/scrollSidebarToActive.ts
+import type { ClientModule } from '@docusaurus/types';
+
+function scrollActiveSidebarLink() {
+  // The aria label is the only one that consistently marks the active link
+  const activeLink = document.querySelector(
+    '.theme-doc-sidebar-container a[aria-current="page"]'
+  ) as HTMLElement | null;
+
+  if (!activeLink) return false;
+
+  // Scroll the menu that actually contains this link
+  const menu = activeLink.closest('.menu') as HTMLElement | null;
+  if (!menu) return false;
+
+  const menuRect = menu.getBoundingClientRect();
+  const linkRect = activeLink.getBoundingClientRect();
+
+  const linkTopWithinMenu = linkRect.top - menuRect.top + menu.scrollTop;
+
+  const targetScrollTop = linkTopWithinMenu - menu.clientHeight / 2 + linkRect.height / 2;
+
+  menu.scrollTo({
+    top: Math.max(0, targetScrollTop),
+    behavior: 'auto',
+  });
+
+  return true;
+}
+
+function runWhenReady() {
+  let tries = 0;
+  const maxTries = 120; // ~2 seconds
+
+  const tick = () => {
+    tries++;
+    if (scrollActiveSidebarLink() || tries >= maxTries) return;
+    requestAnimationFrame(tick);
+  };
+
+  requestAnimationFrame(tick);
+}
+
+const module: ClientModule = {
+  onRouteDidUpdate({ location, previousLocation }) {
+    // Skip hash-only changes
+    if (previousLocation && location.pathname === previousLocation.pathname) {
+      return;
+    }
+
+    runWhenReady();
+  },
+};
+
+export default module;


### PR DESCRIPTION
## What does this PR do?

This collapses all of the menus in the sidebar and automatically scrolls the sidebar to the current page a reader is on, even if they refresh or come from a direct link. This addresses https://github.com/temporalio/documentation/issues/4108.

## Notes to reviewers

Here's a quick demo:

https://github.com/user-attachments/assets/75331af8-b4ea-44a1-9adf-606c2706fe81