### PR TITLE
Update Namespace Name requirements

### DIFF
--- a/docs/cloud/get-started/namespaces.mdx
+++ b/docs/cloud/get-started/namespaces.mdx
@@ -47,8 +47,6 @@ Each Namespace Name must conform to the following rules:
 - A Namespace Name must contain at least 2 characters and no more than 39 characters.
 - A Namespace Name must begin with a letter, end with a letter or number, and contain only letters, numbers, and the
   hyphen (-) character.
-- Each hyphen (-) character must be immediately preceded _and_ followed by a letter or number; consecutive hyphens are
-  not permitted.
 - All letters in a Namespace Name must be lowercase.
 
 ## What is a Temporal Cloud Account ID? {#temporal-cloud-account-id}


### PR DESCRIPTION
Clarified the requirements for Namespace Names by removing the rule about hyphen placement.

We allow consecutive hyphen, see thread here for context: https://temporaltechnologies.slack.com/archives/C0771363HMM/p1776264283508739

## What does this PR do?
remove the requirement that shouldn't be there

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214079174999476">EDU-6209 Update Namespace Name requirements</a>
