### PR TITLE
add rust to quickstarts

### DIFF
--- a/docs/quickstarts.mdx
+++ b/docs/quickstarts.mdx
@@ -22,6 +22,7 @@ Choose your language to get started quickly.
     { href: "/develop/ruby/set-up-local-ruby", title: "Ruby", description: "Install the Ruby SDK and run a Hello World Workflow in Ruby." },
     { href: "/develop/typescript/set-up-your-local-typescript", title: "TypeScript", description: "Install the TypeScript SDK and run a Hello World Workflow in TypeScript." },
     { href: "/develop/dotnet/set-up-your-local-dotnet", title: ".NET", description: "Install the .NET SDK and run a Hello World Workflow in C#." },
+    { href: "/develop/rust/quickstart", title: "Rust", description: "Install the Rust SDK and run a Hello World Workflow in Rust." },
   ]}
 />
 


### PR DESCRIPTION
## What does this PR do?

This PR adds Rust as a button in the main "Quickstarts" section

## Notes to reviewers

Noticed that Rust's quickstart url is "quickstart" vs all other language SDKs use "set-up-your-local-[language]". Opted not to touch the URL to avoid breaking any bookmarks, but i'll change it to match if requested.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214461239702415">EDU-6308 add rust to quickstarts</a>
