### PR TITLE
Update description of pending requests metric

### DIFF
--- a/docs/cloud/metrics/openmetrics/metrics-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-reference.mdx
@@ -104,7 +104,7 @@ gRPC errors per second.
 
 #### temporal\_cloud\_v1\_service\_pending\_requests
 
-The number of pollers that are waiting for a task. Use this to track against ``temporal_cloud_v1_poller_limit``
+The number of pollers that are actively long polling for a task. Use this to track against ``temporal_cloud_v1_poller_limit``
 
 | Label | Description |
 | ----- | ----- |


### PR DESCRIPTION
## What does this PR do?

Slightly change our wording in the definition of the pending requests metric

## Notes to reviewers

Got some feedback that the word _waiting_ can sound like these pollers are inactive -- hoping this change can make it a little more clear that these are active long pollers

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214120275600426">EDU-6214 Update description of pending requests metric</a>
