### PR TITLE
docs: update default cloud namespace limits

### DIFF
--- a/docs/cloud/nexus/limits.mdx
+++ b/docs/cloud/nexus/limits.mdx
@@ -31,7 +31,7 @@ Many of these defaults are configurable, so if you need them changed please open
 ## Rate Limiting
 
 Nexus requests (commands, polling) are counted as part of the overall Namespace RPS limit in both the caller and handler Namespaces.
-Default Namespace RPS limits are set at 1600 and automatically adjust based on recent usage (over prior 7 days).
+See [Temporal Cloud limits](/cloud/limits#requests-per-second) for current default Namespace RPS limits.
 
 ## Operational Limits
 


### PR DESCRIPTION
## What does this PR do?

- Removes outdated rate limit info with reference to new page

## Notes to reviewers

<!-- delete if n/a -->