### PR TITLE
Document Java Worker Heartbeating

### DIFF
--- a/docs/cloud/worker-health.mdx
+++ b/docs/cloud/worker-health.mdx
@@ -456,6 +456,14 @@ Set the `WorkerHeartbeatInterval` property on [`TemporalRuntimeOptions`](https:/
 Set it to `null` to disable heartbeating.
 
 </SdkTabs.DotNet>
+<SdkTabs.Java>
+
+_Available since Java SDK v1.35.0_
+
+Set the heartbeat interval on [`WorkflowClientOptions.Builder`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/client/WorkflowClientOptions.Builder.html) with `setWorkerHeartbeatInterval(Duration)`.
+Set it to a negative `Duration` to disable heartbeating.
+
+</SdkTabs.Java>
 <SdkTabs.Ruby>
 
 _Available since Ruby SDK v1.1.0_


### PR DESCRIPTION
## Summary

Java SDK v1.35.0 added Worker Heartbeating ([sdk-java#2818](https://github.com/temporalio/sdk-java/pull/2818)). Adds a Java tab to the **Manage Worker Heartbeating** section on `cloud/worker-health` matching the format used for Go, Python, TypeScript, .NET, and Ruby.

## Why

The page already covers heartbeat configuration for every other SDK. Java users had no documentation pointing them at `WorkflowClientOptions.Builder.setWorkerHeartbeatInterval(Duration)` (default 60s, 1-60s range, negative `Duration` disables).

## Checklist
- [x] Follows STYLE.md (matches sibling SDK tabs in the same section)
- [x] Frontmatter unchanged
- [x] Links to Java SDK API docs (javadoc.io)
- [ ] sidebars.js updated (not needed — edit only)
- [x] No broken links

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214449847012852">EDU-6303 Document Java Worker Heartbeating</a>
