### PR TITLE
Remove references to web UI env vars

### DIFF
--- a/docs/references/web-ui-environment-variables.mdx
+++ b/docs/references/web-ui-environment-variables.mdx
@@ -29,7 +29,6 @@ docker run\
 -e TEMPORAL_CLOUD_UI=false\
 -e TEMPORAL_DEFAULT_NAMESPACE=default\
 -e TEMPORAL_FEEDBACK_URL=https://feedback.here\
--e TEMPORAL_NOTIFY_ON_NEW_VERSION=true\
 -e TEMPORAL_CONFIG_REFRESH_INTERVAL=0s\
 -e TEMPORAL_SHOW_TEMPORAL_SYSTEM_NAMESPACE=false\
 -e TEMPORAL_DISABLE_WRITE_ACTIONS=false\
@@ -95,10 +94,6 @@ The default [Namespace](/namespaces) that the Web UI opens first.
 The URL that users are directed to when they click the Feedback button in the UI.
 
 If not specified, this variable defaults to the UI's GitHub Issue page.
-
-## `TEMPORAL_NOTIFY_ON_NEW_VERSION`
-
-Enables or disables notifications that appear in the UI whenever a newer version of the Temporal Cluster is available.
 
 ## `TEMPORAL_CONFIG_REFRESH_INTERVAL`
 


### PR DESCRIPTION
## What does this PR do?

Removes references to unused `TEMPORAL_BANNER_TEXT` and `TEMPORAL_NOTIFY_ON_NEW_VERSION` environment variables.

## Notes to reviewers

<!-- delete if n/a -->
 See https://github.com/temporalio/ui/pull/3163.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213320398509707">EDU-5919 Remove references to web UI env vars</a>
