### PR TITLE
Add activity metrics to OpenMetrics reference

### DIFF
--- a/docs/cloud/metrics/openmetrics/metrics-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-reference.mdx
@@ -248,193 +248,6 @@ Workflows continued as new per second.
 
 **Type**: Rate
 
-### Task Queue Metrics
-
-:::caution High Cardinality
-
-These metrics could have high cardinality depending on number of task queues present.
-
-:::
-
-#### temporal\_cloud\_v1\_approximate\_backlog\_count
-
-The approximate number of tasks pending in a task queue. Started Activities are not included in the count as they have been dequeued from the task queue.
-
-| Label | Description |
-| ----- | ----- |
-| `temporal_task_queue` | The task queue name |
-| `task_type` | Type of task: `workflow` or `activity` |
-
-**Type**: Value
-
-#### temporal\_cloud\_v1\_poll\_success\_count
-
-Successfully matched tasks per second.
-
-| Label | Description |
-| ----- | ----- |
-| `operation` | The poll operation name |
-| `task_type` | Type of task: `workflow` or `activity` |
-| `temporal_task_queue` | The task queue name |
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_poll\_success\_sync\_count
-
-Tasks matched synchronously per second (no polling wait).
-
-| Label | Description |
-| ----- | ----- |
-| `operation` | The poll operation name |
-| `task_type` | Type of task: `workflow` or `activity` |
-| `temporal_task_queue` | The task queue name |
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_poll\_timeout\_count
-
-The rate of poll requests that timed out without receiving a task.
-
-| Label | Description |
-| ----- | ----- |
-| `operation` | The poll operation name |
-| `task_type` | Type of task: `workflow` or `activity` |
-| `temporal_task_queue` | The task queue name |
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_no\_poller\_tasks\_count
-
-The rate of tasks added to queues with no active pollers.
-
-| Label | Description |
-| ----- | ----- |
-| `temporal_task_queue` | The task queue name |
-| `task_type` | Type of task: `workflow` or `activity` |
-
-**Type**: Rate
-
-### Namespace Metrics
-
-#### temporal\_cloud\_v1\_namespace\_open\_workflows
-
-The current number of open workflows in a namespace.
-
-**Type**: Value
-
-#### temporal\_cloud\_v1\_total\_action\_count
-
-The total number of actions performed per second. Actions with `is_background=false` are counted toward the ``temporal_cloud_v1_action_limit``.
-
-| Label | Description |
-| ----- | ----- |
-| `is_background` | Whether the action was background: `true` or `false`. Background actions (e.g. History export) do not count toward the action rate limit |
-| `namespace_mode` | Indicates if actions are produced by an `active` or a `standby` Namespace |
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_total\_action\_throttled\_count
-
-The total number of actions throttled per second.
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_operations\_count
-
-Operations performed per second.
-
-| Label | Description |
-| ----- | ----- |
-| `operation` | The name of the operation |
-| `is_background` | Whether the operation was background: `true` or `false`. Background operations do not count toward the operation rate limit |
-| `namespace_mode` | Indicates if operations are produced by an `active` or a `standby` Namespace |
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_operations\_throttled\_count
-
-Operations throttled due to rate limits per second.
-
-| Label | Description |
-| ----- | ----- |
-| `operation` | The name of the operation |
-| `is_background` | Whether the operation was background: `true` or `false`. Background operations do not count toward the operation rate limit |
-| `namespace_mode` | Indicates if actions are throttled in an `active` or a `standby` Namespace |
-
-**Type**: Rate
-
-### Schedule Metrics
-
-#### temporal\_cloud\_v1\_schedule\_action\_success\_count
-
-Successfully executed scheduled workflows per second.
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_schedule\_buffer\_overruns\_count
-
-The rate of schedule buffer overruns when using `BUFFER_ALL` overlap policy.
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_schedule\_missed\_catchup\_window\_count
-
-The rate of missed schedule executions outside the catchup window.
-
-**Type**: Rate
-
-#### temporal\_cloud\_v1\_schedule\_rate\_limited\_count
-
-The rate of scheduled workflows delayed due to rate limiting.
-
-**Type**: Rate
-
-### Replication Metrics
-
-#### temporal\_cloud\_v1\_replication\_lag\_p50
-
-The 50th percentile cross-region replication lag in seconds.
-
-**Type**: Latency
-
-#### temporal\_cloud\_v1\_replication\_lag\_p95
-
-The 95th percentile cross-region replication lag in seconds.
-
-**Type**: Latency
-
-#### temporal\_cloud\_v1\_replication\_lag\_p99
-
-The 99th percentile cross-region replication lag in seconds.
-
-**Type**: Latency
-
-### Limit Metrics
-
-#### temporal\_cloud\_v1\_operations\_limit
-
-The current configured operations per second limit for a namespace.
-
-**Type**: Value
-
-#### temporal\_cloud\_v1\_action\_limit
-
-The current configured actions per second limit for a namespace. Track utilization against this limit with ``temporal_cloud_v1_total_action_count`` and `is_background=false`.
-
-**Type**: Value
-
-#### temporal\_cloud\_v1\_service\_request\_limit
-
-The current configured frontend service RPS limit for a namespace. Track utilization against this limit with ``temporal_cloud_v1_service_request_count``
-
-**Type**: Value
-
-#### temporal\_cloud\_v1\_poller\_limit
-
-The current configured poller limit for a namespace. Track utilization against this limit with ``temporal_cloud_v1_service_pending_requests``.
-
-**Type**: Value
-
 ### Activity Metrics
 
 :::caution High Cardinality
