### PR TITLE
Add /mcp authentication instruction for Claude Code

### DIFF
--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -29,7 +29,7 @@ To add it to a specific project only (stored in `.mcp.json`):
 claude mcp add --transport http temporal-docs https://temporal.mcp.kapa.ai
 ```
 
-After adding, restart Claude Code for the changes to take effect.
+After adding, restart Claude Code and run `/mcp` to authenticate with your Google account.
 
 ## Claude Desktop
 


### PR DESCRIPTION
## Summary
- Adds instruction to run `/mcp` after installation to authenticate with Google account

## Test plan
- [ ] Verify the with-ai page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)