### PR TITLE
chore(worker versioning): removed note about public preview

### DIFF
--- a/docs/production-deployment/worker-deployments/worker-versioning.mdx
+++ b/docs/production-deployment/worker-deployments/worker-versioning.mdx
@@ -61,8 +61,6 @@ Watch this Temporal Replay 2025 talk to learn more about Worker Versioning and s
 
 :::note
 
-Worker Versioning is currently available in Public Preview.
-
 Minimum versions:
 
 - Go SDK version [v1.35.0](https://github.com/temporalio/sdk-go/releases/tag/v1.35.0)
@@ -71,7 +69,6 @@ Minimum versions:
 - Typescript [v1.12](https://github.com/temporalio/sdk-typescript/releases/tag/v1.12.0)
 - .NET [v1.7.0](https://github.com/temporalio/sdk-dotnet/releases/tag/1.7.0)
 - Ruby [v0.5.0](https://github.com/temporalio/sdk-ruby/releases/tag/v0.5.0)
-- Other SDKs: coming soon!
 
 Self-hosted users:
 


### PR DESCRIPTION
## What does this PR do?

Worker versioning is in GA so this removes the public preview note.

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214702958834620">EDU-6331 chore(worker versioning): removed note about public preview</a>
