### PR TITLE
docs: relax host resource reporting requirement; refresh audit log fields

### DIFF
--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -83,13 +83,7 @@ Instead, explore the [Export](/cloud/export) feature, which does let you send cl
 
 :::info DEPRECATION NOTICE
 
-The following fields are deprecated and are planned for removal on or after April 1 2026. 
-
-- `user_email`.  This field is duplicated by `principal.name` for principals of type `user`. Other principal types do not have associated emails.
-- `level`.  This field is duplicated by `status`.
-- `caller_ip_address`.  This field is replaced by `x_forwarded_for`.
-- `details`.  This field is replaced by `raw_details` that includes request details.
-- `category`.  This field is no longer used.
+The `request_id` field is deprecated and is planned for removal on or after November 1 2026. Use `async_operation_id` instead.
 
 :::
 
@@ -97,20 +91,16 @@ Audit Logs use the following JSON format:
 
 ```json
 {
-  "operation":  // Operation that was performed
-  "principal": // Information about who initiated the operation
-  "details":  // DEPRECATED, see raw_details
-  "raw_details": // details about the request
-  "user_email":  // DEPRECATED, use principal.user where applicable
-  "x_forwarded_for": // the IP address making the call
-  "caller_ip_address": // DEPRECATED, use x_forwarded_for
-  "category":  // DEPRECATED, no longer used
-  "emit_time": // Time the operation was recorded
-  "level": // DEPRECATED, use status
-  "log_id": // Unique ID of the log entry
-  "request_id": // Optional async request id set by the user when sending a request
-  "status": // Status, such as OK or ERROR
-  "version": // Version of the log entry
+  "operation":          // Operation that was performed
+  "principal":          // Information about who initiated the operation
+  "raw_details":        // Details about the request
+  "x_forwarded_for":    // The IP address(es) making the call
+  "emit_time":          // Time the operation was recorded
+  "log_id":             // Unique ID of the log entry
+  "async_operation_id": // Optional async operation id set by the user when sending a request
+  "request_id":         // DEPRECATED, use async_operation_id
+  "status":             // Status, such as OK or ERROR
+  "version":            // Version of the log entry
 }
 ```
 

--- a/docs/cloud/worker-health.mdx
+++ b/docs/cloud/worker-health.mdx
@@ -401,9 +401,14 @@ Set it to a negative value to disable heartbeating.
 
 By default, the Go SDK reports `0` for CPU and memory usage in Worker heartbeats.
 Set `SysInfoProvider` on [`worker.Options`](https://pkg.go.dev/go.temporal.io/sdk/worker#Options) to enable host resource reporting.
-The SDK includes a [gopsutil](https://github.com/shirou/gopsutil)-based implementation via the [sysinfo](https://pkg.go.dev/go.temporal.io/sdk/contrib/sysinfo) library that supports cgroup metrics in containerized Linux environments:
+Host resource reporting is not included in the core SDK module. Add the [sysinfo](https://pkg.go.dev/go.temporal.io/sdk/contrib/sysinfo) contrib package to your imports - it provides a [gopsutil](https://github.com/shirou/gopsutil)-based implementation that supports cgroup metrics in containerized Linux environments:
 
 ```go
+import (
+	"go.temporal.io/sdk/contrib/sysinfo"
+	"go.temporal.io/sdk/worker"
+)
+
 w := worker.New(c, "my-task-queue", worker.Options{
 	SysInfoProvider: sysinfo.SysInfoProvider(),
 })

--- a/docs/cloud/worker-health.mdx
+++ b/docs/cloud/worker-health.mdx
@@ -400,33 +400,12 @@ Set it to a negative value to disable heartbeating.
 #### Enable host resource reporting
 
 By default, the Go SDK reports `0` for CPU and memory usage in Worker heartbeats.
-To enable host resource reporting, provide a `SysInfoProvider` when creating your Worker.
-You must use a resource based tuner to enable host resource reporting.
-
+Set `SysInfoProvider` on [`worker.Options`](https://pkg.go.dev/go.temporal.io/sdk/worker#Options) to enable host resource reporting.
 The SDK includes a [gopsutil](https://github.com/shirou/gopsutil)-based implementation via the [sysinfo](https://pkg.go.dev/go.temporal.io/sdk/contrib/sysinfo) library that supports cgroup metrics in containerized Linux environments:
 
 ```go
-import (
-    "log"
-    
-    "go.temporal.io/sdk/client"
-    "go.temporal.io/sdk/contrib/envconfig"
-    "go.temporal.io/sdk/contrib/sysinfo"
-    "go.temporal.io/sdk/worker"
-)
-
-c, err := client.Dial(envconfig.MustLoadDefaultClientOptions())
-if err != nil {
-	log.Fatalln("Unable to create client", err)
-}
-defer c.Close()
-tuner, err := worker.NewResourceBasedTuner(worker.ResourceBasedTunerOptions{
-	TargetMem:    0.8,
-	TargetCpu:    0.9,
-	InfoSupplier: sysinfo.SysInfoProvider(),
-})
 w := worker.New(c, "my-task-queue", worker.Options{
-	Tuner:                      tuner,
+	SysInfoProvider: sysinfo.SysInfoProvider(),
 })
 ```
 


### PR DESCRIPTION
## Summary

Two unrelated docs updates bundled together:

### `cloud/worker-health` - Host resource reporting
- Drop the requirement that users wire up a resource-based tuner just to get CPU/memory in Worker heartbeats.
- Trim the Go example to a minimal `worker.Options{ SysInfoProvider: ... }` snippet, matching the brevity of the other SDK sections.

Reflects [temporalio/sdk-go#2301](https://github.com/temporalio/sdk-go/pull/2301), which added `SysInfoProvider` as a top-level field on `worker.Options` so heartbeating is no longer coupled to the resource tuner.

### `cloud/audit-logs` - Field cleanup
- Remove the previously deprecated fields (`user_email`, `level`, `caller_ip_address`, `details`, `category`) from the format spec - they were planned for removal April 1 2026.
- Add `async_operation_id` to the format spec, matching the proto.
- Mark `request_id` as deprecated and call out `async_operation_id` as its replacement, with a planned removal target of on or after November 1 2026 to give customers the standard 6-month deprecation window.

Per discussion in [this Slack thread](https://temporaltechnologies.slack.com/archives/C0A83KJVBD5/p1777669067361719?thread_ts=1777569826.918009&cid=C0A83KJVBD5).

## Why

- Worker health: the prior requirement was incidental to the implementation, not a real constraint. Documenting the simpler API removes a needless adoption barrier for heartbeat-based observability.
- Audit logs: the deprecated fields have already been replaced in real payloads, and `async_operation_id` is what the proto uses going forward. `request_id` will follow the standard customer-comms deprecation cycle.

## Checklist
- [x] Follows STYLE.md guidelines
- [x] Frontmatter unchanged
- [x] No new pages added (sidebar untouched)
- [x] No broken links introduced

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214495246306791">EDU-6309 docs: relax host resource reporting requirement; refresh audit log fields</a>
