### PR TITLE
Update Claude Code plugin install instructions

### DIFF
--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -28,11 +28,14 @@ error handling, testing strategies, worker configuration, versioning, and common
 1. Add the Temporal skills marketplace to Claude Code:
 
    ```bash
-   /plugin marketplace add temporalio/agent-skills
+   /plugin marketplace add temporalio/claude-temporal-plugin
    ```
 
-2. Open the plugin manager by running `/plugin` within Claude Code, select the marketplace, and install
-   `temporal-developer`.
+2. Install the Temporal Developer Skill:
+
+   ```bash
+   /plugin install temporal-developer@temporal-marketplace
+   ```
 
 </TabItem>
 <TabItem value="npx" label="npx">


### PR DESCRIPTION
## Summary
- Update marketplace repo from `temporalio/agent-skills` to `temporalio/claude-temporal-plugin`
- Replace interactive plugin manager step with CLI command (`/plugin install temporal-developer@temporal-marketplace`)

## Test plan
- [ ] Verify the two install commands work in Claude Code
- [ ] Confirm other tabs (npx, Manual) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214065710288842">EDU-6203 Update Claude Code plugin install instructions</a>
