### PR TITLE
Update docs to refine explanations for non-determinism

### DIFF
--- a/docs/develop/dotnet/workflows/basics.mdx
+++ b/docs/develop/dotnet/workflows/basics.mdx
@@ -64,7 +64,7 @@ Temporal requires that the deterministic `TaskScheduler.Current` is used, but ma
 Here are some known gotchas to avoid with .NET tasks inside of Workflows:
 
 -  Use `Workflow.RunTaskAsync` instead of `Task.Run`. `Task.Run` uses the default scheduler and puts work on the thread pool.
-    - Can also use `Task.Factory.StartNew` with current scheduler or instantiate the `Task` and run `Task.Start` on it.
+    - You can also use `Task.Factory.StartNew` with current scheduler or instantiate the `Task` and run `Task.Start` on it.
 - If you need to use `Task.ConfigureAwait`, use `Task.ConfigureAwait(true)`. `Task.ConfigureAwait(false)` won't use the current context.
   - There is no significant performance benefit to `Task.ConfigureAwait` in workflows because of how the scheduler works.
 - Avoid anything that defaults to the default task scheduler.

--- a/docs/develop/dotnet/workflows/basics.mdx
+++ b/docs/develop/dotnet/workflows/basics.mdx
@@ -66,7 +66,7 @@ Here are some known gotchas to avoid with .NET tasks inside of Workflows:
 -  Use `Workflow.RunTaskAsync` instead of `Task.Run`. `Task.Run` uses the default scheduler and puts work on the thread pool.
     - Can also use `Task.Factory.StartNew` with current scheduler or instantiate the `Task` and run `Task.Start` on it.
 - If you need to use `Task.ConfigureAwait`, use `Task.ConfigureAwait(true)`. `Task.ConfigureAwait(false)` won't use the current context.
-  - There is no significant performance benefit to `Task.ConfigureAwait` in workflows anyways due to how the scheduler works.
+  - There is no significant performance benefit to `Task.ConfigureAwait` in workflows because of how the scheduler works.
 - Avoid anything that defaults to the default task scheduler.
 - Use `Workflow.DelayAsync`, `Workflow.WaitConditionAsync`, or non-timeout-based cancellation token sources instead of `Task.Delay`, `Task.Wait`, timeout-based `CancellationTokenSource`, or anything that uses .NET built-in timers.
 - Use `Workflow.WhenAnyAsync` instead of `Task.WhenAny`.

--- a/docs/develop/dotnet/workflows/basics.mdx
+++ b/docs/develop/dotnet/workflows/basics.mdx
@@ -44,11 +44,9 @@ All Workflow Definition parameters must be serializable.
 
 ## Workflow logic requirements {#workflow-logic-requirements}
 
-Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints).
-Therefore, each language is limited to the use of certain idiomatic techniques.
-However, each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
+Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints). Each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with application code outside the Workflow.
 
-This means there are several things Workflows cannot do such as:
+This means there are several things Workflows shouldn't do such as:
 
 - Perform IO (network, disk, stdio, etc)
 - Access/alter external mutable state
@@ -65,27 +63,20 @@ This is especially true with `Task`s.
 Temporal requires that the deterministic `TaskScheduler.Current` is used, but many .NET async calls will use `TaskScheduler.Default` implicitly (and some analyzers even encourage this).
 Here are some known gotchas to avoid with .NET tasks inside of Workflows:
 
-- Do not use `Task.Run` - this uses the default scheduler and puts work on the thread pool.
-  - Use `Workflow.RunTaskAsync` instead.
-  - Can also use `Task.Factory.StartNew` with current scheduler or instantiate the `Task` and run `Task.Start` on it.
-- Do not use `Task.ConfigureAwait(false)` - this will not use the current context.
-  - If you must use `Task.ConfigureAwait`, use `Task.ConfigureAwait(true)`.
+-  Use `Workflow.RunTaskAsync` instead of `Task.Run`. `Task.Run` uses the default scheduler and puts work on the thread pool.
+    - Can also use `Task.Factory.StartNew` with current scheduler or instantiate the `Task` and run `Task.Start` on it.
+- If you need to use `Task.ConfigureAwait`, use `Task.ConfigureAwait(true)`. `Task.ConfigureAwait(false)` won't use the current context.
   - There is no significant performance benefit to `Task.ConfigureAwait` in workflows anyways due to how the scheduler works.
