### PR TITLE
Add task_priority and worker_version labels to backlog metric

### DIFF
--- a/docs/cloud/metrics/openmetrics/metrics-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-reference.mdx
@@ -65,6 +65,7 @@ When an opt-in label is enabled, it is populated on **all metrics** that support
 | Label | Available on | Description |
 | ----- | ----- | ----- |
 | `temporal_activity_type` | Activity metrics | The activity type name |
+| `worker_version` | `temporal_cloud_v1_approximate_backlog_count` | The Worker version |
 
 For example, to include `temporal_activity_type` in your scrape results:
 
@@ -461,6 +462,8 @@ The approximate number of tasks pending in a task queue. Started Activities are 
 | ----- | ----- |
 | `temporal_task_queue` | The task queue name |
 | `task_type` | Type of task: `workflow` or `activity` |
+| `task_priority` | The task priority |
+| `worker_version` | The Worker version (opt-in) |
 
 **Type**: Value
 


### PR DESCRIPTION
## Summary
- Adds `task_priority` as a standard label on `temporal_cloud_v1_approximate_backlog_count`
- Adds `worker_version` as an opt-in label on `temporal_cloud_v1_approximate_backlog_count`
- Registers `worker_version` in the opt-in labels reference table

## Test plan
- [ ] Verify metrics reference page renders correctly
- [ ] Confirm label table formatting is consistent with existing metrics

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213455106719369">EDU-5954 Add task_priority and worker_version labels to backlog metric</a>
