### PR TITLE
Add Cursor Marketplace tab for Temporal Developer Skill

### DIFF
--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -38,6 +38,16 @@ error handling, testing strategies, worker configuration, versioning, and common
    ```
 
 </TabItem>
+<TabItem value="cursor" label="Cursor">
+
+Install the Temporal plugin from the [Cursor Marketplace](https://cursor.com/marketplace/temporal), or run the following
+command in Cursor's agent chat:
+
+```
+/add-plugin temporal-developer
+```
+
+</TabItem>
 <TabItem value="npx" label="npx">
 
 This works with Claude Code, Codex, Cline, and other agents.


### PR DESCRIPTION
## Summary
- Add a Cursor tab to the Temporal Developer Skill installation instructions
- Links to the [Cursor Marketplace listing](https://cursor.com/marketplace/temporal) and provides the `/add-plugin temporal-developer` command for agent chat

## Test plan
- [x] Verify `/add-plugin temporal-developer` works in Cursor agent chat
- [ ] Verify the Cursor tab renders correctly alongside existing Claude Code Plugin, npx, and Manual tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214069319576208">EDU-6204 Add Cursor Marketplace tab for Temporal Developer Skill</a>
