### PR TITLE
docs: add no-animal-violence Vale package for inclusive language checking

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,11 +2,11 @@ StylesPath = "vale/styles"
 
 MinAlertLevel = suggestion
 
-Packages = Google, Microsoft, alex
+Packages = Google, Microsoft, alex, https://github.com/Open-Paws/vale-no-animal-violence/releases/latest/download/NoAnimalViolence.zip
 Vocab = Temporal
 
 [*.{md,mdx}]
-BasedOnStyles = Vale, Google, Microsoft, alex, Temporal
+BasedOnStyles = Vale, Google, Microsoft, alex, Temporal, NoAnimalViolence
 
 ; these are already covered in Google which we prioritize
 Microsoft.Contractions = NO
@@ -29,4 +29,3 @@ Google.WordList = NO
 
 [formats]
 mdx = md
-


### PR DESCRIPTION
Adds the [NoAnimalViolence](https://github.com/Open-Paws/vale-no-animal-violence) Vale package to the existing Vale setup. This package flags phrases that normalize violence toward animals (e.g. "kill two birds with one stone", "beat a dead horse", "cattle vs. pets") and suggests clearer professional alternatives.

## Changes

- `.vale.ini`: add `NoAnimalViolence` package URL to `Packages =` and `NoAnimalViolence` to `BasedOnStyles`

## The package

The [vale-no-animal-violence](https://github.com/Open-Paws/vale-no-animal-violence) package detects phrases like:
- "kill two birds with one stone" → "accomplish two things at once"
- "beat a dead horse" → "belabor the point"
- "guinea pig" → "test subject"
- "cattle vs. pets" → "ephemeral vs. persistent"
- "canary deployment" → "progressive rollout"
- "monkey patch" → "runtime patch"

All rules are at `warning` level — informational, not blocking.

Part of the [Open Paws](https://openpaws.ai) no-animal-violence toolchain for inclusive language.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213480800207908">EDU-5973 docs: add no-animal-violence Vale package for inclusive language checking</a>
