### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/bin/ensure-ai-cookbook.js
+++ b/bin/ensure-ai-cookbook.js
@@ -4,7 +4,13 @@ const { existsSync, mkdirSync, writeFileSync } = require('fs');
 const path = require('path');
 
 const WORKSPACE_ROOT = path.resolve(__dirname, '..');
-const OUTPUT_DIR = path.join(WORKSPACE_ROOT, process.env.AI_COOKBOOK_OUTPUT_DIR ?? 'ai-cookbook');
+const outputDirFromEnv = process.env.AI_COOKBOOK_OUTPUT_DIR ?? 'ai-cookbook';
+const OUTPUT_DIR = path.resolve(WORKSPACE_ROOT, outputDirFromEnv);
+
+if (OUTPUT_DIR !== WORKSPACE_ROOT && !OUTPUT_DIR.startsWith(`${WORKSPACE_ROOT}${path.sep}`)) {
+  throw new Error('[ensure-ai-cookbook] AI_COOKBOOK_OUTPUT_DIR must resolve within the repository root');
+}
+
 const PLACEHOLDER_PATH = path.join(OUTPUT_DIR, 'recipes-not-synced.mdx');
 
 // Ensure ai-cookbook directory exists with a placeholder file.

--- a/src/components/elements/CallToAction.js
+++ b/src/components/elements/CallToAction.js
@@ -1,9 +1,33 @@
 import React from 'react';
 import styles from './call-to-action.module.css';
 
+ const getSafeHref = (href) => {
+   if (typeof href !== 'string') {
+     return '#';
+   }
+
+   const value = href.trim();
+
+   if (!value || value.startsWith('/') || value.startsWith('#') || value.startsWith('?')) {
+     return value || '#';
+   }
+
+   const lowerValue = value.toLowerCase();
+
+   if (
+     lowerValue.startsWith('http://') ||
+     lowerValue.startsWith('https://') ||
+     lowerValue.startsWith('mailto:')
+   ) {
+     return value;
+   }
+
+   return '#';
+ };
+
  export const CallToAction = ({ href, children }) => {
    return (
-     <a href={href} className={styles.cta}>
+     <a href={getSafeHref(href)} className={styles.cta}>
        <div className={styles.content}>
          {children}
        </div>


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `bin/ensure-ai-cookbook.js:L7`

The output directory is derived from the `AI_COOKBOOK_OUTPUT_DIR` environment variable and joined directly into a filesystem path. An attacker (or misconfigured CI job) could supply values like `../../...` to write outside the repository root when creating the placeholder file.

## Solution

Validate and constrain `AI_COOKBOOK_OUTPUT_DIR` to an allowlisted subdirectory. Use `path.resolve` and enforce that the resolved path starts with `WORKSPACE_ROOT` (or a specific intended base directory) before writing.

## Changes

- `bin/ensure-ai-cookbook.js` (modified)
- `src/components/elements/CallToAction.js` (modified)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214131320514772">EDU-6224 fix(security): 2 improvements across 2 files</a>
