### PR TITLE
Document Worker Status UI in worker performance and worker health

### DIFF
--- a/docs/cloud/worker-health.mdx
+++ b/docs/cloud/worker-health.mdx
@@ -39,6 +39,12 @@ This page is a guide to monitoring a Temporal Worker fleet and covers the follow
 - [How to detect misconfigured Workers](#detect-misconfigured-workers)
 - [How to configure Sticky cache](#configure-sticky-cache)
 
+:::tip
+
+You can also inspect Workers and the Workers assigned to a Task Queue directly in the Temporal UI. See [Visualize Workers in the UI](/develop/worker-performance#visualize-workers).
+
+:::
+
 ## Minimal Observations {#minimal-observations}
 
 These alerts should be configured and understood first to gain intelligence into your application health and behaviors.

--- a/docs/develop/worker-performance.mdx
+++ b/docs/develop/worker-performance.mdx
@@ -178,7 +178,7 @@ To recover from errors, Eager Workflow Start falls back to the non-eager path. F
 
 ## Visualize Workers in the UI {#visualize-workers}
 
-The Temporal SDK includes a heartbeat for Worker processes that is sent to the Server every 60 seconds, carrying information such as available task slots, CPU usage, and Worker configuration.
+The Temporal SDK includes a heartbeat for Worker processes that is sent to the Server every 60 seconds by default, carrying information such as available task slots, CPU usage, and Worker configuration.
 The Server exposes this data through APIs that surface Worker details in the Temporal UI.
 Use the UI to view the list of Workers assigned to a Task Queue and inspect Worker details to troubleshoot Workflows with delayed processing.
 

--- a/docs/develop/worker-performance.mdx
+++ b/docs/develop/worker-performance.mdx
@@ -176,6 +176,15 @@ The above figure shows Eager Workflow Start in action:
 
 To recover from errors, Eager Workflow Start falls back to the non-eager path. For example, when the first Task is returned eagerly, but the local Worker fails or times out while processing the task, the server retries this task non-eagerly after WorkflowTaskTimeout.
 
+## Visualize Workers in the UI {#visualize-workers}
+
+The Temporal SDK includes a heartbeat for Worker processes that is sent to the Server every 60 seconds, carrying information such as available task slots, CPU usage, and Worker configuration.
+The Server exposes this data through APIs that surface Worker details in the Temporal UI.
+Use the UI to view the list of Workers assigned to a Task Queue and inspect Worker details to troubleshoot Workflows with delayed processing.
+
+This feature requires Temporal Server 1.30 or higher with API version 1.62 or higher, and is also available in Temporal Cloud.
+Worker Heartbeating is required; see [Manage Worker Heartbeating](/cloud/worker-health#manage-worker-heartbeating) for the minimum SDK versions.
+
 ## Performance metrics for tuning {#metrics}
 
 The Temporal SDKs emit metrics from Temporal Client usage and Worker Processes.

--- a/docs/develop/worker-performance.mdx
+++ b/docs/develop/worker-performance.mdx
@@ -178,9 +178,9 @@ To recover from errors, Eager Workflow Start falls back to the non-eager path. F
 
 ## Visualize Workers in the UI {#visualize-workers}
 
-The Temporal SDK includes a heartbeat for Worker processes that is sent to the Server every 60 seconds by default, carrying information such as available task slots, CPU usage, and Worker configuration.
-The Server exposes this data through APIs that surface Worker details in the Temporal UI.
-Use the UI to view the list of Workers assigned to a Task Queue and inspect Worker details to troubleshoot Workflows with delayed processing.
+The Temporal SDK includes a heartbeat for Worker processes that is sent to the Server, carrying information such as available task slots, CPU usage, and Worker configuration.
+The Server exposes this data through APIs that surface Worker details in the Temporal UI. See a list of all running Workers by selecting Workers in the left navigation menu.
+View the list of Workers assigned to the Workflow Task Queue and inspect Worker details to troubleshoot Workflows with delayed processing by selecting the Workers tab in the Workflow details page.
 
 This feature requires Temporal Server 1.30 or higher with API version 1.62 or higher, and is also available in Temporal Cloud.
 Worker Heartbeating is required; see [Manage Worker Heartbeating](/cloud/worker-health#manage-worker-heartbeating) for the minimum SDK versions.


### PR DESCRIPTION
## Summary

Documents the Worker Status UI feature, which surfaces Worker details (task slots, CPU usage, configuration) and the Workers assigned to a Task Queue in the Temporal UI.

- **`docs/develop/worker-performance.mdx`** — adds a new section, "Visualize Workers in the UI," after the "Worker performance concepts" section. Describes how the SDK heartbeat feeds Server APIs that the UI consumes, calls out version requirements (Server 1.30+, API 1.62+), notes Cloud availability, and links to Manage Worker Heartbeating for minimum SDK versions.
- **`docs/cloud/worker-health.mdx`** — adds a brief tip near the top pointing to the new section in worker-performance.

## Why

There is no current docs coverage for visualizing Workers in the UI. This gives PMs, SAs, and customers a single place to point users when they ask how to see Workers and Workers-per-Task-Queue in the UI for troubleshooting delayed Workflow processing.

## Checklist
- [x] Follows STYLE.md (sentence-case, infinitive-form heading)
- [x] No new pages, so no sidebars.js change
- [x] Internal link uses slug-based path
- [x] Cross-links between Cloud and Develop pages

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214383141585556">EDU-6275 Document Worker Status UI in worker performance and worker health</a>
