### PR TITLE
Go: Note that workers should run in dedicated terminal instances

### DIFF
--- a/docs/develop/go/core-application.mdx
+++ b/docs/develop/go/core-application.mdx
@@ -911,6 +911,13 @@ Lastly, call either the `Start()` or the `Run()` method on the instance of the W
 Run accepts an interrupt channel as a parameter, so that the Worker can be stopped in the terminal.
 Otherwise, the `Stop()` method must be called to stop the Worker.
 
+:::note
+
+The Worker process is a long-running process that blocks while polling for tasks. Run it in a separate terminal from your
+starter code or other application logic.
+
+:::
+
 :::tip
 
 If you have [`gow`](https://github.com/mitranim/gow) installed, the Worker Process automatically "reloads" when you update the Worker file:


### PR DESCRIPTION
## What does this PR do?

Make a note that workers should run in dedicated terminal instances. This was something I remember I misunderstood when I first learned about Temporal. Probably worth having this in the `Core application` section of the docs. I'm also not 100% if other SDKs have this same flow, but also probably worth porting this to other SDKs that share this requirement.

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213351077319440">EDU-5920 Go: Note that workers should run in dedicated terminal instances</a>
