### PR TITLE
Remove Public Preview label from Environment Configuration

### DIFF
--- a/docs/develop/environment-configuration.mdx
+++ b/docs/develop/environment-configuration.mdx
@@ -23,13 +23,6 @@ without code changes.
 For a list of all available configuration settings, their corresponding environment variables, and TOML file paths,
 refer to [Temporal Client Environment Configuration Reference](../references/client-environment-configuration).
 
-:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
-
-Environment configuration is in
-[Public Preview](../evaluate/development-production-features/release-stages.mdx#public-preview) in the Temporal Go,
-Python, Ruby, TypeScript, and .NET SDKs, as well as the Temporal CLI.
-
-:::
 
 ## Configuration methods
 


### PR DESCRIPTION
## Summary
- Removes the "Public Preview" tip callout from the Environment Configuration page (`docs/develop/environment-configuration.mdx`)
- Environment Configuration is no longer in Public Preview

## Test plan
- [ ] Verify the Environment Configuration page renders correctly without the callout
- [ ] Confirm no other pages reference this specific Public Preview status

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213423954230043">EDU-5939 Remove Public Preview label from Environment Configuration</a>
