### PR TITLE
[manager-identity] Correct temporal worker deployment describe option

### DIFF
--- a/docs/cli/worker.mdx
+++ b/docs/cli/worker.mdx
@@ -192,7 +192,7 @@ who is expected to make changes to the Worker Deployment.
 The current Manager Identity is returned with `describe`:
 ```
  temporal worker deployment describe \
-    --deployment-name YourDeploymentName
+    --name YourDeploymentName
 ```
 
 #### set


### PR DESCRIPTION
## What does this PR do?
There is no option of  `--deployment-name` for `temporal worker deployment describe`, in fact it is `--name`

```
 temporal worker deployment describe \
    --name YourDeploymentName
```
(in the describe section)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1213812706957646">EDU-6102 [manager-identity] Correct temporal worker deployment describe option</a>
