### PR TITLE
Document Nexus Operation Cancellation types in TS

### DIFF
--- a/docs/develop/typescript/temporal-nexus.mdx
+++ b/docs/develop/typescript/temporal-nexus.mdx
@@ -326,15 +326,25 @@ Requesting cancellation of a Cancellation Scope results in requesting cancellati
 The Workflow itself defines the root Cancellation Scope.
 Requesting cancellation of the Workflow therefore propagates the cancellation request to all cancellable operations started by that workflow, including Nexus Operations.
 
-To provide more granular control over cancellation of a specific Nexus Operation, you may explicitly create a new Cancellation Scope, and start the Nexus Operation from within that scope.
-An example demonstrating this can be found at our [nexus cancellation sample](https://github.com/temporalio/samples-typescript/tree/main/nexus-cancellation).
-
 Only asynchronous operations can be canceled in Nexus, since cancellation is sent using an operation token.
 The Workflow or other resources backing the operation may choose to ignore the cancellation request.
 
-Once the caller Workflow completes, the caller's Nexus Machinery will not make any further attempts to cancel operations that are still running.
+When a Nexus operation is started the caller can specify different cancellation types that will control how the caller reacts to cancellation:
+
+- `ABANDON` - Do not request cancellation of the operation.
+- `TRY_CANCEL` - Initiate a cancellation request and immediately report cancellation to the caller. Note that this type doesn't guarantee that cancellation is delivered to the operation handler if the caller exits before the delivery is done.
+- `WAIT_CANCELLATION_REQUESTED` ` Request cancellation of the operation and wait for confirmation that the request was received. Doesn't wait for actual cancellation.
+- `WAIT_CANCELLATION_COMPLETED` - Wait for operation completion. Operation may or may not complete as cancelled.
+
+The default is `WAIT_CANCELLATION_COMPLETED`. Users can set a different option on the `StartNexusOperationOptions`.
+
+Once the caller Workflow completes, the caller's Nexus Machinery stops attempting to cancel operations that have not yet been canceled, letting them run to completion.
+
 It's okay to leave operations running in some use cases.
-To ensure cancellations are delivered, wait for all pending operations to finish before exiting the Workflow.
+To ensure cancelations are delivered, wait for all pending operations to deliver their cancellation requests before exiting the Workflow.
+
+To provide more granular control over cancellation of a specific Nexus Operation, you may explicitly create a new Cancellation Scope, and start the Nexus Operation from within that scope.
+An example demonstrating this can be found at our [nexus cancellation sample](https://github.com/temporalio/samples-typescript/tree/main/nexus-cancellation).
 
 ## Make Nexus calls across Namespaces in Temporal Cloud {#nexus-calls-across-namespaces-temporal-cloud}
 


### PR DESCRIPTION
## What does this PR do?

Document Nexus Operation Cancellation types in TS. Similar to what we have for Go, Java, and Dotnet

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213409358095217">EDU-5934 Document Nexus Operation Cancellation types in TS</a>