@@ -631,4 +444,191 @@ The 99th percentile activity schedule-to-close latency in seconds.
 | `temporal_activity_type` | The activity type (opt-in) |
 
 **Type**: Latency
+
+### Task Queue Metrics
+
+:::caution High Cardinality
+
+These metrics could have high cardinality depending on number of task queues present.
+
+:::
+
+#### temporal\_cloud\_v1\_approximate\_backlog\_count
+
+The approximate number of tasks pending in a task queue. Started Activities are not included in the count as they have been dequeued from the task queue.
+
+| Label | Description |
+| ----- | ----- |
+| `temporal_task_queue` | The task queue name |
+| `task_type` | Type of task: `workflow` or `activity` |
+
+**Type**: Value
+
+#### temporal\_cloud\_v1\_poll\_success\_count
+
+Successfully matched tasks per second.
+
+| Label | Description |
+| ----- | ----- |
+| `operation` | The poll operation name |
+| `task_type` | Type of task: `workflow` or `activity` |
+| `temporal_task_queue` | The task queue name |
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_poll\_success\_sync\_count
+
+Tasks matched synchronously per second (no polling wait).
+
+| Label | Description |
+| ----- | ----- |
+| `operation` | The poll operation name |
+| `task_type` | Type of task: `workflow` or `activity` |
+| `temporal_task_queue` | The task queue name |
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_poll\_timeout\_count
+
+The rate of poll requests that timed out without receiving a task.
+
+| Label | Description |
+| ----- | ----- |
+| `operation` | The poll operation name |
+| `task_type` | Type of task: `workflow` or `activity` |
+| `temporal_task_queue` | The task queue name |
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_no\_poller\_tasks\_count
+
+The rate of tasks added to queues with no active pollers.
+
+| Label | Description |
+| ----- | ----- |
+| `temporal_task_queue` | The task queue name |
+| `task_type` | Type of task: `workflow` or `activity` |
+
+**Type**: Rate
+
+### Namespace Metrics
+
+#### temporal\_cloud\_v1\_namespace\_open\_workflows
+
+The current number of open workflows in a namespace.
+
+**Type**: Value
+
+#### temporal\_cloud\_v1\_total\_action\_count
+
+The total number of actions performed per second. Actions with `is_background=false` are counted toward the ``temporal_cloud_v1_action_limit``.
+
+| Label | Description |
+| ----- | ----- |
+| `is_background` | Whether the action was background: `true` or `false`. Background actions (e.g. History export) do not count toward the action rate limit |
+| `namespace_mode` | Indicates if actions are produced by an `active` or a `standby` Namespace |
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_total\_action\_throttled\_count
+
+The total number of actions throttled per second.
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_operations\_count
+
+Operations performed per second.
+
+| Label | Description |
+| ----- | ----- |
+| `operation` | The name of the operation |
+| `is_background` | Whether the operation was background: `true` or `false`. Background operations do not count toward the operation rate limit |
+| `namespace_mode` | Indicates if operations are produced by an `active` or a `standby` Namespace |
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_operations\_throttled\_count
+
+Operations throttled due to rate limits per second.
+
+| Label | Description |
+| ----- | ----- |
+| `operation` | The name of the operation |
+| `is_background` | Whether the operation was background: `true` or `false`. Background operations do not count toward the operation rate limit |
+| `namespace_mode` | Indicates if actions are throttled in an `active` or a `standby` Namespace |
+
+**Type**: Rate
+
+### Schedule Metrics
+
+#### temporal\_cloud\_v1\_schedule\_action\_success\_count
+
+Successfully executed scheduled workflows per second.
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_schedule\_buffer\_overruns\_count
+
+The rate of schedule buffer overruns when using `BUFFER_ALL` overlap policy.
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_schedule\_missed\_catchup\_window\_count
+
+The rate of missed schedule executions outside the catchup window.
+
+**Type**: Rate
+
+#### temporal\_cloud\_v1\_schedule\_rate\_limited\_count
+
+The rate of scheduled workflows delayed due to rate limiting.
+
+**Type**: Rate
+
+### Replication Metrics
+
+#### temporal\_cloud\_v1\_replication\_lag\_p50
+
+The 50th percentile cross-region replication lag in seconds.
+
+**Type**: Latency
+
+#### temporal\_cloud\_v1\_replication\_lag\_p95
+
+The 95th percentile cross-region replication lag in seconds.
+
+**Type**: Latency
+
+#### temporal\_cloud\_v1\_replication\_lag\_p99
+
+The 99th percentile cross-region replication lag in seconds.
+
+**Type**: Latency
+
+### Limit Metrics
+
+#### temporal\_cloud\_v1\_operations\_limit
+
+The current configured operations per second limit for a namespace.
+
+**Type**: Value
+
+#### temporal\_cloud\_v1\_action\_limit
+
+The current configured actions per second limit for a namespace. Track utilization against this limit with ``temporal_cloud_v1_total_action_count`` and `is_background=false`.
+
+**Type**: Value
+
+#### temporal\_cloud\_v1\_service\_request\_limit
+
+The current configured frontend service RPS limit for a namespace. Track utilization against this limit with ``temporal_cloud_v1_service_request_count``
+
+**Type**: Value
+
+#### temporal\_cloud\_v1\_poller\_limit
+
+The current configured poller limit for a namespace. Track utilization against this limit with ``temporal_cloud_v1_service_pending_requests``.
+
+**Type**: Value
 


### PR DESCRIPTION
## Summary
- Adds 13 activity metrics to the OpenMetrics metrics reference: success, fail, timeout, task fail, task timeout, cancel, terminate, and start-to-close/schedule-to-close latency percentiles (p50/p95/p99)
- Introduces **opt-in labels** concept: `temporal_activity_type` is a new high-cardinality label not included by default, must be explicitly added via `?labels=temporal_activity_type` on the scrape URL
- Includes high-cardinality warning on the activity metrics section

## Test plan
- [ ] Verify metrics render correctly in Docusaurus preview
- [ ] Confirm opt-in labels anchor link works from the activity metrics section
- [ ] Cross-reference metric names and labels against internal observability docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213382462552465">EDU-5928 Add activity metrics to OpenMetrics reference</a>
