### PR TITLE
docs: Serverless Worker Autoscaling encyclopedia page (5/4)

### DIFF
--- a/docs/encyclopedia/workers/serverless-worker-autoscaling.mdx
+++ b/docs/encyclopedia/workers/serverless-worker-autoscaling.mdx
@@ -1,0 +1,143 @@
+---
+id: serverless-worker-autoscaling
+title: Serverless Worker Autoscaling
+sidebar_label: Serverless Worker Autoscaling
+description:
+  Learn how Temporal automatically scales Serverless Workers on AWS Lambda based on task queue signals.
+slug: /serverless-worker-autoscaling
+toc_max_heading_level: 4
+keywords:
+  - serverless
+  - autoscaling
+  - workers
+  - lambda
+  - worker controller instance
+tags:
+  - Workers
+  - Concepts
+  - Serverless
+---
+
+This page covers the following:
+
+- [How autoscaling works](#how-autoscaling-works)
+- [Scaling signals](#scaling-signals)
+- [Scaling flow](#scaling-flow)
+- [Lambda invocation lifecycle](#lambda-invocation-lifecycle)
+- [Failure handling](#failure-handling)
+- [Key constraints](#key-constraints)
+
+## How autoscaling works {#how-autoscaling-works}
+
+Temporal's internal Worker Controller Instance (WCI) manages the lifecycle of Serverless Workers.
+It decides when to start, scale, and stop Lambda invocations on your behalf.
+Your worker code stays in your AWS account; the WCI only manages scaling decisions.
+
+The WCI does not take work off the Task Queue.
+It observes Task Queue metadata and reacts to scaling signals to invoke new workers as needed.
+When the backlog grows, the WCI invokes additional Lambdas in parallel.
+When the work is done, workers exit and scale to zero.
+
+## Scaling signals {#scaling-signals}
+
+The WCI uses two signals to decide when to invoke new workers:
+
+### Task Queue backlog
+
+The WCI monitors Task Queue metadata to determine whether pending Tasks exist without enough workers to process them.
+If there is work on the queue and not enough workers, the WCI calls `async invoke` on Lambda.
+
+### Sync match rate
+
+When a Task is submitted (for example, `StartWorkflow` triggers a Workflow Task), the Temporal matching system attempts to route it directly to an available worker.
+If no worker is available, the sync match fails, and the WCI reacts immediately by invoking a new Lambda.
+
+This is the primary scaling path.
+It is **push-based, not polling-based**, which keeps latency low and scaling responsive.
+
+## Scaling flow {#scaling-flow}
+
+The following describes the sequence of events when a Task arrives on a Task Queue with a [compute provider](/serverless-workers#compute-providers) configured:
+
+1. A Task is submitted (for example, `StartWorkflow` or `ScheduleActivity`).
+2. The Temporal matching system attempts a sync match to an available worker.
+3. If a worker is available (**sync match succeeds**), the Task is routed to that worker. No scaling action is needed.
+4. If no worker is available (**sync match fails**), the WCI detects the failed match.
+5. The WCI checks the Task Queue backlog and match rate, then calls `async invoke` on the configured Lambda function using a cross-account IAM role.
+6. The Lambda starts, creates a Temporal Client, and begins polling the Task Queue.
+7. The worker processes available Tasks until it exits (see [Lambda invocation lifecycle](#lambda-invocation-lifecycle)).
+
+If the backlog continues to grow, the WCI invokes additional Lambdas in parallel until the backlog drains or account concurrency limits are reached.
+
+## Lambda invocation lifecycle {#lambda-invocation-lifecycle}
+
+Each Lambda invocation follows the three-phase lifecycle described in [Worker lifecycle](/serverless-workers#worker-lifecycle): **init**, **work**, and **shutdown**.
+
+From an autoscaling perspective, the key behaviors are:
+
+- **The Lambda runs as long as there is work.**
+  The worker continues polling and processing Tasks until the queue is empty.
+- **The Lambda exits when idle.**
+  If no more work is available, the worker shuts down. There is no cost when no work is pending.
+- **The Lambda exits before the invocation deadline.**
+  The [shutdown deadline buffer](/serverless-workers#worker-lifecycle) stops the worker from accepting new work before Lambda's execution limit, giving in-flight Tasks time to complete.
+
+Each invocation is independent.
+The worker creates a fresh client connection on every invocation.
+There is no connection reuse or shared state across invocations.
+
+### Tuning for long-running Activities
+
+If your worker handles long-running Activities, set the **Worker stop timeout** and **shutdown deadline buffer** together.
+See [Tuning for long-running Activities](/serverless-workers#tuning-for-long-running-activities) for configuration details and examples.
+
+:::note
+
+Server-side autoscaler tuning parameters (such as scale-up aggressiveness) are not currently user-configurable.
+Default behavior biases toward low latency.
+This may change in future releases.
+
+:::
+
+## Failure handling {#failure-handling}
+
+### Lambda OOM or crash
+
+If a Lambda invocation crashes (out of memory, unhandled exception, etc.), the behavior follows standard Temporal retry semantics:
+
+- The Activity Timeout fires after the configured duration.
+- Temporal retries the Activity on a **different** Lambda invocation.
+- No manual intervention is required.
+
+### Account concurrency limit
+
+If your AWS account's Lambda concurrency limit is reached:
+
+- Further `invoke` calls from the WCI fail.
+- Tasks remain in the Task Queue backlog; **no data loss occurs**.
+- Processing slows until concurrency frees up.
+
+### Noisy neighbor isolation
+
+By default, a Lambda invocation may run multiple Activity slots.
+If you need compute isolation (for example, running untrusted binaries or memory-intensive operations):
+
+- **Split Workflow and Activity workers** into separate Lambda functions.
+- **Set Activity slots to 1** per Lambda invocation.
+
+With single-slot configuration, each Activity gets a dedicated Lambda execution environment.
+A crash or resource exhaustion in one Activity cannot affect others.
+
+For configuration details, see [Serverless Workers - Go SDK](/develop/go/workers/serverless-workers/aws-lambda).
+
+## Key constraints {#key-constraints}
+
+| Constraint | Detail |
+|-----------|--------|
+| Activity duration | Must complete within Lambda's 15-minute limit (minus shutdown deadline buffer). |
+| Workflow duration | **No limit**: Workflows of any duration work, regardless of Lambda's timeout. |
+| Worker code | Same Temporal SDK worker code, using the `lambdaworker` package (Go SDK at launch). |
+| Versioning | [Worker Versioning](/worker-versioning) is required. Each worker must declare `AutoUpgrade` or `Pinned` behavior. |
+
+A Workflow with 10,000 Activities that each take 1 minute will run for 10,000 minutes across many Lambda invocations.
+The 15-minute limit applies only to individual Activities, not the Workflow as a whole.

--- a/docs/encyclopedia/workers/serverless-workers.mdx
+++ b/docs/encyclopedia/workers/serverless-workers.mdx
@@ -138,3 +138,11 @@ provider because the Worker process manages its own lifecycle.
 | Provider   | Description                                                                   |
 | ---------- | ----------------------------------------------------------------------------- |
 | AWS Lambda | Temporal assumes an IAM role in your AWS account to invoke a Lambda function. |
+
+## Autoscaling {#autoscaling}
+
+Temporal automatically scales Serverless Workers based on Task Queue signals.
+When Tasks arrive and no worker is available, Temporal invokes new Lambda functions.
+When the work is done, workers exit and scale to zero.
+
+For a detailed explanation of the scaling signals, scaling flow, failure handling, and constraints, see [Serverless Worker Autoscaling](/serverless-worker-autoscaling).

--- a/sidebars.js
+++ b/sidebars.js
@@ -1397,6 +1397,7 @@ module.exports = {
             'encyclopedia/workers/worker-shutdown',
             'encyclopedia/workers/worker-versioning',
             'encyclopedia/workers/serverless-workers',
+            'encyclopedia/workers/serverless-worker-autoscaling',
           ],
         },
         {


### PR DESCRIPTION
## Summary

- Adds a dedicated encyclopedia page explaining how Temporal autoscales Serverless Workers on AWS Lambda
- Covers scaling signals (Task Queue backlog + sync match rate), the push-based scaling flow, Lambda invocation lifecycle from an autoscaling perspective, failure handling (OOM, concurrency limits, noisy neighbor isolation), and key constraints
- Adds an Autoscaling section to the existing Serverless Workers encyclopedia page with a cross-link
- Adds sidebar entry under Workers > Encyclopedia

This is a companion to the existing serverless worker docs split:
- #4417 (Evaluate)
- #4418 (Go SDK)
- #4416 (Deploy guide)
- #4415 (Encyclopedia)

Content is grounded in the Hebbia <> Temporal serverless discussion ([Gong](https://us-11514.app.gong.io/call?id=2934263572820276031)) where Stefan described the autoscaling architecture in detail. Cross-referenced against all four existing PRs to ensure terminology and configuration details are accurate.

## Test plan

- [ ] Verify the new page renders at `/serverless-worker-autoscaling`
- [ ] Verify the sidebar shows the new entry under Workers > Encyclopedia
- [ ] Verify the cross-link from `/serverless-workers` Autoscaling section works
- [ ] Verify internal links to `/serverless-workers#worker-lifecycle` and `/worker-versioning` resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214152359983530">EDU-6233 docs: Serverless Worker Autoscaling encyclopedia page (5&#x2F;4)</a>
