### PR TITLE
GRWMK-179: Create Docs Redirect for Cloud Terraform Provider

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2049,6 +2049,11 @@
       "source": "/cloud/audit-logging-gcp",
       "destination": "/cloud/audit-logs-gcp",
       "permanent": true
+    },
+    {
+      "source": "/production-deployment/cloud/terraform-provider",
+      "destination": "/cloud/terraform-provider",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
## What does this PR do?
Addresses [GRWMK-179](https://temporalio.atlassian.net/browse/GRWMK-179)
Adds in a redirect for a link that 404s but persistently arrives in google search: www.google.com/search?q=temporal+terraform


## Notes to reviewers
Test on the generated preview link.
https://temporal-documentation-git-grwmk-179-create-docs-redirec-a4d25a.preview.thundergun.io/production-deployment/cloud/terraform-provider 


[GRWMK-179]: https://temporalio.atlassian.net/browse/GRWMK-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