### PR TITLE
Use present tense for Fairness Action surcharge in actions.mdx

### DIFF
--- a/docs/evaluate/temporal-cloud/actions.mdx
+++ b/docs/evaluate/temporal-cloud/actions.mdx
@@ -210,7 +210,7 @@ choice.
 
 ## Fairness {#fairness}
 
-For each hour a Namespace has the [Fairness](/develop/task-queue-priority-fairness#task-queue-fairness) feature enabled, an additional `0.1` Action will be charged per Action in the Namespace.
+For each hour a Namespace has the [Fairness](/develop/task-queue-priority-fairness#task-queue-fairness) feature enabled, an additional `0.1` Action is charged per Action in the Namespace.
 - Excluded from APS calculations.
 
 | Usage Name | Metric Name | History Event Type |


### PR DESCRIPTION
Fairness is GA in v1.31.0 and billing is live. Updates the Fairness section of `actions.mdx` from "will be charged" to "is charged" to match the present-tense framing already used in `pricing.mdx#fairness-pricing`.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214410886651716">EDU-6294 Use present tense for Fairness Action surcharge in actions.mdx</a>
