### PR TITLE
fix Nexus .NET SDK guide landing page redirect

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1380,11 +1380,6 @@
       "permanent": true
     },
     {
-      "source": "/develop/dotnet/nexus",
-      "destination": "/develop/dotnet/nexus/feature-guide",
-      "permanent": true
-    },
-    {
       "source": "/develop/dotnet/observability",
       "destination": "/develop/dotnet/platform/observability",
       "permanent": true


### PR DESCRIPTION
## What does this PR do?
- fixes the out of date redirect for the .NET SDK guide for Nexus so it shows the new landing page with the Quickstart when the URL is entered in the browser address bar (or a link is provided)
- note: the other SDK guide landing pages work fine

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214011077664690">EDU-6200 fix Nexus .NET SDK guide landing page redirect</a>