-- Do not use anything that defaults to the default task scheduler.
-- Do not use `Task.Delay`, `Task.Wait`, timeout-based `CancellationTokenSource`, or anything that uses .NET built-in timers.
-  - `Workflow.DelayAsync`, `Workflow.WaitConditionAsync`, or non-timeout-based cancellation token source is suggested.
-- Do not use `Task.WhenAny`.
-  - Use `Workflow.WhenAnyAsync` instead.
+- Avoid anything that defaults to the default task scheduler.
+- Use `Workflow.DelayAsync`, `Workflow.WaitConditionAsync`, or non-timeout-based cancellation token sources instead of `Task.Delay`, `Task.Wait`, timeout-based `CancellationTokenSource`, or anything that uses .NET built-in timers.
+- Use `Workflow.WhenAnyAsync` instead of `Task.WhenAny`.
   - Technically this only applies to an enumerable set of tasks with results or more than 2 tasks with results. Other
     uses are safe. See [this issue](https://github.com/dotnet/runtime/issues/87481).
-- Do not use `Task.WhenAll`
-  - Use `Workflow.WhenAllAsync` instead.
+- Use `Workflow.WhenAllAsync` instead of `Task.WhenAll`.
   - Technically `Task.WhenAll` is currently deterministic in .NET and safe, but it is better to use the wrapper to be
     sure.
-- Do not use `CancellationTokenSource.CancelAsync`.
-  - Use `CancellationTokenSource.Cancel` instead.
-- Do not use `System.Threading.Semaphore` or `System.Threading.SemaphoreSlim` or `System.Threading.Mutex`.
-  - Use `Temporalio.Workflows.Semaphore` or `Temporalio.Workflows.Mutex` instead.
+- Use `CancellationTokenSource.Cancel` instead of `CancellationTokenSource.CancelAsync`.
+- Use `Temporalio.Workflows.Semaphore` or `Temporalio.Workflows.Mutex` instead of `System.Threading.Semaphore`, `System.Threading.SemaphoreSlim`, or `System.Threading.Mutex`.
   - _Technically_ `SemaphoreSlim` does work if only the async form of `WaitAsync` is used without no timeouts and
     `Release` is used. But anything else can deadlock the workflow and its use is cumbersome since it must be disposed.
 - Be wary of additional libraries' implicit use of the default scheduler.
@@ -93,6 +84,7 @@ Here are some known gotchas to avoid with .NET tasks inside of Workflows:
 
 In order to help catch wrong scheduler use, by default the Temporal .NET SDK adds an event source listener for info-level task events.
 While this technically receives events from all uses of tasks in the process, we make sure to ignore anything that is not running in a Workflow in a high performant way (basically one thread local check).
+
 For code that does run in a Workflow and accidentally starts a task in another scheduler, an `InvalidWorkflowOperationException` will be thrown which "pauses" the Workflow (fails the Workflow Task which continually retries until the code is fixed).
 This is unfortunately a runtime-only check, but can help catch mistakes early. If this needs to be turned off for any reason, set `DisableWorkflowTracingEventListener` to `true` in Worker options.
 

--- a/docs/develop/dotnet/workflows/versioning.mdx
+++ b/docs/develop/dotnet/workflows/versioning.mdx
@@ -31,8 +31,8 @@ import { CaptionedImage } from '@site/src/components';
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints).
-If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:
 

--- a/docs/develop/dotnet/workflows/versioning.mdx
+++ b/docs/develop/dotnet/workflows/versioning.mdx
@@ -31,7 +31,7 @@ import { CaptionedImage } from '@site/src/components';
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, and database queries should be placed in Activities, which Temporal retries reliably.
 
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:

--- a/docs/develop/go/workflows/basics.mdx
+++ b/docs/develop/go/workflows/basics.mdx
@@ -183,9 +183,7 @@ func main() {
 
 ### How to develop Workflow logic {#workflow-logic-requirements}
 
-Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints).
-Therefore, each language is limited to the use of certain idiomatic techniques.
-However, each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
+Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints). Each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with application code outside the Workflow.
 
 In Go, Workflow Definition code cannot directly do the following:
 

--- a/docs/develop/go/workflows/versioning.mdx
+++ b/docs/develop/go/workflows/versioning.mdx
@@ -20,8 +20,8 @@ tags:
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints).
-If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:
 

--- a/docs/develop/go/workflows/versioning.mdx
+++ b/docs/develop/go/workflows/versioning.mdx
@@ -20,7 +20,7 @@ tags:
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, and database queries should be placed in Activities, which Temporal retries reliably.
 
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:

--- a/docs/develop/java/workflows/basics.mdx
+++ b/docs/develop/java/workflows/basics.mdx
@@ -211,34 +211,23 @@ When you set the Workflow Type this way, the value of the `name` parameter does 
 
 ## Workflow logic requirements {#workflow-logic-requirements}
 
-Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints).
-Therefore, each language is limited to the use of certain idiomatic techniques.
-However, each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
+Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints). Therefore, each language is limited to the use of certain idiomatic techniques. However, each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
 
 When defining Workflows using the Temporal Java SDK, the Workflow code must be written to execute effectively once and to completion.
 
 The following constraints apply when writing Workflow Definitions:
 
-- Do not use mutable global variables in your Workflow implementations.
-  This will ensure that multiple Workflow instances are fully isolated.
-- Your Workflow code must be deterministic.
-  Do not call non-deterministic functions (such as non-seeded random or `UUID.randomUUID()`) directly from the Workflow code.
-  The Temporal SDK provides specific API for calling non-deterministic code in your Workflows.
-- Do not use programming language constructs that rely on system time.
-  For example, only use `Workflow.currentTimeMillis()` to get the current time inside a Workflow.
-- Do not use native Java `Thread` or any other multi-threaded classes like `ThreadPoolExecutor`.
-  Use `Async.function` or `Async.procedure`, provided by the Temporal SDK, to execute code asynchronously.
-- Do not use synchronization, locks, or other standard Java blocking concurrency-related classes besides those provided by the Workflow class.
-  There is no need for explicit synchronization because multi-threaded code inside a Workflow is executed one thread at a time and under a global lock.
+- Do not use mutable global variables in your Workflow implementations. This will ensure that multiple Workflow instances are fully isolated.
+- Your Workflow code must be deterministic. Do not call non-deterministic functions (such as non-seeded random or `UUID.randomUUID()`) directly from the Workflow code. The Temporal SDK provides specific API for calling non-deterministic code in your Workflows.
+  - For operations like calling external APIs, invoking LLMs, querying databases, or performing I/O, use Activities. Activities run outside Workflow replay and are retried reliably.
+- Do not use programming language constructs that rely on system time. For example, only use `Workflow.currentTimeMillis()` to get the current time inside a Workflow.
+- Do not use native Java `Thread` or any other multi-threaded classes like `ThreadPoolExecutor`. Use `Async.function` or `Async.procedure`, provided by the Temporal SDK, to execute code asynchronously.
+- Do not use synchronization, locks, or other standard Java blocking concurrency-related classes besides those provided by the Workflow class. There is no need for explicit synchronization because multi-threaded code inside a Workflow is executed one thread at a time and under a global lock.
   - Call `Workflow.sleep` instead of `Thread.sleep`.
   - Use `Promise` and `CompletablePromise` instead of `Future` and `CompletableFuture`.
   - Use `WorkflowQueue` instead of `BlockingQueue`.
