### PR TITLE
fix(rust): fix typo on Rust SDK index page

### DIFF
--- a/docs/develop/rust/index.mdx
+++ b/docs/develop/rust/index.mdx
@@ -61,6 +61,6 @@ Once your local Temporal Service is set up, continue building with the following
 - [Rust API Documentation](https://docs.rs/temporalio-sdk/latest/temporalio_sdk/)
 - [Rust SDK GitHub](https://github.com/temporalio/sdk-core/tree/master/crates/sdk)
 
-### Get Connected with the Temporal TypeScript Community
+### Get Connected with the Temporal Rust Community
 
 - [Temporal Rust Community Slack](https://temporalio.slack.com/archives/C08G723SFNZ/p1773935454727179)


### PR DESCRIPTION
Per the tin. There's a typo: https://docs.temporal.io/develop/rust#get-connected-with-the-temporal-typescript-community

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214661210773223">EDU-6327 fix(rust): fix typo on Rust SDK index page</a>
