### PR TITLE
perf(encyclopedia): added clarification for how Updates work with delayed start Workflows

### DIFF
--- a/docs/encyclopedia/workflow/workflow-execution/timers-delays.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/timers-delays.mdx
@@ -30,8 +30,8 @@ Workers consume no additional resources while waiting for a Timer to fire, so a 
 - [How to set Timers in TypeScript](/develop/typescript/workflows/timers)
 - [How to set Timers in .NET](/develop/dotnet/workflows/timers)
 
-The duration of a Timer is fixed, and your Workflow might specify a value as short as one second or as long as several years.
-Although it's possible to specify an extremely precise duration, such as 36 milliseconds or 15.072 minutes, your Workflows should not rely on sub-second accuracy for Timers.
+The duration of a Timer is fixed, and your Workflow might specify a value as short as one second or as long as several years. Although it's possible to specify an extremely precise duration, such as 36 milliseconds or 15.072 minutes, your Workflows should not rely on sub-second accuracy for Timers.
+
 We recommend that you consider the duration as a minimum time, one which will be rounded up slightly due to the latency involved with scheduling and firing the Timer.
 For example, setting a Timer for 11.97 seconds is guaranteed to delay execution for at least that long, but will likely be closer to 12 seconds in practice.
 
@@ -46,8 +46,8 @@ Start Delay Workflow Execution is incompatible with both [Schedules](/schedule) 
 Start Delay determines the amount of time to wait before initiating a Workflow Execution.
 This is useful if you have a Workflow you want to schedule out in the future, but only want it to execute once: in comparison to reoccurring Workflows using Schedules.
 
-If the Workflow receives a Signal-With-Start or Update-With-Start during the delay, it dispatches a Workflow Task and the remaining delay is bypassed.
-If the Workflow receives a Signal during the delay that is not a Signal-With-Start, the Signal does not interrupt the delay, and the Workflow continues to be delayed until the delay expires or a Signal-With-Start is received.
+If the Workflow receives a Signal-With-Start or Update-With-Start during the delay, it dispatches a Workflow Task and the remaining delay is bypassed. If the Workflow receives a [Signal](/sending-messages#sending-signals) during the delay that is not a Signal-With-Start, the Signal does not interrupt the delay, and the Workflow continues to be delayed until the delay expires or a Signal-With-Start is received.
 
-You can delay the dispatch of the initial Workflow Execution by setting this option in the Workflow Options field of your chosen SDK.
-This delay only applies to the initial Workflow Execution and does not affect subsequent executions, such as when the Workflow Continues-as-New.
+A delayed-start Workflow can be triggered with an [Update](/sending-messages#sending-updates). This is because a Workflow Task needs to be scheduled to deliver an Update to Worker. Once a Workflow Task is scheduled, the Workflow is unblocked. Delay start essentially works by not scheduling the first Workflow Task on Workflow creation.
+
+You can delay the dispatch of the initial Workflow Execution by setting this option in the Workflow Options field of your chosen SDK. This delay only applies to the initial Workflow Execution and does not affect subsequent executions, such as when the Workflow Continues-as-New.

--- a/docs/encyclopedia/workflow/workflow-execution/timers-delays.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/timers-delays.mdx
@@ -48,6 +48,6 @@ This is useful if you have a Workflow you want to schedule out in the future, bu
 
 If the Workflow receives a Signal-With-Start or Update-With-Start during the delay, it dispatches a Workflow Task and the remaining delay is bypassed. If the Workflow receives a [Signal](/sending-messages#sending-signals) during the delay that is not a Signal-With-Start, the Signal does not interrupt the delay, and the Workflow continues to be delayed until the delay expires or a Signal-With-Start is received.
 
-A delayed-start Workflow can be triggered with an [Update](/sending-messages#sending-updates). This is because a Workflow Task needs to be scheduled to deliver an Update to Worker. Once a Workflow Task is scheduled, the Workflow is unblocked. Delay start essentially works by not scheduling the first Workflow Task on Workflow creation.
+A delayed-start Workflow can be triggered with an [Update](/sending-messages#sending-updates). This is because a Workflow Task needs to be scheduled to deliver an Update to Worker. Once a Workflow Task is scheduled, the Workflow is unblocked. Delay start works by not scheduling the first Workflow Task on Workflow creation.
 
 You can delay the dispatch of the initial Workflow Execution by setting this option in the Workflow Options field of your chosen SDK. This delay only applies to the initial Workflow Execution and does not affect subsequent executions, such as when the Workflow Continues-as-New.


### PR DESCRIPTION
## What does this PR do?

We mentioned how Signals don't interfere with delayed start Workflows, but didn't explicitly say how Updates can force the Workflows to run.

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214152093432731">EDU-6232 perf(encyclopedia): added clarification for how Updates work with delayed start Workflows</a>