-- Use `Workflow.getVersion` when making any changes to the Workflow code.
-  Without this, any deployment of updated Workflow code might break already running Workflows.
-- Do not access configuration APIs directly from a Workflow because changes in the configuration might affect a Workflow Execution path.
-  Pass it as an argument to a Workflow function or use an Activity to load it.
-- Use `DynamicWorkflow` when you need a default Workflow that can handle all Workflow Types that are not registered with a Worker.
-  A single implementation can implement a Workflow Type which by definition is dynamically loaded from some external source.
-  All standard `WorkflowOptions` and determinism rules apply to Dynamic Workflow implementations.
+- Use `Workflow.getVersion` when making any changes to the Workflow code. Without this, any deployment of updated Workflow code might break already running Workflows.
+- Do not access configuration APIs directly from a Workflow because changes in the configuration might affect a Workflow Execution path. Pass it as an argument to a Workflow function or use an Activity to load it.
+- Use `DynamicWorkflow` when you need a default Workflow that can handle all Workflow Types that are not registered with a Worker. A single implementation can implement a Workflow Type which by definition is dynamically loaded from some external source. All standard `WorkflowOptions` and determinism rules apply to Dynamic Workflow implementations.
 
 Java Workflow reference: [https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/package-summary.html](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/package-summary.html)

--- a/docs/develop/java/workflows/basics.mdx
+++ b/docs/develop/java/workflows/basics.mdx
@@ -218,7 +218,7 @@ When defining Workflows using the Temporal Java SDK, the Workflow code must be w
 The following constraints apply when writing Workflow Definitions:
 
 - Do not use mutable global variables in your Workflow implementations. This will ensure that multiple Workflow instances are fully isolated.
-- Workflow code must be deterministic. If you need to call non-deterministic functions (such as non-seeded random or `UUID.randomUUID()`) directly from the Workflow code. The Temporal SDK provides specific API for calling non-deterministic code in your Workflows.
+- Workflow code must be deterministic. If you need to call non-deterministic functions (such as non-seeded random or `UUID.randomUUID()`) directly from the Workflow code, the Temporal SDK provides specific API for calling non-deterministic code in your Workflows.
   - For operations like calling external APIs, invoking LLMs, querying databases, or performing I/O, use Activities. Activities run outside Workflow replay and are retried reliably.
 - Use Temporal-provided functions instead of that rely on system time. For example, only use `Workflow.currentTimeMillis()` to get the current time inside a Workflow.
 - Use `Async.function` or `Async.procedure`, provided by the Temporal SDK, to execute code asynchronously instead of native Java `Thread` or any other multi-threaded classes like `ThreadPoolExecutor`.

--- a/docs/develop/java/workflows/basics.mdx
+++ b/docs/develop/java/workflows/basics.mdx
@@ -211,7 +211,7 @@ When you set the Workflow Type this way, the value of the `name` parameter does 
 
 ## Workflow logic requirements {#workflow-logic-requirements}
 
-Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints). Therefore, each language is limited to the use of certain idiomatic techniques. However, each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
+Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints). Each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
 
 When defining Workflows using the Temporal Java SDK, the Workflow code must be written to execute effectively once and to completion.
 

--- a/docs/develop/java/workflows/basics.mdx
+++ b/docs/develop/java/workflows/basics.mdx
@@ -220,7 +220,7 @@ The following constraints apply when writing Workflow Definitions:
 - Do not use mutable global variables in your Workflow implementations. This will ensure that multiple Workflow instances are fully isolated.
 - Workflow code must be deterministic. If you need to call non-deterministic functions (such as non-seeded random or `UUID.randomUUID()`) directly from the Workflow code, the Temporal SDK provides specific API for calling non-deterministic code in your Workflows.
   - For operations like calling external APIs, invoking LLMs, querying databases, or performing I/O, use Activities. Activities run outside Workflow replay and are retried reliably.
-- Use Temporal-provided functions instead of that rely on system time. For example, only use `Workflow.currentTimeMillis()` to get the current time inside a Workflow.
+- Use Temporal-provided functions instead of that rely on system time. For example, use only `Workflow.currentTimeMillis()` to get the current time inside a Workflow.
 - Use `Async.function` or `Async.procedure`, provided by the Temporal SDK, to execute code asynchronously instead of native Java `Thread` or any other multi-threaded classes like `ThreadPoolExecutor`.
 - Use only the concurrency features provided by the Workflow class. Multi-threaded code inside a Workflow is executed one thread at a time and under a global lock, so there is no need for explicit synchronization.
   - Call `Workflow.sleep` instead of `Thread.sleep`.

--- a/docs/develop/java/workflows/basics.mdx
+++ b/docs/develop/java/workflows/basics.mdx
@@ -227,7 +227,7 @@ The following constraints apply when writing Workflow Definitions:
   - Use `Promise` and `CompletablePromise` instead of `Future` and `CompletableFuture`.
   - Use `WorkflowQueue` instead of `BlockingQueue`.
 - Use `Workflow.getVersion` when making any changes to the Workflow code to avoid deployment of updated Workflow code interfering with already-running Workflows.
