### PR TITLE
docs: self-hosted setup for serverless workers

### DIFF
--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -152,14 +152,14 @@ aws lambda update-function-code \
 
 ## 3. Configure IAM for Temporal invocation (Cloud only) {#configure-iam}
 
+This section applies to Temporal Cloud.
+For self-hosted Temporal Service deployments, see [Self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup#create-invocation-role) for IAM configuration with a different CloudFormation template.
+
 Temporal needs permission to invoke your Lambda function.
 The Temporal server assumes an IAM role in your AWS account to call `lambda:InvokeFunction`.
 The trust policy on the role includes an External ID condition to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks.
 
 Deploy the following CloudFormation template to create the invocation role and its permissions. [Download the template](/files/temporal-cloud-serverless-worker-role.yaml).
-
-This section applies to Temporal Cloud.
-For self-hosted Temporal Service deployments, see [Self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup#create-invocation-role) for IAM configuration with a different CloudFormation template.
 
 | Parameter | Description |
 |---|---|

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -370,9 +370,3 @@ You can verify the invocation by checking:
 
 - **Temporal UI:** The Workflow execution should show task completions in the event history.
 - **AWS CloudWatch Logs:** The Lambda function's log group (`/aws/lambda/my-temporal-worker`) should show invocation logs with the Worker startup, task processing, and graceful shutdown.
-
-To view the Worker Controller Instance (WCI) workflow that manages scaling for your deployment, filter workflows in the Temporal UI or CLI with:
-
-```bash
-temporal workflow list --query 'TemporalNamespaceDivision = "TemporalWorkerControllerInstance"'
-```

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -150,7 +150,7 @@ aws lambda update-function-code \
   --zip-file fileb://function.zip
 ```
 
-## 3. Configure IAM for Temporal invocation {#configure-iam}
+## 3. Configure IAM for Temporal invocation (Cloud only) {#configure-iam}
 
 Temporal needs permission to invoke your Lambda function.
 The Temporal server assumes an IAM role in your AWS account to call `lambda:InvokeFunction`.

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -370,3 +370,9 @@ You can verify the invocation by checking:
 
 - **Temporal UI:** The Workflow execution should show task completions in the event history.
 - **AWS CloudWatch Logs:** The Lambda function's log group (`/aws/lambda/my-temporal-worker`) should show invocation logs with the Worker startup, task processing, and graceful shutdown.
+
+To view the Worker Controller Instance (WCI) workflow that manages scaling for your deployment, filter workflows in the Temporal UI or CLI with:
+
+```bash
+temporal workflow list --query 'TemporalNamespaceDivision = "TemporalWorkerControllerInstance"'
+```

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -27,11 +27,12 @@ This guide walks through deploying a Temporal [Serverless Worker](/serverless-wo
 ## Prerequisites {#prerequisites}
 
 - A Temporal Cloud account or a self-hosted Temporal Service vx.xx.x or later.
-  - For self-hosted deployments, complete the [self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup) before following this guide.
-  - The Temporal Service frontend must be reachable from the Lambda execution environment. For Temporal Cloud, no additional configuration is needed. For self-hosted deployments on a private network, use features like [VPC access](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html) to reach the Temporal frontend.
+- For self-hosted deployments, complete the
+  [self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup) before following
+  this guide.
 - An AWS account with permissions to create and invoke Lambda functions and create IAM roles.
-- The AWS-specific steps in this guide require the [`aws` CLI](https://aws.amazon.com/cli/) installed and configured with your AWS credentials. You may use other tools to perform the steps, such as the AWS Console or the AWS SDKs.
-
+- The AWS-specific steps in this guide require the [`aws` CLI](https://aws.amazon.com/cli/) installed and configured
+  with your AWS credentials. You may use other tools to perform the steps, such as the AWS Console or the AWS SDKs.
 
 <SdkTabs hideUnsupportedLanguages>
 <SdkTabs.Go>
@@ -43,8 +44,8 @@ This guide walks through deploying a Temporal [Serverless Worker](/serverless-wo
 
 ## 1. Write Worker code {#write-worker-code}
 
-Write a Worker that runs inside a Lambda function.
-The Worker handles the per-invocation lifecycle: connecting to Temporal, polling for tasks, and gracefully shutting down before the invocation deadline.
+Write a Worker that runs inside a Lambda function. The Worker handles the per-invocation lifecycle: connecting to
+Temporal, polling for tasks, and gracefully shutting down before the invocation deadline.
 
 <SdkTabs hideUnsupportedLanguages>
 <SdkTabs.Go>
@@ -77,9 +78,11 @@ func main() {
 }
 ```
 
-Each Workflow must declare a [versioning behavior](/worker-versioning#versioning-behaviors) at registration time, either `AutoUpgrade` or `Pinned`.
+Each Workflow must declare a [versioning behavior](/worker-versioning#versioning-behaviors) at registration time, either
+`AutoUpgrade` or `Pinned`.
 
-For details on configuration options, Lambda-tuned defaults, and the invocation lifecycle, see [Serverless Workers - Go SDK](/develop/go/workers/serverless-workers/aws-lambda).
+For details on configuration options, Lambda-tuned defaults, and the invocation lifecycle, see
+[Serverless Workers - Go SDK](/develop/go/workers/serverless-workers/aws-lambda).
 
 </SdkTabs.Go>
 </SdkTabs>
@@ -122,26 +125,28 @@ aws lambda create-function \
   --environment "Variables={HOME=/tmp,TEMPORAL_ADDRESS=<your-temporal-address>:7233,TEMPORAL_NAMESPACE=<your-namespace>,TEMPORAL_API_KEY=<your-api-key>}"
 ```
 
-| Parameter | Description |
-|---|---|
-| `--function-name` | Name of the Lambda function. |
-| `--runtime` | Lambda runtime. Use `provided.al2023` for custom Go binaries. |
-| `--handler` | Entry point binary name. Must be `bootstrap` when using the `provided.al2023` custom runtime. |
-| `--role` | ARN of the Lambda [execution role](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html), which grants the function permission to run. Trusted principal must be `lambda.amazonaws.com`. This is separate from the role Temporal uses to invoke the function in [Step 3](#configure-iam). The role must have at least the [`AWSLambdaBasicExecutionRole`](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicExecutionRole.html) managed policy attached. |
-| `--zip-file` | Path to your packaged deployment zip. |
-| `--timeout` | Invocation deadline in seconds. This is the maximum time each Lambda invocation can run before AWS terminates it. Set this high enough for the Worker to start, process Tasks, and [shut down gracefully](/serverless-workers#worker-lifecycle). |
-| `--memory-size` | Memory in MB allocated to each invocation. |
-| `HOME` | Must be `/tmp`. |
-| `TEMPORAL_ADDRESS` | Temporal frontend address (e.g., `<namespace>.<account>.tmprl.cloud:7233`). |
-| `TEMPORAL_NAMESPACE` | Temporal Namespace. |
-| `TEMPORAL_TASK_QUEUE` | Task Queue name. Overrides the value set in code. |
-| `TEMPORAL_TLS_CLIENT_CERT_PATH` | Path to the TLS client certificate file for mTLS authentication. |
-| `TEMPORAL_TLS_CLIENT_KEY_PATH` | Path to the TLS client key file for mTLS authentication. |
-| `TEMPORAL_API_KEY` | API key for API key authentication. |
+| Parameter                       | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--function-name`               | Name of the Lambda function.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| `--runtime`                     | Lambda runtime. Use `provided.al2023` for custom Go binaries.                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `--handler`                     | Entry point binary name. Must be `bootstrap` when using the `provided.al2023` custom runtime.                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `--role`                        | ARN of the Lambda [execution role](https://docs.aws.amazon.com/lambda/latest/dg/lambda-intro-execution-role.html), which grants the function permission to run. Trusted principal must be `lambda.amazonaws.com`. This is separate from the role Temporal uses to invoke the function in [Step 3](#configure-iam). The role must have at least the [`AWSLambdaBasicExecutionRole`](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicExecutionRole.html) managed policy attached. |
+| `--zip-file`                    | Path to your packaged deployment zip.                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `--timeout`                     | Invocation deadline in seconds. This is the maximum time each Lambda invocation can run before AWS terminates it. Set this high enough for the Worker to start, process Tasks, and [shut down gracefully](/serverless-workers#worker-lifecycle).                                                                                                                                                                                                                                                              |
+| `--memory-size`                 | Memory in MB allocated to each invocation.                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+| `HOME`                          | Must be `/tmp`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| `TEMPORAL_ADDRESS`              | Temporal frontend address (e.g., `<namespace>.<account>.tmprl.cloud:7233`).                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+| `TEMPORAL_NAMESPACE`            | Temporal Namespace.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| `TEMPORAL_TASK_QUEUE`           | Task Queue name. Overrides the value set in code.                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| `TEMPORAL_TLS_CLIENT_CERT_PATH` | Path to the TLS client certificate file for mTLS authentication.                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `TEMPORAL_TLS_CLIENT_KEY_PATH`  | Path to the TLS client key file for mTLS authentication.                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+| `TEMPORAL_API_KEY`              | API key for API key authentication.                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
-The `lambdaworker` package reads environment variables automatically at startup. For the full list, see [Client environment configuration](/references/client-environment-configuration).
+The `lambdaworker` package reads environment variables automatically at startup. For the full list, see
+[Client environment configuration](/references/client-environment-configuration).
 
-Sensitive values like TLS keys and API keys should be encrypted at rest. See [AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars-encryption.html) for options.
+Sensitive values like TLS keys and API keys should be encrypted at rest. See
+[AWS documentation](https://docs.aws.amazon.com/lambda/latest/dg/configuration-envvars-encryption.html) for options.
 
 To update an existing function with new code:
 
@@ -153,20 +158,22 @@ aws lambda update-function-code \
 
 ## 3. Configure IAM for Temporal invocation (Cloud only) {#configure-iam}
 
-This section applies to Temporal Cloud.
-For self-hosted Temporal Service deployments, see [Self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup#create-invocation-role) for IAM configuration with a different CloudFormation template.
+This section applies to Temporal Cloud. For self-hosted Temporal Service deployments, see
+[Self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup#create-invocation-role)
+for IAM configuration with a different CloudFormation template.
 
-Temporal needs permission to invoke your Lambda function.
-The Temporal server assumes an IAM role in your AWS account to call `lambda:InvokeFunction`.
-The trust policy on the role includes an External ID condition to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks.
+Temporal needs permission to invoke your Lambda function. The Temporal server assumes an IAM role in your AWS account to
+call `lambda:InvokeFunction`. The trust policy on the role includes an External ID condition to prevent
+[confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks.
 
-Deploy the following CloudFormation template to create the invocation role and its permissions. [Download the template](/files/temporal-cloud-serverless-worker-role.yaml).
+Deploy the following CloudFormation template to create the invocation role and its permissions.
+[Download the template](/files/temporal-cloud-serverless-worker-role.yaml).
 
-| Parameter | Description |
-|---|---|
-| `AssumeRoleExternalId` | A unique identifier that Temporal Cloud presents when assuming the role. Provided in your Namespace configuration. |
-| `LambdaFunctionARNs` | Comma-separated list of Lambda function ARNs that Temporal may invoke. One role can authorize multiple Worker Lambdas. |
-| `RoleName` | Base name for the created IAM role. Defaults to `Temporal-Cloud-Serverless-Worker`. |
+| Parameter              | Description                                                                                                            |
+| ---------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `AssumeRoleExternalId` | A unique identifier that Temporal Cloud presents when assuming the role. Provided in your Namespace configuration.     |
+| `LambdaFunctionARNs`   | Comma-separated list of Lambda function ARNs that Temporal may invoke. One role can authorize multiple Worker Lambdas. |
+| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Cloud-Serverless-Worker`.                                    |
 
 <details>
 <summary>CloudFormation template</summary>
@@ -174,7 +181,8 @@ Deploy the following CloudFormation template to create the invocation role and i
 ```yaml
 # CloudFormation template for creating an IAM role that Temporal Cloud can assume to invoke Lambda functions.
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Creates an IAM role that Temporal Cloud can assume to invoke multiple Lambda functions for Serverless Workers.
+Description:
+  Creates an IAM role that Temporal Cloud can assume to invoke multiple Lambda functions for Serverless Workers.
 
 Parameters:
   AssumeRoleExternalId:
@@ -187,8 +195,8 @@ Parameters:
   LambdaFunctionARNs:
     Type: CommaDelimitedList
     Description: >-
-      Comma-separated list of Lambda function ARNs to invoke
-      (e.g., arn:aws:lambda:us-west-2:123456789012:function:worker-1,arn:aws:lambda:us-west-2:123456789012:function:worker-2)
+      Comma-separated list of Lambda function ARNs to invoke (e.g.,
+      arn:aws:lambda:us-west-2:123456789012:function:worker-1,arn:aws:lambda:us-west-2:123456789012:function:worker-2)
 
   RoleName:
     Type: String
@@ -198,21 +206,21 @@ Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
       - Label:
-          default: "Temporal Cloud Configuration"
+          default: 'Temporal Cloud Configuration'
         Parameters:
           - AssumeRoleExternalId
       - Label:
-          default: "Lambda Configuration"
+          default: 'Lambda Configuration'
         Parameters:
           - LambdaFunctionARNs
           - RoleName
     ParameterLabels:
       AssumeRoleExternalId:
-        default: "External ID (provided by Temporal Cloud)"
+        default: 'External ID (provided by Temporal Cloud)'
       LambdaFunctionARNs:
-        default: "Lambda Function ARNs (comma-separated list)"
+        default: 'Lambda Function ARNs (comma-separated list)'
       RoleName:
-        default: "IAM Role Name"
+        default: 'IAM Role Name'
 
 Resources:
   TemporalCloudServerlessWorker:
@@ -230,13 +238,13 @@ Resources:
                   arn:aws:iam::160190466495:role/wci-lambda-invoke,
                   arn:aws:iam::819232936619:role/wci-lambda-invoke,
                   arn:aws:iam::829909441867:role/wci-lambda-invoke,
-                  arn:aws:iam::354116250941:role/wci-lambda-invoke
+                  arn:aws:iam::354116250941:role/wci-lambda-invoke,
                 ]
             Action: sts:AssumeRole
             Condition:
               StringEquals:
                 'sts:ExternalId': [!Ref AssumeRoleExternalId]
-      Description: "The role Temporal Cloud uses to invoke Lambda functions for Serverless Workers"
+      Description: 'The role Temporal Cloud uses to invoke Lambda functions for Serverless Workers'
       MaxSessionDuration: 3600 # 1 hour
 
   TemporalCloudLambdaInvokePermissions:
@@ -260,7 +268,7 @@ Outputs:
     Description: The ARN of the IAM role created for Temporal Cloud
     Value: !GetAtt TemporalCloudServerlessWorker.Arn
     Export:
-      Name: !Sub "${AWS::StackName}-RoleARN"
+      Name: !Sub '${AWS::StackName}-RoleARN'
 
   RoleName:
     Description: The name of the IAM role
@@ -268,7 +276,7 @@ Outputs:
 
   LambdaFunctionARNs:
     Description: The Lambda function ARNs that can be invoked
-    Value: !Join [", ", !Ref LambdaFunctionARNs]
+    Value: !Join [', ', !Ref LambdaFunctionARNs]
 ```
 
 </details>
@@ -290,9 +298,10 @@ The stack output `RoleARN` contains the IAM role ARN to use in your Worker Deplo
 
 ## 4. Create Worker Deployment Version {#create-worker-deployment-version}
 
-Create a [Worker Deployment Version](/production-deployment/worker-deployments/worker-versioning) with a compute provider that points to your Lambda function.
-The compute configuration tells Temporal how to invoke your Worker: the provider type (`aws-lambda`), the Lambda function ARN, and the IAM role to assume.
-The deployment name and build ID must match the values in your Worker code.
+Create a [Worker Deployment Version](/production-deployment/worker-deployments/worker-versioning) with a compute
+provider that points to your Lambda function. The compute configuration tells Temporal how to invoke your Worker: the
+provider type (`aws-lambda`), the Lambda function ARN, and the IAM role to assume. The deployment name and build ID must
+match the values in your Worker code.
 
 You can create the version using the Temporal UI or the Temporal CLI.
 
@@ -302,19 +311,22 @@ You can create the version using the Temporal UI or the Temporal CLI.
 1. In the Temporal UI, open your Namespace.
 2. In the left pane, select **Workers**.
 3. Click **Create Worker Deployment** in the upper right corner.
-4. Under **Configuration**, enter a **Name** and **Build ID**. These must match the `DeploymentName` and `BuildID` in your Worker code.
+4. Under **Configuration**, enter a **Name** and **Build ID**. These must match the `DeploymentName` and `BuildID` in
+   your Worker code.
 5. Under **Compute**, select **AWS Lambda** and provide:
    - **Lambda ARN**: the ARN of your Lambda function.
    - **IAM Role ARN**: the role ARN from [Step 3](#configure-iam) (output of the CloudFormation stack).
    - **External ID**: the same value you passed to the CloudFormation template.
 6. Click **Save**.
 
-When you create a version through the UI, the version is automatically set as current. Skip to [Verify the deployment](#verify-the-deployment).
+When you create a version through the UI, the version is automatically set as current. Skip to
+[Verify the deployment](#verify-the-deployment).
 
 </TabItem>
 <TabItem value="cli" label="Temporal CLI">
 
-Use the CLI for manual setup, shell scripts, and CI/CD pipelines. When you create a version through the CLI, you must [set the version as current](#set-current-version) as a separate step.
+Use the CLI for manual setup, shell scripts, and CI/CD pipelines. When you create a version through the CLI, you must
+[set the version as current](#set-current-version) as a separate step.
 
 ```bash
 temporal worker deployment create-version \
@@ -326,13 +338,13 @@ temporal worker deployment create-version \
   --aws-lambda-assume-role-external-id <EXTERNAL_ID>
 ```
 
-| Flag | Description |
-|---|---|
-| `--deployment-name` | Worker Deployment name. Must match `DeploymentName` in your Worker code. |
-| `--build-id` | Worker Deployment Version build ID. Must match `BuildID` in your Worker code. |
-| `--aws-lambda-function-arn` | ARN of the Lambda function Temporal invokes for this version. |
-| `--aws-lambda-assume-role-arn` | IAM role Temporal assumes to invoke the function. This is the `RoleARN` output from the CloudFormation stack in [Step 3](#configure-iam). |
-| `--aws-lambda-assume-role-external-id` | External ID configured in the IAM role trust policy. |
+| Flag                                   | Description                                                                                                                               |
+| -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `--deployment-name`                    | Worker Deployment name. Must match `DeploymentName` in your Worker code.                                                                  |
+| `--build-id`                           | Worker Deployment Version build ID. Must match `BuildID` in your Worker code.                                                             |
+| `--aws-lambda-function-arn`            | ARN of the Lambda function Temporal invokes for this version.                                                                             |
+| `--aws-lambda-assume-role-arn`         | IAM role Temporal assumes to invoke the function. This is the `RoleARN` output from the CloudFormation stack in [Step 3](#configure-iam). |
+| `--aws-lambda-assume-role-external-id` | External ID configured in the IAM role trust policy.                                                                                      |
 
 </TabItem>
 </Tabs>
@@ -341,8 +353,8 @@ temporal worker deployment create-version \
 
 If you created the version through the Temporal UI, the version is already current and you can skip this step.
 
-If you used the CLI, set the version as current.
-Without this step, tasks on the Task Queue will not route to the version, and Temporal will not invoke the Lambda function.
+If you used the CLI, set the version as current. Without this step, tasks on the Task Queue will not route to the
+version, and Temporal will not invoke the Lambda function.
 
 ```bash
 temporal worker deployment set-current-version \
@@ -361,10 +373,11 @@ temporal workflow start \
   --input '"Hello, serverless!"'
 ```
 
-When the task lands on the Task Queue with no active pollers, Temporal detects the compute provider configuration and invokes your Lambda function.
-The Worker starts, connects to Temporal, picks up the task, and processes it.
+When the task lands on the Task Queue with no active pollers, Temporal detects the compute provider configuration and
+invokes your Lambda function. The Worker starts, connects to Temporal, picks up the task, and processes it.
 
 You can verify the invocation by checking:
 
 - **Temporal UI:** The Workflow execution should show task completions in the event history.
-- **AWS CloudWatch Logs:** The Lambda function's log group (`/aws/lambda/my-temporal-worker`) should show invocation logs with the Worker startup, task processing, and graceful shutdown.
+- **AWS CloudWatch Logs:** The Lambda function's log group (`/aws/lambda/my-temporal-worker`) should show invocation
+  logs with the Worker startup, task processing, and graceful shutdown.

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -28,7 +28,7 @@ This guide walks through deploying a Temporal [Serverless Worker](/serverless-wo
 
 - A Temporal Cloud account or a self-hosted Temporal Service vx.xx.x or later.
   - For self-hosted deployments, complete the [self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup) before following this guide.
-  - The Temporal Service frontend must be reachable from the Lambda execution environment. For Temporal Cloud, no additional configuration is needed. For self-hosted deployments on a private network, configure the Lambda function with [VPC access](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html) to reach the Temporal frontend.
+  - The Temporal Service frontend must be reachable from the Lambda execution environment. For Temporal Cloud, no additional configuration is needed. For self-hosted deployments on a private network, use features like [VPC access](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html) to reach the Temporal frontend.
 - An AWS account with permissions to create and invoke Lambda functions and create IAM roles.
 - The AWS-specific steps in this guide require the [`aws` CLI](https://aws.amazon.com/cli/) installed and configured with your AWS credentials. You may use other tools to perform the steps, such as the AWS Console or the AWS SDKs.
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -27,7 +27,8 @@ This guide walks through deploying a Temporal [Serverless Worker](/serverless-wo
 ## Prerequisites {#prerequisites}
 
 - A Temporal Cloud account or a self-hosted Temporal Service vx.xx.x or later.
-  - Your Temporal Service frontend must be reachable from the Lambda execution environment. For Temporal Cloud, no additional configuration is needed. For self-hosted deployments on a private network, configure the Lambda function with [VPC access](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html) to reach the Temporal frontend.
+  - For self-hosted deployments, complete the [self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup) before following this guide.
+  - The Temporal Service frontend must be reachable from the Lambda execution environment. For Temporal Cloud, no additional configuration is needed. For self-hosted deployments on a private network, configure the Lambda function with [VPC access](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html) to reach the Temporal frontend.
 - An AWS account with permissions to create and invoke Lambda functions and create IAM roles.
 - The AWS-specific steps in this guide require the [`aws` CLI](https://aws.amazon.com/cli/) installed and configured with your AWS credentials. You may use other tools to perform the steps, such as the AWS Console or the AWS SDKs.
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -158,11 +158,8 @@ The trust policy on the role includes an External ID condition to prevent [confu
 
 Deploy the following CloudFormation template to create the invocation role and its permissions. [Download the template](/files/temporal-cloud-serverless-worker-role.yaml).
 
-:::note
-
-This template is scoped to Temporal Cloud. Self-hosted configuration guidance is in progress.
-
-:::
+This section applies to Temporal Cloud.
+For self-hosted Temporal Service deployments, see [Self-hosted setup](/production-deployment/worker-deployments/serverless-workers/self-hosted-setup#create-invocation-role) for IAM configuration with a different CloudFormation template.
 
 | Parameter | Description |
 |---|---|

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -185,4 +185,10 @@ Deploy the template:
 aws cloudformation create-stack --stack-name temporal-serverless-worker --template-body file://temporal-self-hosted-serverless-worker-role.yaml --parameters ParameterKey=TemporalIamRoleArn,ParameterValue=<TEMPORAL_SERVER_ROLE_ARN> ParameterKey=AssumeRoleExternalId,ParameterValue=<EXTERNAL_ID> ParameterKey=LambdaFunctionARNs,ParameterValue='"<LAMBDA_FUNCTION_ARN>"' --capabilities CAPABILITY_NAMED_IAM --region <AWS_REGION>
 ```
 
-The stack output `RoleARN` contains the IAM role ARN to use when creating the Worker Deployment Version.
+After the stack finishes creating, retrieve the IAM role ARN from the stack outputs:
+
+```bash
+aws cloudformation describe-stacks --stack-name temporal-serverless-worker --query 'Stacks[0].Outputs[?OutputKey==`RoleARN`].OutputValue' --output text --region <AWS_REGION>
+```
+
+Use this role ARN when creating the Worker Deployment Version.

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -33,14 +33,16 @@ Worker.
 
 ## Ensure Lambda can reach the Temporal Service {#ensure-network-reachability}
 
-The [Temporal Service frontend](/temporal-service#frontend-service) must be reachable from the Lambda execution environment.
-How to achieve this depends on your network setup.
-If the Temporal Service runs on a private network, you may need [VPC access for Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html), VPC peering, or a similar mechanism to allow the Lambda function to connect to the Temporal frontend.
+The [Temporal Service frontend](/temporal-service#frontend-service) must be reachable from the Lambda execution
+environment. How to achieve this depends on your network setup. If the Temporal Service runs on a private network, you
+may need [VPC access for Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html), VPC peering, or a
+similar mechanism to allow the Lambda function to connect to the Temporal frontend.
 
 ## Enable the Worker Controller {#enable-worker-controller}
 
-[WCI](/serverless-workers#how-invocation-works) is the server component that monitors Task Queues and invokes compute providers. It is disabled by default and must
-be enabled through [dynamic configuration](/references/dynamic-configuration).
+[WCI](/serverless-workers#how-invocation-works) is the server component that monitors Task Queues and invokes compute
+providers. It is disabled by default and must be enabled through
+[dynamic configuration](/references/dynamic-configuration).
 
 Add the following keys to your dynamic config file:
 
@@ -97,7 +99,12 @@ Temporal invokes Lambda functions by assuming an IAM role in your AWS account. T
 identity to assume it.
 
 Deploy the following CloudFormation template to create the role.
-[Download the template](/files/temporal-self-hosted-serverless-worker-role.yaml).
+[Download the template](/files/temporal-self-hosted-serverless-worker-role.yaml). Replace the parameter values in the
+command below and run it in your terminal:
+
+```bash
+aws cloudformation create-stack --stack-name temporal-serverless-worker --template-body file://temporal-self-hosted-serverless-worker-role.yaml --parameters ParameterKey=TemporalIamRoleArn,ParameterValue=<TEMPORAL_SERVER_ROLE_ARN> ParameterKey=AssumeRoleExternalId,ParameterValue=<EXTERNAL_ID> ParameterKey=LambdaFunctionARNs,ParameterValue='"<LAMBDA_FUNCTION_ARN>"' --capabilities CAPABILITY_NAMED_IAM --region <AWS_REGION>
+```
 
 | Parameter              | Description                                                                                                                                                                                                        |
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -187,12 +194,6 @@ Outputs:
 ```
 
 </details>
-
-Deploy the template:
-
-```bash
-aws cloudformation create-stack --stack-name temporal-serverless-worker --template-body file://temporal-self-hosted-serverless-worker-role.yaml --parameters ParameterKey=TemporalIamRoleArn,ParameterValue=<TEMPORAL_SERVER_ROLE_ARN> ParameterKey=AssumeRoleExternalId,ParameterValue=<EXTERNAL_ID> ParameterKey=LambdaFunctionARNs,ParameterValue='"<LAMBDA_FUNCTION_ARN>"' --capabilities CAPABILITY_NAMED_IAM --region <AWS_REGION>
-```
 
 After the stack finishes creating, retrieve the IAM role ARN from the stack outputs:
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -92,7 +92,7 @@ Deploy the following CloudFormation template to create the role. [Download the t
 
 | Parameter | Description |
 |---|---|
-| `TemporalIamRoleArn` | The ARN of the IAM role or user that the Temporal Service runs as. This is the identity the server uses to call `sts:AssumeRole`. |
+| `TemporalIamRoleArn` | The ARN of the IAM role or user that the Temporal Service runs as. This is the identity the server uses to call `sts:AssumeRole`. To find the ARN, run `aws sts get-caller-identity` in the server's environment. |
 | `AssumeRoleExternalId` | A unique string to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks. Choose any value and pass the same value when creating the Worker Deployment Version. |
 | `LambdaFunctionARNs` | Comma-separated list of Lambda function ARNs that Temporal may invoke. |
 | `RoleName` | Base name for the created IAM role. Defaults to `Temporal-Serverless-Worker`. |
@@ -192,3 +192,19 @@ aws cloudformation describe-stacks --stack-name temporal-serverless-worker --que
 ```
 
 Use this role ARN when creating the Worker Deployment Version.
+
+## Verify the Worker Controller {#verify-worker-controller}
+
+After you complete the [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) and create a Worker Deployment Version with a compute provider, the Temporal Service starts a Worker Controller Instance (WCI) workflow to manage scaling for that version.
+
+To confirm the WCI is running, list workflows with the `TemporalNamespaceDivision` search attribute filter:
+
+```bash
+temporal workflow list --query 'TemporalNamespaceDivision = "TemporalWorkerControllerInstance"'
+```
+
+The WCI workflow is hidden from the default workflow list.
+In the Temporal UI, add the same filter in the Workflows tab to view it.
+
+To verify end-to-end, start a Workflow on the Task Queue configured for the deployment.
+The WCI should detect the task, invoke the Lambda function, and the Workflow should complete.

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -1,0 +1,188 @@
+---
+id: self-hosted-setup
+title: Self-hosted setup for Serverless Workers
+sidebar_label: Self-hosted setup
+description: Configure a self-hosted Temporal Service to use Serverless Workers with AWS Lambda.
+slug: /production-deployment/worker-deployments/serverless-workers/self-hosted-setup
+toc_max_heading_level: 4
+keywords:
+  - serverless
+  - self-hosted
+  - lambda
+  - aws
+  - worker
+  - deployment
+tags:
+  - Workers
+  - Deploy
+  - Serverless
+  - Self-hosted
+---
+
+Temporal Cloud handles Serverless Worker infrastructure automatically.
+Self-hosted Temporal Service operators must enable the feature and configure the server to invoke compute providers.
+
+This page covers the prerequisites for running [Serverless Workers](/serverless-workers) on a self-hosted Temporal Service with AWS Lambda.
+Once setup is complete, follow the [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) to deploy your Worker.
+
+## Enable the Worker Controller {#enable-worker-controller}
+
+The Worker Controller is the server component that monitors Task Queues and invokes compute providers.
+It is disabled by default and must be enabled through [dynamic configuration](/references/dynamic-configuration).
+
+Add the following keys to your dynamic config file:
+
+```yaml
+workercontroller.enabled:
+  - value: true
+
+workercontroller.compute_providers.enabled:
+  - value:
+    - aws-lambda
+
+workercontroller.scaling_algorithms.enabled:
+  - value:
+    - no-sync
+```
+
+To enable the Worker Controller for specific Namespaces instead of globally:
+
+```yaml
+workercontroller.enabled:
+  - value: true
+    constraints:
+      namespace: "your-namespace"
+```
+
+The Temporal Service watches the dynamic config file for changes and applies updates without a restart.
+
+### Worker Controller dynamic config reference {#dynamic-config-reference}
+
+| Key | Scope | Default | Description |
+|---|---|---|---|
+| `workercontroller.enabled` | Namespace | `false` | Enables the Worker Controller for a Namespace. |
+| `workercontroller.compute_providers.enabled` | Global | none | List of enabled compute providers (e.g., `["aws-lambda"]`). |
+| `workercontroller.scaling_algorithms.enabled` | Global | none | List of enabled scaling algorithms (e.g., `["no-sync"]`). |
+| `workercontroller.maxInstances` | Namespace | `100` | Maximum number of Worker Controller instances per Namespace. |
+| `workercontroller.compute_providers.aws.require_role_and_external_id` | Global | `true` | Whether AWS Lambda compute providers require a role ARN and external ID. |
+
+## Configure AWS credentials {#configure-aws-credentials}
+
+The Temporal Service needs AWS credentials to assume an IAM role that invokes Lambda functions.
+How you provide credentials depends on where the Temporal Service runs.
+
+**On AWS infrastructure (EC2, ECS, EKS):** The server uses the attached instance role, task role, or pod role automatically. No additional credential configuration is needed. The attached role must have `sts:AssumeRole` permission for the Lambda invocation role created in the next step.
+
+**Outside AWS:** Configure AWS credentials in the server's environment:
+
+```
+AWS_ACCESS_KEY_ID=<access-key>
+AWS_SECRET_ACCESS_KEY=<secret-key>
+AWS_REGION=<region>
+```
+
+These credentials must belong to an IAM user or role that has `sts:AssumeRole` permission for the Lambda invocation role.
+
+## Create the Lambda invocation role {#create-invocation-role}
+
+Temporal invokes Lambda functions by assuming an IAM role in your AWS account.
+This role needs `lambda:InvokeFunction` permission on your Worker Lambda functions, and a trust policy that allows the Temporal server's identity to assume it.
+
+Deploy the following CloudFormation template to create the role. [Download the template](/files/temporal-self-hosted-serverless-worker-role.yaml).
+
+| Parameter | Description |
+|---|---|
+| `TemporalIamRoleArn` | The ARN of the IAM role or user that the Temporal Service runs as. This is the identity the server uses to call `sts:AssumeRole`. |
+| `AssumeRoleExternalId` | A unique string to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks. Choose any value and pass the same value when creating the Worker Deployment Version. |
+| `LambdaFunctionARNs` | Comma-separated list of Lambda function ARNs that Temporal may invoke. |
+| `RoleName` | Base name for the created IAM role. Defaults to `Temporal-Serverless-Worker`. |
+
+<details>
+<summary>CloudFormation template</summary>
+
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Creates an IAM role that a self-hosted Temporal Service can assume to invoke Lambda functions for Serverless Workers.
+
+Parameters:
+  TemporalIamRoleArn:
+    Type: String
+    Description: The ARN of the IAM role or user that the Temporal Service runs as.
+
+  AssumeRoleExternalId:
+    Type: String
+    Description: A unique identifier to prevent confused deputy attacks.
+    AllowedPattern: '[a-zA-Z0-9_+=,.@-]*'
+    MinLength: 5
+    MaxLength: 45
+
+  LambdaFunctionARNs:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma-separated list of Lambda function ARNs to invoke
+      (e.g., arn:aws:lambda:us-west-2:123456789012:function:worker-1,arn:aws:lambda:us-west-2:123456789012:function:worker-2)
+
+  RoleName:
+    Type: String
+    Default: 'Temporal-Serverless-Worker'
+
+Resources:
+  TemporalServerlessWorker:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${RoleName}-${AWS::StackName}'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                [!Ref TemporalIamRoleArn]
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                'sts:ExternalId': [!Ref AssumeRoleExternalId]
+      Description: "The role the Temporal Service uses to invoke Lambda functions for Serverless Workers"
+      MaxSessionDuration: 3600
+
+  TemporalLambdaInvokePermissions:
+    Type: AWS::IAM::Policy
+    DependsOn: TemporalServerlessWorker
+    Properties:
+      PolicyName: 'Temporal-Lambda-Invoke-Permissions'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+              - lambda:GetFunction
+            Resource: !Ref LambdaFunctionARNs
+      Roles:
+        - !Sub '${RoleName}-${AWS::StackName}'
+
+Outputs:
+  RoleARN:
+    Description: The ARN of the IAM role created for the Temporal Service
+    Value: !GetAtt TemporalServerlessWorker.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-RoleARN"
+
+  RoleName:
+    Description: The name of the IAM role
+    Value: !Ref RoleName
+
+  LambdaFunctionARNs:
+    Description: The Lambda function ARNs that can be invoked
+    Value: !Join [", ", !Ref LambdaFunctionARNs]
+```
+
+</details>
+
+Deploy the template:
+
+```bash
+aws cloudformation create-stack --stack-name temporal-serverless-worker --template-body file://temporal-self-hosted-serverless-worker-role.yaml --parameters ParameterKey=TemporalIamRoleArn,ParameterValue=<TEMPORAL_SERVER_ROLE_ARN> ParameterKey=AssumeRoleExternalId,ParameterValue=<EXTERNAL_ID> ParameterKey=LambdaFunctionARNs,ParameterValue='"<LAMBDA_FUNCTION_ARN>"' --capabilities CAPABILITY_NAMED_IAM --region <AWS_REGION>
+```
+
+The stack output `RoleARN` contains the IAM role ARN to use when creating the Worker Deployment Version.

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -19,15 +19,18 @@ tags:
   - Self-hosted
 ---
 
-Temporal Cloud handles Serverless Worker infrastructure automatically.
-Self-hosted Temporal Service operators must enable the feature and configure the server to invoke compute providers.
-
 This page covers the prerequisites for running [Serverless Workers](/serverless-workers) on a self-hosted Temporal Service with AWS Lambda.
 Once setup is complete, follow the [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) to deploy your Worker.
 
+To set up your self-hosted Temporal Service for Serverless Workers:
+
+1. Enable the Worker Controller Instance (WCI) on the server through dynamic configuration.
+2. Provide the server with AWS credentials to assume IAM roles.
+3. Create an IAM role in your AWS account that grants Temporal permission to invoke Lambda functions.
+
 ## Enable the Worker Controller {#enable-worker-controller}
 
-The Worker Controller is the server component that monitors Task Queues and invokes compute providers.
+The Worker Controller Instance (WCI) is the server component that monitors Task Queues and invokes compute providers.
 It is disabled by default and must be enabled through [dynamic configuration](/references/dynamic-configuration).
 
 Add the following keys to your dynamic config file:
@@ -55,16 +58,6 @@ workercontroller.enabled:
 ```
 
 The Temporal Service watches the dynamic config file for changes and applies updates without a restart.
-
-### Worker Controller dynamic config reference {#dynamic-config-reference}
-
-| Key | Scope | Default | Description |
-|---|---|---|---|
-| `workercontroller.enabled` | Namespace | `false` | Enables the Worker Controller for a Namespace. |
-| `workercontroller.compute_providers.enabled` | Global | none | List of enabled compute providers (e.g., `["aws-lambda"]`). |
-| `workercontroller.scaling_algorithms.enabled` | Global | none | List of enabled scaling algorithms (e.g., `["no-sync"]`). |
-| `workercontroller.maxInstances` | Namespace | `100` | Maximum number of Worker Controller instances per Namespace. |
-| `workercontroller.compute_providers.aws.require_role_and_external_id` | Global | `true` | Whether AWS Lambda compute providers require a role ARN and external ID. |
 
 ## Configure AWS credentials {#configure-aws-credentials}
 
@@ -193,18 +186,6 @@ aws cloudformation describe-stacks --stack-name temporal-serverless-worker --que
 
 Use this role ARN when creating the Worker Deployment Version.
 
-## Verify the Worker Controller {#verify-worker-controller}
+## Next steps {#next-steps}
 
-After you complete the [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) and create a Worker Deployment Version with a compute provider, the Temporal Service starts a Worker Controller Instance (WCI) workflow to manage scaling for that version.
-
-To confirm the WCI is running, list workflows with the `TemporalNamespaceDivision` search attribute filter:
-
-```bash
-temporal workflow list --query 'TemporalNamespaceDivision = "TemporalWorkerControllerInstance"'
-```
-
-The WCI workflow is hidden from the default workflow list.
-In the Temporal UI, add the same filter in the Workflows tab to view it.
-
-To verify end-to-end, start a Workflow on the Task Queue configured for the deployment.
-The WCI should detect the task, invoke the Lambda function, and the Workflow should complete.
+Follow the [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) to write your Worker code, deploy it to Lambda, and create a Worker Deployment Version with the IAM role from the previous step.

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -22,18 +22,25 @@ tags:
 This page covers the prerequisites for running [Serverless Workers](/serverless-workers) on a self-hosted Temporal
 Service with AWS Lambda:
 
-1. Enable the Worker Controller Instance (WCI) on the server through dynamic configuration.
-2. Provide the server with AWS credentials to assume IAM roles.
-3. Create an IAM role in your AWS account that grants Temporal permission to invoke Lambda functions.
+1. Ensure Lambda can reach the Temporal Service.
+2. Enable the Worker Controller Instance (WCI) on the server through dynamic configuration.
+3. Provide the server with AWS credentials to assume IAM roles.
+4. Create an IAM role in your AWS account that grants Temporal permission to invoke Lambda functions.
 
 Once setup is complete, follow the
 [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) to deploy your
 Worker.
 
+## Ensure Lambda can reach the Temporal Service {#ensure-network-reachability}
+
+The [Temporal Service frontend](/temporal-service#frontend-service) must be reachable from the Lambda execution environment.
+How to achieve this depends on your network setup.
+If the Temporal Service runs on a private network, you may need [VPC access for Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html), VPC peering, or a similar mechanism to allow the Lambda function to connect to the Temporal frontend.
+
 ## Enable the Worker Controller {#enable-worker-controller}
 
-The Worker Controller Instance (WCI) is the server component that monitors Task Queues and invokes compute providers. It
-is disabled by default and must be enabled through [dynamic configuration](/references/dynamic-configuration).
+[WCI](/serverless-workers#how-invocation-works) is the server component that monitors Task Queues and invokes compute providers. It is disabled by default and must
+be enabled through [dynamic configuration](/references/dynamic-configuration).
 
 Add the following keys to your dynamic config file:
 
@@ -50,7 +57,8 @@ workercontroller.scaling_algorithms.enabled:
       - no-sync
 ```
 
-To enable the Worker Controller for specific Namespaces instead of globally:
+To enable the Worker Controller for specific Namespaces instead of globally, add a `constraints` section with the
+Namespace name under `workercontroller.enabled`. For example, to enable WCI only for `your-namespace`:
 
 ```yaml
 workercontroller.enabled:
@@ -70,7 +78,8 @@ credentials depends on where the Temporal Service runs.
 automatically. No additional credential configuration is needed. The attached role must have `sts:AssumeRole` permission
 for the Lambda invocation role created in the next step.
 
-**Outside AWS:** Use [IAM Roles Anywhere](https://aws.amazon.com/iam/roles-anywhere/), or configure static AWS credentials in the server's environment (not recommended):
+**Outside AWS:** Use [IAM Roles Anywhere](https://aws.amazon.com/iam/roles-anywhere/), or configure static AWS
+credentials in the server's environment (not recommended):
 
 ```
 AWS_ACCESS_KEY_ID=<access-key>
@@ -83,8 +92,9 @@ role.
 
 ## Create the Lambda invocation role {#create-invocation-role}
 
-Temporal invokes Lambda functions by assuming an IAM role in your AWS account. This role needs `lambda:GetFunction` and `lambda:InvokeFunction`
-permission on your Worker Lambda functions, and a trust policy that allows the Temporal server's identity to assume it.
+Temporal invokes Lambda functions by assuming an IAM role in your AWS account. This role needs `lambda:GetFunction` and
+`lambda:InvokeFunction` permission on your Worker Lambda functions, and a trust policy that allows the Temporal server's
+identity to assume it.
 
 Deploy the following CloudFormation template to create the role.
 [Download the template](/files/temporal-self-hosted-serverless-worker-role.yaml).

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -70,7 +70,7 @@ credentials depends on where the Temporal Service runs.
 automatically. No additional credential configuration is needed. The attached role must have `sts:AssumeRole` permission
 for the Lambda invocation role created in the next step.
 
-**Outside AWS:** Configure AWS credentials in the server's environment:
+**Outside AWS:** Use [IAM Roles Anywhere](https://aws.amazon.com/iam/roles-anywhere/), or configure static AWS credentials in the server's environment (not recommended):
 
 ```
 AWS_ACCESS_KEY_ID=<access-key>
@@ -83,7 +83,7 @@ role.
 
 ## Create the Lambda invocation role {#create-invocation-role}
 
-Temporal invokes Lambda functions by assuming an IAM role in your AWS account. This role needs `lambda:InvokeFunction`
+Temporal invokes Lambda functions by assuming an IAM role in your AWS account. This role needs `lambda:GetFunction` and `lambda:InvokeFunction`
 permission on your Worker Lambda functions, and a trust policy that allows the Temporal server's identity to assume it.
 
 Deploy the following CloudFormation template to create the role.

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -19,19 +19,21 @@ tags:
   - Self-hosted
 ---
 
-This page covers the prerequisites for running [Serverless Workers](/serverless-workers) on a self-hosted Temporal Service with AWS Lambda.
-Once setup is complete, follow the [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) to deploy your Worker.
-
-To set up your self-hosted Temporal Service for Serverless Workers:
+This page covers the prerequisites for running [Serverless Workers](/serverless-workers) on a self-hosted Temporal
+Service with AWS Lambda:
 
 1. Enable the Worker Controller Instance (WCI) on the server through dynamic configuration.
 2. Provide the server with AWS credentials to assume IAM roles.
 3. Create an IAM role in your AWS account that grants Temporal permission to invoke Lambda functions.
 
+Once setup is complete, follow the
+[AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) to deploy your
+Worker.
+
 ## Enable the Worker Controller {#enable-worker-controller}
 
-The Worker Controller Instance (WCI) is the server component that monitors Task Queues and invokes compute providers.
-It is disabled by default and must be enabled through [dynamic configuration](/references/dynamic-configuration).
+The Worker Controller Instance (WCI) is the server component that monitors Task Queues and invokes compute providers. It
+is disabled by default and must be enabled through [dynamic configuration](/references/dynamic-configuration).
 
 Add the following keys to your dynamic config file:
 
@@ -41,11 +43,11 @@ workercontroller.enabled:
 
 workercontroller.compute_providers.enabled:
   - value:
-    - aws-lambda
+      - aws-lambda
 
 workercontroller.scaling_algorithms.enabled:
   - value:
-    - no-sync
+      - no-sync
 ```
 
 To enable the Worker Controller for specific Namespaces instead of globally:
@@ -54,17 +56,19 @@ To enable the Worker Controller for specific Namespaces instead of globally:
 workercontroller.enabled:
   - value: true
     constraints:
-      namespace: "your-namespace"
+      namespace: 'your-namespace'
 ```
 
 The Temporal Service watches the dynamic config file for changes and applies updates without a restart.
 
 ## Configure AWS credentials {#configure-aws-credentials}
 
-The Temporal Service needs AWS credentials to assume an IAM role that invokes Lambda functions.
-How you provide credentials depends on where the Temporal Service runs.
+The Temporal Service needs AWS credentials to assume an IAM role that invokes Lambda functions. How you provide
+credentials depends on where the Temporal Service runs.
 
-**On AWS infrastructure (EC2, ECS, EKS):** The server uses the attached instance role, task role, or pod role automatically. No additional credential configuration is needed. The attached role must have `sts:AssumeRole` permission for the Lambda invocation role created in the next step.
+**On AWS infrastructure (EC2, ECS, EKS):** The server uses the attached instance role, task role, or pod role
+automatically. No additional credential configuration is needed. The attached role must have `sts:AssumeRole` permission
+for the Lambda invocation role created in the next step.
 
 **Outside AWS:** Configure AWS credentials in the server's environment:
 
@@ -74,28 +78,31 @@ AWS_SECRET_ACCESS_KEY=<secret-key>
 AWS_REGION=<region>
 ```
 
-These credentials must belong to an IAM user or role that has `sts:AssumeRole` permission for the Lambda invocation role.
+These credentials must belong to an IAM user or role that has `sts:AssumeRole` permission for the Lambda invocation
+role.
 
 ## Create the Lambda invocation role {#create-invocation-role}
 
-Temporal invokes Lambda functions by assuming an IAM role in your AWS account.
-This role needs `lambda:InvokeFunction` permission on your Worker Lambda functions, and a trust policy that allows the Temporal server's identity to assume it.
+Temporal invokes Lambda functions by assuming an IAM role in your AWS account. This role needs `lambda:InvokeFunction`
+permission on your Worker Lambda functions, and a trust policy that allows the Temporal server's identity to assume it.
 
-Deploy the following CloudFormation template to create the role. [Download the template](/files/temporal-self-hosted-serverless-worker-role.yaml).
+Deploy the following CloudFormation template to create the role.
+[Download the template](/files/temporal-self-hosted-serverless-worker-role.yaml).
 
-| Parameter | Description |
-|---|---|
-| `TemporalIamRoleArn` | The ARN of the IAM role or user that the Temporal Service runs as. This is the identity the server uses to call `sts:AssumeRole`. To find the ARN, run `aws sts get-caller-identity` in the server's environment. |
+| Parameter              | Description                                                                                                                                                                                                        |
+| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `TemporalIamRoleArn`   | The ARN of the IAM role or user that the Temporal Service runs as. This is the identity the server uses to call `sts:AssumeRole`. To find the ARN, run `aws sts get-caller-identity` in the server's environment.  |
 | `AssumeRoleExternalId` | A unique string to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks. Choose any value and pass the same value when creating the Worker Deployment Version. |
-| `LambdaFunctionARNs` | Comma-separated list of Lambda function ARNs that Temporal may invoke. |
-| `RoleName` | Base name for the created IAM role. Defaults to `Temporal-Serverless-Worker`. |
+| `LambdaFunctionARNs`   | Comma-separated list of Lambda function ARNs that Temporal may invoke.                                                                                                                                             |
+| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Serverless-Worker`.                                                                                                                                      |
 
 <details>
 <summary>CloudFormation template</summary>
 
 ```yaml
 AWSTemplateFormatVersion: '2010-09-09'
-Description: Creates an IAM role that a self-hosted Temporal Service can assume to invoke Lambda functions for Serverless Workers.
+Description:
+  Creates an IAM role that a self-hosted Temporal Service can assume to invoke Lambda functions for Serverless Workers.
 
 Parameters:
   TemporalIamRoleArn:
@@ -112,8 +119,8 @@ Parameters:
   LambdaFunctionARNs:
     Type: CommaDelimitedList
     Description: >-
-      Comma-separated list of Lambda function ARNs to invoke
-      (e.g., arn:aws:lambda:us-west-2:123456789012:function:worker-1,arn:aws:lambda:us-west-2:123456789012:function:worker-2)
+      Comma-separated list of Lambda function ARNs to invoke (e.g.,
+      arn:aws:lambda:us-west-2:123456789012:function:worker-1,arn:aws:lambda:us-west-2:123456789012:function:worker-2)
 
   RoleName:
     Type: String
@@ -129,13 +136,12 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS:
-                [!Ref TemporalIamRoleArn]
+              AWS: [!Ref TemporalIamRoleArn]
             Action: sts:AssumeRole
             Condition:
               StringEquals:
                 'sts:ExternalId': [!Ref AssumeRoleExternalId]
-      Description: "The role the Temporal Service uses to invoke Lambda functions for Serverless Workers"
+      Description: 'The role the Temporal Service uses to invoke Lambda functions for Serverless Workers'
       MaxSessionDuration: 3600
 
   TemporalLambdaInvokePermissions:
@@ -159,7 +165,7 @@ Outputs:
     Description: The ARN of the IAM role created for the Temporal Service
     Value: !GetAtt TemporalServerlessWorker.Arn
     Export:
-      Name: !Sub "${AWS::StackName}-RoleARN"
+      Name: !Sub '${AWS::StackName}-RoleARN'
 
   RoleName:
     Description: The name of the IAM role
@@ -167,7 +173,7 @@ Outputs:
 
   LambdaFunctionARNs:
     Description: The Lambda function ARNs that can be invoked
-    Value: !Join [", ", !Ref LambdaFunctionARNs]
+    Value: !Join [', ', !Ref LambdaFunctionARNs]
 ```
 
 </details>
@@ -188,4 +194,6 @@ Use this role ARN when creating the Worker Deployment Version.
 
 ## Next steps {#next-steps}
 
-Follow the [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) to write your Worker code, deploy it to Lambda, and create a Worker Deployment Version with the IAM role from the previous step.
+Follow the [AWS Lambda deployment guide](/production-deployment/worker-deployments/serverless-workers/aws-lambda) to
+write your Worker code, deploy it to Lambda, and create a Worker Deployment Version with the IAM role from the previous
+step.

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -38,7 +38,7 @@ environment. How to achieve this depends on your network setup. If the Temporal 
 may need [VPC access for Lambda](https://docs.aws.amazon.com/lambda/latest/dg/configuration-vpc.html), VPC peering, or a
 similar mechanism to allow the Lambda function to connect to the Temporal frontend.
 
-## Enable the Worker Controller {#enable-worker-controller}
+## Enable the Worker Controller Instance {#enable-worker-controller}
 
 [WCI](/serverless-workers#how-invocation-works) is the server component that monitors Task Queues and invokes compute
 providers. It is disabled by default and must be enabled through
@@ -59,7 +59,7 @@ workercontroller.scaling_algorithms.enabled:
       - no-sync
 ```
 
-To enable the Worker Controller for specific Namespaces instead of globally, add a `constraints` section with the
+To enable WCI for specific Namespaces instead of globally, add a `constraints` section with the
 Namespace name under `workercontroller.enabled`. For example, to enable WCI only for `your-namespace`:
 
 ```yaml

--- a/sidebars.js
+++ b/sidebars.js
@@ -1219,6 +1219,7 @@ module.exports = {
               },
               items: [
                 'production-deployment/worker-deployments/serverless-workers/aws-lambda',
+                'production-deployment/worker-deployments/serverless-workers/self-hosted-setup',
               ],
             },
           ],

--- a/static/files/temporal-self-hosted-serverless-worker-role.yaml
+++ b/static/files/temporal-self-hosted-serverless-worker-role.yaml
@@ -1,0 +1,74 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Creates an IAM role that a self-hosted Temporal Service can assume to invoke Lambda functions for Serverless Workers.
+
+Parameters:
+  TemporalIamRoleArn:
+    Type: String
+    Description: The ARN of the IAM role or user that the Temporal Service runs as.
+
+  AssumeRoleExternalId:
+    Type: String
+    Description: A unique identifier to prevent confused deputy attacks.
+    AllowedPattern: '[a-zA-Z0-9_+=,.@-]*'
+    MinLength: 5
+    MaxLength: 45
+
+  LambdaFunctionARNs:
+    Type: CommaDelimitedList
+    Description: >-
+      Comma-separated list of Lambda function ARNs to invoke
+      (e.g., arn:aws:lambda:us-west-2:123456789012:function:worker-1,arn:aws:lambda:us-west-2:123456789012:function:worker-2)
+
+  RoleName:
+    Type: String
+    Default: 'Temporal-Serverless-Worker'
+
+Resources:
+  TemporalServerlessWorker:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub '${RoleName}-${AWS::StackName}'
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS:
+                [!Ref TemporalIamRoleArn]
+            Action: sts:AssumeRole
+            Condition:
+              StringEquals:
+                'sts:ExternalId': [!Ref AssumeRoleExternalId]
+      Description: "The role the Temporal Service uses to invoke Lambda functions for Serverless Workers"
+      MaxSessionDuration: 3600
+
+  TemporalLambdaInvokePermissions:
+    Type: AWS::IAM::Policy
+    DependsOn: TemporalServerlessWorker
+    Properties:
+      PolicyName: 'Temporal-Lambda-Invoke-Permissions'
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+              - lambda:GetFunction
+            Resource: !Ref LambdaFunctionARNs
+      Roles:
+        - !Sub '${RoleName}-${AWS::StackName}'
+
+Outputs:
+  RoleARN:
+    Description: The ARN of the IAM role created for the Temporal Service
+    Value: !GetAtt TemporalServerlessWorker.Arn
+    Export:
+      Name: !Sub "${AWS::StackName}-RoleARN"
+
+  RoleName:
+    Description: The name of the IAM role
+    Value: !Ref RoleName
+
+  LambdaFunctionARNs:
+    Description: The Lambda function ARNs that can be invoked
+    Value: !Join [", ", !Ref LambdaFunctionARNs]


### PR DESCRIPTION
## Summary
- Adds a self-hosted setup page covering prerequisites for running Serverless Workers on a self-hosted Temporal Service with AWS Lambda
- Covers enabling the Worker Controller via dynamic config, configuring AWS credentials, and creating the Lambda invocation role
- Includes a CloudFormation template adapted for self-hosted (uses `TemporalIamRoleArn` parameter instead of hardcoded Temporal Cloud accounts)

## Test plan
- [ ] Verify the dynamic config keys match the source code in `temporal-auto-scaled-workers`
- [ ] Review CloudFormation template with Stefan
- [ ] Confirm page renders correctly in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214208882374894">EDU-6254 docs: self-hosted setup for serverless workers</a>
