### PR TITLE
docs: clarify Task definitions on /tasks page

### DIFF
--- a/docs/encyclopedia/workers/tasks.mdx
+++ b/docs/encyclopedia/workers/tasks.mdx
@@ -32,8 +32,9 @@ This page discusses the following:
 
 ## What is a Task? {#task}
 
-A Task is the context that a Worker needs to progress with a specific [Workflow Execution](/workflow-execution),
-[Activity Execution](/activity-execution), or a [Nexus Task Execution](#nexus-task-execution).
+A Task is a unit of work for [Workers](/workers). The Temporal Service places Tasks on [Task Queues](/task-queue), and
+Workers poll for and process them to advance [Workflows](/workflows), run [Activity](/activities) attempts, or handle
+[Nexus](/nexus) requests.
 
 There are three types of Tasks:
 
@@ -43,7 +44,7 @@ There are three types of Tasks:
 
 ## What is a Workflow Task? {#workflow-task}
 
-A Workflow Task is a Task that contains the context needed to make progress with a Workflow Execution.
+A Workflow Task advances a [Workflow Execution](/workflow-execution) by one step.
 
 ### When are Workflow Tasks scheduled? {#when-workflow-tasks-scheduled}
 
@@ -125,11 +126,7 @@ uncaught, and the Workflow closes as Failed. The customer updates payment detail
 
 ## What is an Activity Task? {#activity-task}
 
-An Activity Task contains the context needed to proceed with an [Activity Task Execution](#activity-task-execution).
-Activity Tasks largely represent the Activity Task Scheduled Event, which contains the data needed to execute an
-Activity Function.
-
-If Heartbeat data is being passed, an Activity Task will also contain the latest Heartbeat details.
+An Activity Task runs one attempt of an [Activity](/activities).
 
 ### What is an Activity Task Execution? {#activity-task-execution}
 
@@ -149,6 +146,10 @@ corresponds to when the Worker has yielded back to the Temporal Service.
 The API to schedule an Activity Execution provides an "effectively once" experience, even though there may be several
 Activity Task Executions that take place to successfully complete an Activity.
 
+Across retries, an Activity Task can carry forward
+[Heartbeat](/encyclopedia/detecting-activity-failures#activity-heartbeat) payload from the previous attempt, allowing
+long-running Activities to resume from their last checkpoint.
+
 Once an Activity Task finishes execution, the Worker responds to the Temporal Service with a specific Event:
 
 - ActivityTaskCanceled
@@ -159,9 +160,7 @@ Once an Activity Task finishes execution, the Worker responds to the Temporal Se
 
 ## What is a Nexus Task? {#nexus-task}
 
-A Nexus Task represents a single Nexus request to start or cancel a Nexus Operation. The Nexus Task includes details
-such as the Nexus Service and Nexus Operation names, and other information required to process the Nexus request. The
-Temporal Worker triggers the registered Operation handler based on the Nexus task information.
+A Nexus Task handles one Nexus request to start or cancel a [Nexus Operation](/nexus).
 
 ### What is a Nexus Task Execution? {#nexus-task-execution}
 

--- a/docs/encyclopedia/workers/tasks.mdx
+++ b/docs/encyclopedia/workers/tasks.mdx
@@ -160,7 +160,7 @@ Once an Activity Task finishes execution, the Worker responds to the Temporal Se
 
 ## What is a Nexus Task? {#nexus-task}
 
-A Nexus Task handles one Nexus request to start or cancel a [Nexus Operation](/nexus).
+A Nexus Task delivers one Nexus request to start or cancel a [Nexus Operation](/nexus).
 
 ### What is a Nexus Task Execution? {#nexus-task-execution}
 


### PR DESCRIPTION
## Summary

Rewrites the four `/tasks` definitions to be active and concrete:

- **Task**: a unit of work for Workers
- **Workflow Task**: advances a Workflow Execution by one step
- **Activity Task**: runs one attempt of an Activity
- **Nexus Task**: handles one Nexus request to start or cancel a Nexus Operation

Adds a Heartbeat cross-link in the Activity Task Execution subsection.

**On the cut Task contents:** Task field details (Service/Operation names, Heartbeat field, Activity Task Scheduled Event reference) intentionally cut: no SDK (Go, Java, Python, TS, .NET, PHP, Ruby) exposes raw Task objects to user code — Tasks live behind handler registration; metadata is accessed via helper APIs.

## Test plan

- [x] Internal link targets exist: `/workers`, `/task-queue`, `/workflows`, `/activities`, `/nexus`, `/workflow-execution`, `/encyclopedia/detecting-activity-failures#activity-heartbeat` (verified via grep against current `main`)
🤖 Generated with [Claude Code](https://claude.com/claude-code)