-- Do not access configuration APIs directly from a Workflow because changes in the configuration might affect a Workflow Execution path. Pass it as an argument to a Workflow function or use an Activity to load it.
+- Do not access configuration APIs directly from a Workflow because changes in the configuration might affect a Workflow Execution path. Instead, pass it as an argument to a Workflow function or use an Activity to load it.
 - Use `DynamicWorkflow` when you need a default Workflow that can handle all Workflow Types that are not registered with a Worker. A single implementation can implement a Workflow Type which by definition is dynamically loaded from some external source. All standard `WorkflowOptions` and determinism rules apply to Dynamic Workflow implementations.
 
 Java Workflow reference: [https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/package-summary.html](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/package-summary.html)

--- a/docs/develop/java/workflows/basics.mdx
+++ b/docs/develop/java/workflows/basics.mdx
@@ -226,7 +226,7 @@ The following constraints apply when writing Workflow Definitions:
   - Call `Workflow.sleep` instead of `Thread.sleep`.
   - Use `Promise` and `CompletablePromise` instead of `Future` and `CompletableFuture`.
   - Use `WorkflowQueue` instead of `BlockingQueue`.
-- Use `Workflow.getVersion` when making any changes to the Workflow code. Without this, any deployment of updated Workflow code might break already running Workflows.
+- Use `Workflow.getVersion` when making any changes to the Workflow code to avoid deployment of updated Workflow code interfering with already-running Workflows.
 - Do not access configuration APIs directly from a Workflow because changes in the configuration might affect a Workflow Execution path. Pass it as an argument to a Workflow function or use an Activity to load it.
 - Use `DynamicWorkflow` when you need a default Workflow that can handle all Workflow Types that are not registered with a Worker. A single implementation can implement a Workflow Type which by definition is dynamically loaded from some external source. All standard `WorkflowOptions` and determinism rules apply to Dynamic Workflow implementations.
 

--- a/docs/develop/java/workflows/basics.mdx
+++ b/docs/develop/java/workflows/basics.mdx
@@ -218,11 +218,11 @@ When defining Workflows using the Temporal Java SDK, the Workflow code must be w
 The following constraints apply when writing Workflow Definitions:
 
 - Do not use mutable global variables in your Workflow implementations. This will ensure that multiple Workflow instances are fully isolated.
-- Your Workflow code must be deterministic. Do not call non-deterministic functions (such as non-seeded random or `UUID.randomUUID()`) directly from the Workflow code. The Temporal SDK provides specific API for calling non-deterministic code in your Workflows.
+- Workflow code must be deterministic. If you need to call non-deterministic functions (such as non-seeded random or `UUID.randomUUID()`) directly from the Workflow code. The Temporal SDK provides specific API for calling non-deterministic code in your Workflows.
   - For operations like calling external APIs, invoking LLMs, querying databases, or performing I/O, use Activities. Activities run outside Workflow replay and are retried reliably.
-- Do not use programming language constructs that rely on system time. For example, only use `Workflow.currentTimeMillis()` to get the current time inside a Workflow.
-- Do not use native Java `Thread` or any other multi-threaded classes like `ThreadPoolExecutor`. Use `Async.function` or `Async.procedure`, provided by the Temporal SDK, to execute code asynchronously.
-- Do not use synchronization, locks, or other standard Java blocking concurrency-related classes besides those provided by the Workflow class. There is no need for explicit synchronization because multi-threaded code inside a Workflow is executed one thread at a time and under a global lock.
+- Use Temporal-provided functions instead of that rely on system time. For example, only use `Workflow.currentTimeMillis()` to get the current time inside a Workflow.
+- Use `Async.function` or `Async.procedure`, provided by the Temporal SDK, to execute code asynchronously instead of native Java `Thread` or any other multi-threaded classes like `ThreadPoolExecutor`.
+- Use only the concurrency features provided by the Workflow class. Multi-threaded code inside a Workflow is executed one thread at a time and under a global lock, so there is no need for explicit synchronization.
   - Call `Workflow.sleep` instead of `Thread.sleep`.
   - Use `Promise` and `CompletablePromise` instead of `Future` and `CompletableFuture`.
   - Use `WorkflowQueue` instead of `BlockingQueue`.

--- a/docs/develop/java/workflows/versioning.mdx
+++ b/docs/develop/java/workflows/versioning.mdx
@@ -21,8 +21,8 @@ tags:
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints).
-If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:
 

--- a/docs/develop/java/workflows/versioning.mdx
+++ b/docs/develop/java/workflows/versioning.mdx
@@ -21,7 +21,7 @@ tags:
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, and database queries should be placed in Activities, which Temporal retries reliably.
 
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:

--- a/docs/develop/php/workflows/basics.mdx
+++ b/docs/develop/php/workflows/basics.mdx
@@ -96,9 +96,7 @@ interface YourWorkflowDefinitionInterface
 
 ### How to develop Workflow logic {#workflow-logic-requirements}
 
-Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints).
-Therefore, each language is limited to the use of certain idiomatic techniques.
-However, each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
+Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints). Each Temporal SDK provides a set of APIs that can be used inside your Workflow to interact with application code outside the Workflow. used inside your Workflow to interact with external (to the Workflow) application code.
 
 \*\*Temporal uses the [Microsoft Azure Event Sourcing pattern](https://docs.microsoft.com/en-us/azure/architecture/patterns/event-sourcing) to recover the state of a Workflow object including its local variable values.
 

--- a/docs/develop/php/workflows/versioning.mdx
+++ b/docs/develop/php/workflows/versioning.mdx
@@ -29,8 +29,8 @@ tags:
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints).
-If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:
 

--- a/docs/develop/php/workflows/versioning.mdx
+++ b/docs/develop/php/workflows/versioning.mdx
@@ -29,7 +29,7 @@ tags:
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, and database queries should be placed in Activities, which Temporal retries reliably.
 
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:

