### PR TITLE
Document Fairness enabling or disabling with active backlogs

### DIFF
--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -601,7 +601,7 @@ var handle = await Client.StartWorkflowAsync(
 </SdkTabs.DotNet>
 </SdkTabs>
 
-### Switching Fairness with an active backlog
+### Enabling or disabling Fairness with an active backlog
 
 When Fairness is enabled on a Namespace, Task Queues in the Namespace begin honoring fairness keys on Tasks for dispatch ordering. Existing queued Tasks are dispatched first, in their original priority + FIFO order. Fairness keys on Tasks already in the backlog do not retroactively affect their dispatch order.
 

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -601,6 +601,14 @@ var handle = await Client.StartWorkflowAsync(
 </SdkTabs.DotNet>
 </SdkTabs>
 
+### Switching Fairness with an active backlog
+
+When Fairness is enabled on a Namespace, Task Queues in the Namespace begin honoring fairness keys on Tasks for dispatch ordering. Existing queued Tasks are dispatched first, in their original priority + FIFO order. Fairness keys on Tasks already in the backlog do not retroactively affect their dispatch order.
+
+When Fairness is disabled on a Namespace, Task Queues in the Namespace stop honoring fairness keys for dispatch ordering. The existing fairness-ordered backlog is dispatched first, in its original fairness order. After the backlog drains, Task Queues run in priority-only mode.
+
+In both directions, the existing backlog is dispatched before any new Tasks queued under the new mode. New Tasks dispatch only after the backlog fully drains. Tasks are not lost in either transition.
+
 ### Set rate limits at the Task Queue level
 
 When you're starting to scale your Temporal Services, you may decide to set [Requests Per Second (RPS)](/references/dynamic-configuration#service-level-rps-limits) limits to test your workload or experiment with provisioning benchmarks. You can set the RPS limit at the Task Queue level with `queue-rps-limit` in the CLI.

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -605,7 +605,7 @@ var handle = await Client.StartWorkflowAsync(
 
 When Fairness is enabled on a Namespace, Task Queues in the Namespace begin honoring fairness keys on Tasks for dispatch ordering. Existing queued Tasks are dispatched first, in their original priority + FIFO order. Fairness keys on Tasks already in the backlog do not retroactively affect their dispatch order.
 
-When Fairness is disabled on a Namespace, Task Queues in the Namespace stop honoring fairness keys for dispatch ordering. The existing fairness-ordered backlog is dispatched first, in its original fairness order. After the backlog drains, Task Queues run in priority-only mode.
+When Fairness is disabled on a Namespace, Task Queues in the Namespace stop honoring fairness keys for dispatch ordering. The existing fairness-ordered backlog is dispatched first, in its original fairness order. After the backlog drains, Task Queues dispatch in priority + FIFO order.
 
 In both directions, the existing backlog is dispatched before any new Tasks queued under the new mode. New Tasks dispatch only after the backlog fully drains. Tasks are not lost in either transition.
 


### PR DESCRIPTION
Adds a subsection covering what happens to active backlogs when Fairness is enabled or disabled at the Namespace level.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214408300060823">EDU-6286 Document Fairness enable&#x2F;disable transitions with active backlogs</a>
