### PR TITLE
Fix typo: 'It TRUs' → 'If TRUs' in pricing docs

### DIFF
--- a/docs/evaluate/temporal-cloud/pricing.mdx
+++ b/docs/evaluate/temporal-cloud/pricing.mdx
@@ -304,7 +304,7 @@ Then the cost of Provisioned Capacity would be calculated as:
 * Hour 4: 500,000 Actions < 1,080,000 minimum Actions so 1,080,000-500,000 Actions = 580,000 additional actions will be added to the hour
 Total for 4 hours: 2,000,000+5,000,000+4,000,000+1,080,000=12,080,000 Actions
 
-It TRUs are changed multiple times within an hour, the highest value within that hour will be used to calculate the minimum actions required.
+If TRUs are changed multiple times within an hour, the highest value within that hour will be used to calculate the minimum actions required.
 
 Temporal’s approach to pricing Provisioned Capacity aligns with our goal to only charge for what you use. 
 The minimum hourly allocation will have no impact on your price if you utilize the requested capacity above your default by 20% or more, and will only incur an additional charge if the requested capacity is not used. 


### PR DESCRIPTION
## Summary
- Fixes typo on [Cloud pricing page](https://docs.temporal.io/cloud/pricing#capacity-modes-pricing): "It TRUs" → "If TRUs"
- Spotted by Kevin Kyyro in #crew-new-provisioned-capacity-mode

## Test plan
- [x] Verify rendered page reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213383869272142">EDU-5930 Fix typo: &#39;It TRUs&#39; → &#39;If TRUs&#39; in pricing docs</a>