--- a/docs/develop/python/workflows/basics.mdx
+++ b/docs/develop/python/workflows/basics.mdx
@@ -163,7 +163,7 @@ class YourWorkflow:
 **How to develop Workflow logic using the Temporal Python SDK.**
 
 Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints).
-Therefore, each language is limited to the use of certain idiomatic techniques. However, each Temporal SDK provides a
+Each Temporal SDK provides a
 set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
 
 Workflow code must be deterministic because the Temporal Server may [replay](/develop/python/best-practices/testing-suite#replay) your Workflow to reconstruct its state. This means:

--- a/docs/develop/python/workflows/versioning.mdx
+++ b/docs/develop/python/workflows/versioning.mdx
@@ -32,8 +32,8 @@ import { CaptionedImage } from '@site/src/components';
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints).
-If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:
 

--- a/docs/develop/python/workflows/versioning.mdx
+++ b/docs/develop/python/workflows/versioning.mdx
@@ -32,7 +32,7 @@ import { CaptionedImage } from '@site/src/components';
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, and database queries should be placed in Activities, which Temporal retries reliably.
 
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:

--- a/docs/develop/ruby/workflows/versioning.mdx
+++ b/docs/develop/ruby/workflows/versioning.mdx
@@ -26,8 +26,8 @@ tags:
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints).
-If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:
 

--- a/docs/develop/ruby/workflows/versioning.mdx
+++ b/docs/develop/ruby/workflows/versioning.mdx
@@ -26,7 +26,7 @@ tags:
 
 Since Workflow Executions in Temporal can run for long periods — sometimes months or even years — it's common to need to make changes to a Workflow Definition, even while a particular Workflow Execution is in progress.
 
-The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, LLM invocations, and database queries should be placed in Activities, which Temporal retries reliably.
+The Temporal Platform requires that Workflow code is [deterministic](/workflow-definition#deterministic-constraints). If you make a change to your Workflow code that would cause non-deterministic behavior on Replay, you'll need to use one of our Versioning methods to gracefully update your running Workflows. This only applies to Workflow orchestration logic. Non-deterministic work such as API calls, and database queries should be placed in Activities, which Temporal retries reliably.
 
 With Versioning, you can modify your Workflow Definition so that new executions use the updated code, while existing ones continue running the original version.
 There are two primary Versioning methods that you can use:

--- a/docs/develop/rust/workflows/basics.mdx
+++ b/docs/develop/rust/workflows/basics.mdx
@@ -176,7 +176,7 @@ pub struct GreetingWorkflow {
 
 ## Workflow logic requirements {#workflow-logic-requirements}
 
-Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints). For non-deterministic operations like API calls, LLM invocations, and database queries, use [Activities](/develop/rust/activities/basics).
+Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints). For non-deterministic operations like API calls, and database queries, use [Activities](/develop/rust/activities/basics).
 
 Workflow code must be deterministic because the Temporal Server may replay your Workflow to reconstruct its state. This means:
 

--- a/docs/develop/typescript/best-practices/debugging.mdx
+++ b/docs/develop/typescript/best-practices/debugging.mdx
@@ -51,16 +51,14 @@ If something isn't behaving the way you expect, make sure to check both location
 
 If you are developing Workflows and finding that code isn't executing as expected, the first place to look is whether old Workflows are still running.
 
-If those old Workflows have the same name and are on the same task queue, Temporal will try to continue executing them on your new code by design.
-You may get errors that make no sense to you because
+If those old Workflows have the same name and are on the same Task Queue, Temporal will try to continue executing them on your new code by design. You may get errors that make no sense to you because:
 
-- Temporal is trying to execute old Workflow code that no longer exists in your codebase, or
-- your new Client code is expecting Temporal to execute old Workflow/Activity code it doesn't yet know about.
+- Temporal is trying to execute old Workflow code that no longer exists in your codebase
+- Your new Client code is expecting Temporal to execute old Workflow/Activity code it doesn't yet know about.
 
-The biggest sign that this is happening is if you notice Temporal is acting non-deterministically: running the same Workflow twice gets different results.
+The biggest sign that this is happening is if you notice Workflow executions are producing different results on replay. If running the same Workflow twice gets different results, that points to a non-determinism error.
 
-Stale workflows are usually a non-issue because the errors generated are just noise from code you no longer want to run.
-If you need to terminate old stale Workflows, you can do so with Temporal Web or the Temporal CLI.
+Stale Workflows are usually a non-issue because the errors generated are just noise from code you no longer want to run. If you need to terminate old stale Workflows, you can do so with Temporal Web or the Temporal CLI.
 
 ### Workflow/Activity registration errors
 

--- a/docs/develop/typescript/best-practices/debugging.mdx
+++ b/docs/develop/typescript/best-practices/debugging.mdx
@@ -56,8 +56,6 @@ If those old Workflows have the same name and are on the same Task Queue, Tempor
 - Temporal is trying to execute old Workflow code that no longer exists in your codebase
 - Your new Client code is expecting Temporal to execute old Workflow/Activity code it doesn't yet know about.
 
-The biggest sign that this is happening is if you notice Workflow executions are producing different results on replay. If running the same Workflow twice gets different results, that points to a non-determinism error.
-
 Stale Workflows are usually a non-issue because the errors generated are just noise from code you no longer want to run. If you need to terminate old stale Workflows, you can do so with Temporal Web or the Temporal CLI.
 
 ### Workflow/Activity registration errors

--- a/docs/develop/typescript/best-practices/debugging.mdx
+++ b/docs/develop/typescript/best-practices/debugging.mdx
@@ -53,7 +53,7 @@ If you are developing Workflows and finding that code isn't executing as expecte
 
 If those old Workflows have the same name and are on the same Task Queue, Temporal will try to continue executing them on your new code by design. You may get errors that make no sense to you because:
 
