### PR TITLE
chore(workflows): clarified explanation of Update behavior across Workflows

### DIFF
--- a/docs/develop/dotnet/workflows/message-passing.mdx
+++ b/docs/develop/dotnet/workflows/message-passing.mdx
@@ -304,7 +304,7 @@ An Update is a synchronous, blocking call that can change Workflow state, contro
 A Client sending an Update must wait until the Server delivers the Update to a Worker.
 Workers must be available and responsive.
 If you need a response as soon as the Server receives the request, use a Signal instead.
-Also note that you can't send Updates to other Workflow Executions.
+You can't send Updates directly from one Workflow to another. If you need to send Updates across Workflows, like to Child Workflows, use an Activity.
 
 - `WorkflowExecutionUpdateAccepted` is added to the Event History when the Worker confirms that the Update passed validation.
 - `WorkflowExecutionUpdateCompleted` is added to the Event History when the Worker confirms that the Update has finished.

--- a/docs/develop/go/workflows/message-passing.mdx
+++ b/docs/develop/go/workflows/message-passing.mdx
@@ -351,7 +351,7 @@ This parameter controls the stage the update must reach before returning a handl
 - If `WaitForStage` is set to `WorkflowUpdateStageCompleted`, the handle is returned after the Update completes.
 - If `WaitForStage` is set to `WorkflowUpdateStageAccepted`, the handle is returned after the Update is accepted (i.e. after the validator has run, if there is a validator).
 
-Also note that you can't send Updates to other Workflow Executions.
+You can't send Updates directly from one Workflow to another. If you need to send Updates across Workflows, like to Child Workflows, use an Activity.
 
 ```go
 ctxWithTimeout, cancel := context.WithTimeout(context.Background(), 15*time.Second)

--- a/docs/develop/java/workflows/message-passing.mdx
+++ b/docs/develop/java/workflows/message-passing.mdx
@@ -343,7 +343,7 @@ An Update is a synchronous, blocking call that can change Workflow state, contro
 A Client sending an Update must wait until the Server delivers the Update to a Worker.
 Workers must be available and responsive.
 If you need a response as soon as the Server receives the request, use a Signal instead.
-Also note that you can't send Updates to other Workflow Executions.
+You can't send Updates directly from one Workflow to another. If you need to send Updates across Workflows, like to Child Workflows, use an Activity.
 
 - `WorkflowExecutionUpdateAccepted` is added to the Event History when the Worker confirms that the Update passed validation.
 - `WorkflowExecutionUpdateCompleted` is added to the Event History when the Worker confirms that the Update has finished.

--- a/docs/develop/python/workflows/message-passing.mdx
+++ b/docs/develop/python/workflows/message-passing.mdx
@@ -274,7 +274,7 @@ An Update is a synchronous, blocking call that can change Workflow state, contro
 A client sending an Update must wait until the Server delivers the Update to a Worker.
 Workers must be available and responsive.
 If you need a response as soon as the Server receives the request, use a Signal instead.
-Also note that you can't send Updates to other Workflow Executions.
+You can't send Updates directly from one Workflow to another. If you need to send Updates across Workflows, like to Child Workflows, use an Activity.
 
 - `WorkflowExecutionUpdateAccepted` is added to the Event History when the Worker confirms that the Update passed validation.
 - `WorkflowExecutionUpdateCompleted` is added to the Event History when the Worker confirms that the Update has finished.

--- a/docs/develop/ruby/workflows/message-passing.mdx
+++ b/docs/develop/ruby/workflows/message-passing.mdx
@@ -277,7 +277,7 @@ An Update is a synchronous, blocking call that can change Workflow state, contro
 A Client sending an Update must wait until the Server delivers the Update to a Worker.
 Workers must be available and responsive.
 If you need a response as soon as the Server receives the request, use a Signal instead.
-Also note that you can't send Updates to other Workflow Executions.
+You can't send Updates directly from one Workflow to another. If you need to send Updates across Workflows, like to Child Workflows, use an Activity.
 
 - `WorkflowExecutionUpdateAccepted` is added to the Event History when the Worker confirms that the Update passed validation.
 - `WorkflowExecutionUpdateCompleted` is added to the Event History when the Worker confirms that the Update has finished.

--- a/docs/develop/rust/workflows/message-passing.mdx
+++ b/docs/develop/rust/workflows/message-passing.mdx
@@ -326,7 +326,7 @@ let wf_handle = client.start_workflow(
 
 An Update is a synchronous, blocking call that can change Workflow state, control its flow, and return a result.
 
-A client sending an Update must wait until the Server delivers the Update to a Worker. Workers must be available and responsive. If you need a response as soon as the Server receives the request, use a Signal instead. Also note that you can't send Updates to other Workflow Executions.
+A client sending an Update must wait until the Server delivers the Update to a Worker. Workers must be available and responsive. If you need a response as soon as the Server receives the request, use a Signal instead. You can't send Updates directly from one Workflow to another. If you need to send Updates across Workflows, like to Child Workflows, use an Activity.
 
 - `WorkflowExecutionUpdateAccepted` is added to the Event History when the Worker confirms that the Update passed validation.
 - `WorkflowExecutionUpdateCompleted` is added to the Event History when the Worker confirms that the Update has finished.

--- a/docs/develop/typescript/workflows/message-passing.mdx
+++ b/docs/develop/typescript/workflows/message-passing.mdx
@@ -313,7 +313,7 @@ An Update is a synchronous, blocking call that can change Workflow state, contro
 A client sending an Update must wait until the Server delivers the Update to a Worker.
 Workers must be available and responsive.
 If you need a response as soon as the Server receives the request, use a Signal instead.
-Also note that you can't send Updates to other Workflow Executions or perform an Update equivalent of Signal-With-Start.
+You can't send Updates directly from one Workflow to another or perform an Update equivalent of Signal-With-Start. If you need to send Updates across Workflows, like to Child Workflows, use an Activity.
 
 - `WorkflowExecutionUpdateAccepted` is added to the Event History when the Worker confirms that the Update passed validation.
 - `WorkflowExecutionUpdateCompleted` is added to the Event History when the Worker confirms that the Update has finished.


### PR DESCRIPTION
## What does this PR do?

During a Replay workshop, a participant flagged that the last sentence _Also note that you can't send Updates to other Workflow Executions_ is confusing

> A Client sending an Update must wait until the Server delivers the Update to a Worker. Workers must be available and responsive. If you need a response as soon as the Server receives the request, use a Signal instead. Also note that you can't send Updates to other Workflow Executions.

It means you can't send update directly from one Workflow to another. This updates the explanation across all of the SDKs.

## Notes to reviewers

Check if the wording is clear and makes sense.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214579692172682">EDU-6320 chore(workflows): clarified explanation of Update behavior across Workflows</a>
