### PR TITLE
Fix: add missing anyhow dependency to Rust quickstart

### DIFF
--- a/docs/develop/rust/quickstart.mdx
+++ b/docs/develop/rust/quickstart.mdx
@@ -72,6 +72,7 @@ temporalio-macros = "0.4.0"
 temporalio-sdk = "0.4.0"
 temporalio-sdk-core = "0.4.0"
 tokio = { version = "1", features = ["full"] }
+anyhow = "1"
 `}
 </CodeSnippet>
 


### PR DESCRIPTION
## Summary

- The `#[workflow_methods]` macro from `temporalio-macros` generates code that internally requires `anyhow`
- Without `anyhow` listed as an explicit dependency in `Cargo.toml`, `cargo run` fails with: `could not find 'anyhow' in the list of imported crates`
- Adds `anyhow = "1"` to the `Cargo.toml` snippet in the quickstart

## Test plan

- [ ] Follow the quickstart from scratch and confirm `cargo run` succeeds without errors

> **Note:** The root fix would be for `#[workflow_methods]` to re-export `anyhow` internally (via `temporalio_macros::__private::anyhow`) so users don't need to add it explicitly. A separate issue should be filed against `temporalio/sdk-rust`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214556418347712">EDU-6316 Fix: add missing anyhow dependency to Rust quickstart</a>