-- Temporal is trying to execute old Workflow code that no longer exists in your codebase
+- Temporal is trying to execute old Workflow code that no longer exists in your codebase.
 - Your new Client code is expecting Temporal to execute old Workflow/Activity code it doesn't yet know about.
 
 Stale Workflows are usually a non-issue because the errors generated are just noise from code you no longer want to run. If you need to terminate old stale Workflows, you can do so with Temporal Web or the Temporal CLI.

--- a/docs/develop/typescript/workflows/basics.mdx
+++ b/docs/develop/typescript/workflows/basics.mdx
@@ -115,7 +115,7 @@ export async function helloWorld(): Promise<string> {
 ## How to develop Workflow logic {#workflow-logic-requirements}
 
 Workflow logic is constrained by [deterministic execution requirements](/workflow-definition#deterministic-constraints).
-Therefore, each language is limited to the use of certain idiomatic techniques. However, each Temporal SDK provides a
+Each Temporal SDK provides a
 set of APIs that can be used inside your Workflow to interact with external (to the Workflow) application code.
 
 In the Temporal TypeScript SDK, Workflows run in a deterministic sandboxed environment. The code is bundled on Worker

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -3,7 +3,7 @@ id: retry-policies
 title: What is a Temporal Retry Policy?
 sidebar_label: Retry Policies
 description:
-  Optimize your Workflow and Activity Task Executions with a custom Retry Policy on Temporal Understand default retries, intervals, backoff, and maximum attempts for error handling.
+  Optimize your Workflow and Activity Task Executions with a custom Retry Policy on Temporal. Understand default retries, intervals, backoff, and maximum attempts for error handling.
 toc_max_heading_level: 4
 keywords:
   - activities

--- a/docs/encyclopedia/retry-policies.mdx
+++ b/docs/encyclopedia/retry-policies.mdx
@@ -3,8 +3,7 @@ id: retry-policies
 title: What is a Temporal Retry Policy?
 sidebar_label: Retry Policies
 description:
-  Optimize your Workflow and Activity Task Executions with a custom Retry Policy on Temporal. Understand default
-  retries, intervals, backoff, and maximum attempts for error handling.
+  Optimize your Workflow and Activity Task Executions with a custom Retry Policy on Temporal Understand default retries, intervals, backoff, and maximum attempts for error handling.
 toc_max_heading_level: 4
 keywords:
   - activities
@@ -18,22 +17,17 @@ import { CaptionedImage, RelatedReadContainer, RelatedReadItem } from '@site/src
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-A Retry Policy is a collection of settings that tells Temporal how and when to try again after something fails in a
-Workflow Execution or Activity Task Execution.
+A Retry Policy is a collection of settings that tells Temporal how and when to try again after something fails in a Workflow Execution or Activity Task Execution.
 
 ## Overview
 
-Temporal's default behavior is to automatically retry an Activity that fails, so transient or intermittent failures
-require no action on your part. This behavior is defined by the Retry Policy.
+Temporal's default behavior is to automatically retry an Activity that fails, so transient or intermittent failures require no action on your part. This behavior is defined by the Retry Policy.
 
-A Retry Policy is declarative. You do not need to implement your own logic for handling the retries; you only need to
-specify the desired behavior and Temporal will provide it.
+A Retry Policy is declarative. You do not need to implement your own logic for handling the retries; you only need to specify the desired behavior and Temporal will provide it.
 
-In contrast to the Activities it contains, a Workflow Execution itself is not associated with a Retry Policy by default.
-This may seem counterintuitive, but Workflows and Activities perform different roles. Activities are intended for
-operations that may fail, so having a default Retry Policy increases the likelihood that they will ultimately complete
-successfully, even if the initial attempt failed. On the other hand, Workflows must be deterministic and are not
-intended to perform failure-prone operations. While it is possible to assign a Retry Policy to a Workflow Execution,
+In contrast to the Activities it contains, a Workflow Execution itself is not associated with a Retry Policy by default. This may seem counterintuitive, but Workflows and Activities perform different roles. Activities are intended for operations that may fail, so having a default Retry Policy increases the likelihood that they will ultimately complete successfully, even if the initial attempt failed.
+
+On the other hand, Workflow code must be deterministic to support replay, and failure-prone or non-deterministic operations (API calls, LLM invocations, etc.) should be placed in Activities, which have built-in retry support. While it is possible to assign a Retry Policy to a Workflow Execution,
 this is not the default and it is uncommon to do so.
 
 Retry Policies do not apply to Workflow Task Executions, which retry until the Workflow Execution Timeout (which is
@@ -146,14 +140,9 @@ re-execute upon failure; this is not typically true of Workflows. In most use ca
 an issue with the design or deployment of your application; for example, a permanent failure that may require different
 input data.
 
-Retrying an entire Workflow Execution is not recommended due to Temporal's deterministic design. Since Workflows replay
-the same sequence of events to reach the same state, retrying the whole workflow would repeat the same logic without
-resolving the underlying issue that caused the failure. This repetition does not address problems related to external
-dependencies or unchanged conditions and can lead to unnecessary resource consumption and higher costs. Instead, it's
-more efficient to retry only the failed Activities. This approach targets specific points of failure, allowing the
-workflow to progress without redundant operations, thereby saving on resources and ensuring a more focused and effective
-error recovery process. If you need to retry parts of your Workflow Definition, we recommend you implement this in your
-Workflow code.
+Retrying an entire Workflow Execution is not recommended due to the deterministic nature of Workflow replay. Since Workflows replay the same sequence of events to reach the same state, retrying the whole Workflow would repeat the same logic without resolving the underlying issue that caused the failure. This repetition doesn't address problems related to external dependencies or unchanged conditions and can lead to unnecessary resource consumption and higher costs.
+
+Instead, retry failed Activities within the Workflow, which is Temporal's default behavior. This approach targets specific points of failure, allowing the Workflow to progress without redundant operations, thereby saving on resources and ensuring a more focused and effective error recovery process. If you need to retry parts of your Workflow Definition, we recommend you implement this in your Workflow code.
 
 ## Custom Retry Policy
 

--- a/docs/encyclopedia/workflow/workflow-definition.mdx
+++ b/docs/encyclopedia/workflow/workflow-definition.mdx
@@ -160,6 +160,12 @@ A critical aspect of developing Workflow Definitions is ensuring that they are d
 Generally speaking, this means you must take care to ensure that any time your Workflow code is executed it makes the same Workflow API calls in the same sequence, given the same input.
 Some changes to those API calls are safe to make.
 
+:::tip Note on determinism
+
+Workflow code must be deterministic to support replay. To handle non-deterministic operations like API calls, LLM/AI invocations, database queries, and other external interactions, put them in Activities. Activities execute outside the replay path and are automatically retried so they don't cause non-determinism errors.
+
+:::
+
 For example, you can change:
 
 - The input parameters, return values, and execution timeouts of Child Workflows and Activities

--- a/docs/encyclopedia/workflow/workflow-overview.mdx
+++ b/docs/encyclopedia/workflow/workflow-overview.mdx
@@ -3,9 +3,7 @@ id: workflow-overview
 title: Temporal Workflow
 sidebar_label: Workflow
 description:
-  This comprehensive guide provides insights into Temporal Workflows, covering Workflow Definitions in various
-  programming languages, deterministic constraints, handling code changes, and ensuring reliability, durability, and
-  scalability in a Temporal Application, with examples and best practices for Workflow Versioning and development.
+  This comprehensive guide provides insights into Temporal Workflows, covering Workflow Definitions in various programming languages, deterministic constraints, handling code changes, and ensuring reliability, durability, and scalability in a Temporal Application, with examples and best practices for Workflow Versioning and development.
 slug: /workflows
 toc_max_heading_level: 4
 keywords:
@@ -25,29 +23,59 @@ This guide provides a comprehensive overview of Temporal Workflows and covers th
 
 ## Intro to Workflows
 
-Conceptually, a workflow defines a sequence of steps. With Temporal, those steps are defined by writing code, known as a
-Workflow Definition, and are carried out by running that code, which results in a Workflow Execution.
+Conceptually, a workflow defines a sequence of steps. With Temporal, those steps are defined by writing code, known as a Workflow Definition, and are carried out by running that code, which results in a Workflow Execution.
 
-In day-to-day conversations, the term Workflow might refer to Workflow Type, a Workflow Definition, or a Workflow
-Execution.
+In day-to-day conversations, the term Workflow might refer to Workflow Type, a Workflow Definition, or a Workflow Execution.
 
 1. A **Workflow Definition** is the code that defines your Workflow.
-2. The **Workflow Type** is the name that maps to a Workflow Definition. It's an identifier that makes it possible to
-   distinguish one type of Workflow (such as order processing) from another (such as customer onboarding).
-3. A **Workflow Execution** is a running Workflow, which is created by combining a Workflow Definition with a request to
-   execute it. You can execute a Workflow Definition any number of times, potentially providing different input each
-   time (i.e., a Workflow Definition for order processing might process order #123 in one execution and order #567 in
-   another execution). It is the actual instance of the Workflow Definition running in the Temporal Platform.
+2. The **Workflow Type** is the name that maps to a Workflow Definition. It's an identifier that makes it possible to distinguish one type of Workflow (such as order processing) from another (such as customer onboarding).
+3. A **Workflow Execution** is a running Workflow, which is created by combining a Workflow Definition with a request to execute it. You can execute a Workflow Definition any number of times, potentially providing different input each time (i.e., a Workflow Definition for order processing might process order #123 in one execution and order #567 in another execution). It is the actual instance of the Workflow Definition running in the Temporal Platform.
 
-You'll develop those Workflows by writing code in a general-purpose programming language such as Go, Java, TypeScript,
-or Python. The code you write is the same code that will be executed at runtime, so you can use your favorite tools and
-libraries to develop Temporal Workflows.
+You'll develop those Workflows by writing code in a general-purpose programming language such as Go, Java, TypeScript, or Python. The code you write is the same code that will be executed at runtime, so you can use your favorite tools and libraries to develop Temporal Workflows.
 
-Temporal Workflows are resilient.
-They can run—and keep running—for years, even if the underlying infrastructure fails.
-If the application itself crashes, Temporal will automatically recreate its pre-failure state so it can continue right where it left off.
+Temporal Workflows are resilient. They can run—and keep running—for years, even if the underlying infrastructure fails. If the application itself crashes, Temporal will automatically recreate its pre-failure state so it can continue right where it left off.
 
-Each Workflow Execution progresses through a series of **Commands** and **Events**, which are recorded in an **Event
-History**.
+Each Workflow Execution progresses through a series of **Commands** and **Events**, which are recorded in an **Event History**.
 
-Workflows must follow deterministic constraints to ensure consistent replay behavior.
+### How Workflow replay works
+
+When a Workflow pauses or encounters an error, the goal of Temporal is to bring the Workflow back to the exact same state it was in before the pause occurred. To make that possible, Temporal keeps the Event History. This is a complete, ordered log of everything that has already happened in a Workflow.
+
+The Event History could look like this for example:
+
+- Started Timer for 5 minutes
+- Scheduled Activity X
+- Activity X completed with result Y
+- Received Signal Z
+
+This history is the source of truth for everything that happens in the Workflow.
+
+#### Resuming a Workflow
+
+When it's time to continue the Workflow, Temporal doesn't restore memory from a snapshot. It starts the Workflow code from the beginning, replays the Event History step by step, and uses that history to guide the code back to the exact state as before. So the Workflow code is re-run, but uses the recorded events instead of redoing work.
+
+Because the Workflow is re-executed to rebuild its state:
+
+- It has to make the same decisions when given the same history, which makes a Workflow deterministic.
+- It shouldn't depend on values that can change between runs.
+
+For example:
+
+- A direct call to `Date.now()` could return a different value on replay.
+- A random number could change.
+- A network call could return something new.
+
+If those values changed, the Workflow could take a different path and fail to match the recorded history. To solve this, Temporal provides replay-safe versions of common operations:
+
+- Time is read from the Workflow context so it matches the recorded history.
+- Timers are recorded as events and don’t “wait” again during replay.
+- Randomness and similar values can be captured once and reused.
+
+These APIs make sure the Workflow receives the same values during replay as it did originally. Activities handle everything that interacts with the outside world, like:
+
+- API calls
+- Database queries
+- LLM invocations
+- File I/O
+
+When a Workflow calls an Activity, the Activity runs once, its result is recorded in the Event History. During replay, that result is reused, not recomputed. So Activities aren't executed again during replay.

--- a/docs/encyclopedia/workflow/workflow-overview.mdx
+++ b/docs/encyclopedia/workflow/workflow-overview.mdx
@@ -35,11 +35,11 @@ You'll develop those Workflows by writing code in a general-purpose programming 
 
 Temporal Workflows are resilient. They can run—and keep running—for years, even if the underlying infrastructure fails. If the application itself crashes, Temporal will automatically recreate its pre-failure state so it can continue right where it left off.
 
-Each Workflow Execution progresses through a series of **Commands** and **Events**, which are recorded in an **Event History**.
+Each Workflow Execution emits a series of **Commands** and processes a sequence of **Events**, which are recorded in an **Event History**.
 
 ### How Workflow replay works
 
-When a Workflow pauses or encounters an error, the goal of Temporal is to bring the Workflow back to the exact same state it was in before the pause occurred. To make that possible, Temporal keeps the Event History. This is a complete, ordered log of everything that has already happened in a Workflow.
+When a Workflow stops or encounters an error, the goal of Temporal is to bring the Workflow back to the exact same state it was in before the pause occurred. To make that possible, Temporal keeps the Event History. This is a complete, ordered log of everything that has already happened in a Workflow.
 
 The Event History could look like this for example:
 
@@ -52,18 +52,18 @@ This history is the source of truth for everything that happens in the Workflow.
 
 #### Resuming a Workflow
 
-When it's time to continue the Workflow, Temporal doesn't restore memory from a snapshot. It starts the Workflow code from the beginning, replays the Event History step by step, and uses that history to guide the code back to the exact state as before. So the Workflow code is re-run, but uses the recorded events instead of redoing work.
+When it's time to continue the Workflow, Temporal doesn't restore memory from a snapshot. It starts the Workflow code from the beginning, replays the Event History step by step, and uses that history to guide the code back to the exact state as before. So the Workflow code is re-run, but uses the recorded events instead of redoing work. Although Temporal doesn't always have to start from the beginning if the state is cached.
 
 Because the Workflow is re-executed to rebuild its state:
 
 - It has to make the same decisions when given the same history, which makes a Workflow deterministic.
-- It shouldn't depend on values that can change between runs.
+- It shouldn't depend on any values _not_ recorded in the history which would be different between runs.
 
 For example:
 
 - A direct call to `Date.now()` could return a different value on replay.
 - A random number could change.
-- A network call could return something new.
+- A network call, which wasn't performed inside an Activity, could return something new.
 
 If those values changed, the Workflow could take a different path and fail to match the recorded history. To solve this, Temporal provides replay-safe versions of common operations:
 

--- a/docs/encyclopedia/workflow/workflow-overview.mdx
+++ b/docs/encyclopedia/workflow/workflow-overview.mdx
@@ -39,7 +39,7 @@ Each Workflow Execution emits a series of **Commands** and processes a sequence 
 
 ### How Workflow replay works
 
-When a Workflow stops or encounters an error, the goal of Temporal is to bring the Workflow back to the exact same state it was in before the pause occurred. To make that possible, Temporal keeps the Event History. This is a complete, ordered log of everything that has already happened in a Workflow.
+When a Workflow [yields](https://en.wikipedia.org/wiki/Yield_(multithreading)) or encounters an error, the goal of Temporal is to bring the Workflow back to the exact same state it was in before the pause occurred. To make that possible, Temporal keeps the Event History. This is a complete, ordered log of everything that has already happened in a Workflow.
 
 The Event History could look like this for example:
 

--- a/docs/evaluate/why-temporal.mdx
+++ b/docs/evaluate/why-temporal.mdx
@@ -22,6 +22,8 @@ But most of them revolve around these three themes:
 - Productive development paradigms and code structure
 - Visible distributed application state
 
+You can check out a list of [use cases for Temporal](/evaluate/use-cases-design-patterns) to better understand how it can fit into your system. Temporal supports things like AI agent orchestration, enabling durable execution of LLM calls, tool use, and complex AI workflows.
+
 :::tip See Temporal in action
 Watch the following video to see how Temporal ensures an order-fulfillment system can recover from various failures, from process crashes to unreachable APIs.
 


### PR DESCRIPTION
## What does this PR do?

Some pages in the docs need to be updated so that determinism is better understood. Right now we say that Temporal is deterministic when really only Workflows are deterministic and Activities handle non-determinism operations. 

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214124203356022">EDU-6219 Update docs to refine explanations for non-determinism</a>
