### PR TITLE
Add Codex install tab to Develop with AI page

### DIFF
--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -48,6 +48,14 @@ command in Cursor's agent chat:
 ```
 
 </TabItem>
+<TabItem value="codex" label="Codex">
+
+Install from the Codex app or CLI:
+
+- **Codex app:** Open the plugins menu, search for **temporal**, then click **+** (or **Add to Codex**).
+- **Codex CLI:** Run `/plugin`, search for **temporal**, and mark it for installation.
+
+</TabItem>
 <TabItem value="npx" label="npx">
 
 This works with Claude Code, Codex, Cline, and other agents.


### PR DESCRIPTION
## Summary
- Adds a **Codex** tab to the Temporal Developer Skill install tabs on `docs/with-ai.mdx`
- Documents both the Codex app plugin menu flow and the Codex CLI `/plugin` flow

## Why
Codex now supports installing the Temporal plugin natively. The existing page only pointed Codex users at the generic npx fallback.

## Checklist
- [x] Follows STYLE.md guidelines
- [x] Matches existing TabItem format in the file
- [x] No new pages, so no sidebars.js update needed
- [x] No broken links

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214247202421712">EDU-6263 Add Codex install tab to Develop with AI page</a>
