### PR TITLE
remove list audit logs command in tcld

### DIFF
--- a/docs/cloud/tcld/account.mdx
+++ b/docs/cloud/tcld/account.mdx
@@ -31,7 +31,6 @@ Alias: `al`
 
 - [tcld account audit-log kinesis](#kinesis)
 - [tcld account audit-log pubsub](#pubsub)
-- [tcld account audit-log list](#audit-log-list)
 
 ### kinesis
 
@@ -308,32 +307,6 @@ Provide a name for the sink.
 The topic name to write to the sink.
 
 Alias: `tn`
-
-### list {#audit-log-list}
-
-Returns a paginated list of audit logs for the account, optionally filtered by time range.
-
-Alias: `l`
-
-#### --end-time
-
-The end time (exclusive) in RFC3339 format (e.g., '2006-01-02T15:04:05Z' or '2006-01-02T15:04:05+07:00').
-
-Alias: `et`
-
-#### --page-size
-
-The page size for list operations.
-
-#### --page-token
-
-The page token for list operations.
-
-#### --start-time
-
-The start time (inclusive) in RFC3339 format (e.g., '2006-01-02T15:04:05Z' or '2006-01-02T15:04:05+07:00').
-
-Alias: `st`
 
 ## get
 


### PR DESCRIPTION
This reverts commit c28f6e386a1cfd1223fd5166f07404eff11c54a8.
we're removing this from tcld so also remove the docs references
## What does this PR do?

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213078808140788">EDU-5855 remove list audit logs command in tcld</a>
