### PR TITLE
docs(openmetrics): recommend 30s scrape interval, add multi-label note

### DIFF
--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -189,7 +189,7 @@ temporal_cloud_v1_approximate_backlog_count{temporal_namespace="production",temp
 #### Summary of Best Practices
 
 * *Honor timestamps*: Set `honor_timestamps: true` in Prometheus  
-* *Scrape interval*: Use 30 or 60 second intervals  
+* *Scrape interval*: Use 30s. Intervals longer than 60s may skip datapoints because metrics update once per minute.  
 * *Timeout*: Set scrape timeout to 10 seconds for large responses  
 * *Filtering*: Use query parameters to reduce response size
 
@@ -365,4 +365,4 @@ count({__name__=~"temporal_cloud_v1_.*"}) by (__name__)
 | Limit | Impact | Mitigation |
 | ----- | ----- | ----- |
 | 30k total datapoints per scrape | Response may be truncated | Use namespace/metric filtering |
-| 180 requests per account per hour (~3 requests per minute) | HTTP 429 returned | Set appropriate scrape interval of 30-60s |
+| 180 requests per account per hour (~3 requests per minute) | HTTP 429 returned | Set scrape interval to 30s |

--- a/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
@@ -58,7 +58,7 @@ Self hosted Prometheus can be used to scrape the OpenMetrics endpoint.
 ```yaml
 scrape_configs:
   - job_name: 'temporal-cloud'
-    scrape_interval: 60s
+    scrape_interval: 30s
     scrape_timeout: 30s
     honor_timestamps: true
     scheme: https
@@ -84,7 +84,7 @@ receivers:
     config:
       scrape_configs:
       - job_name: 'temporal-cloud'
-        scrape_interval: 60s
+        scrape_interval: 30s
         scrape_timeout: 30s
         honor_timestamps: true
         scheme: https

--- a/docs/cloud/metrics/openmetrics/metrics-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-reference.mdx
@@ -70,7 +70,6 @@ For example, to include `temporal_activity_type` in your scrape results:
 /v1/metrics?labels=temporal_activity_type
 ```
 
-:::note
 
 Multiple labels can be enabled at the same time using multiple `labels` query parameters:
 
@@ -78,7 +77,6 @@ Multiple labels can be enabled at the same time using multiple `labels` query pa
 /v1/metrics?labels=temporal_worker_build_id&labels=temporal_worker_deployment_name
 ```
 
-:::
 
 ## Metrics Catalog
 

--- a/docs/cloud/metrics/openmetrics/metrics-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-reference.mdx
@@ -71,7 +71,7 @@ For example, to include `temporal_activity_type` in your scrape results:
 ```
 
 
-Multiple labels can be enabled at the same time using multiple `labels` query parameters:
+Enable multiple labels at the same time by concatenating multiple `labels` query parameters:
 
 ```
 /v1/metrics?labels=temporal_worker_build_id&labels=temporal_worker_deployment_name

--- a/docs/cloud/metrics/openmetrics/metrics-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-reference.mdx
@@ -70,6 +70,16 @@ For example, to include `temporal_activity_type` in your scrape results:
 /v1/metrics?labels=temporal_activity_type
 ```
 
+:::note
+
+Multiple labels can be enabled at the same time using multiple `labels` query parameters:
+
+```
+/v1/metrics?labels=temporal_worker_build_id&labels=temporal_worker_deployment_name
+```
+
+:::
+
 ## Metrics Catalog
 
 ### Frontend Service Metrics

--- a/docs/cloud/metrics/openmetrics/migration-guide.mdx
+++ b/docs/cloud/metrics/openmetrics/migration-guide.mdx
@@ -208,7 +208,7 @@ scrape_configs:
     scheme: https
     metrics_path: '/v1/metrics'
     honor_timestamps: true
-    scrape_interval: 60s
+    scrape_interval: 30s
     scrape_timeout: 30s
     authorization:
       type: Bearer


### PR DESCRIPTION
## What?

* Change the recommended OpenMetrics scrape interval from 60s to 30s across the best-practices summary, API limits table, and all config examples (Prometheus, OpenTelemetry Collector, migration guide).
* Add a note in the metrics reference showing how to pass multiple `labels` query parameters in a single request.

## Why?

Scrape intervals longer than 60s can skip datapoints because metrics update once per minute. 30s captures every minute's data and stays comfortably within the 180 req/hour rate limit (120 scrapes/hour). Values up to 60s still work, but 30s is the safer default to recommend.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214153862722428">EDU-6237 docs(openmetrics): recommend 30s scrape interval, add multi-label note</a>
