### PR TITLE
docs: clarify serverless availability for cloud

### DIFF
--- a/docs/develop/go/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/develop/go/workers/serverless-workers/aws-lambda.mdx
@@ -22,7 +22,8 @@ tags:
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
-APIs are experimental and may change.
+To request access during Pre-release, create a [support ticket](/cloud/support#support-ticket) or contact your account team.
+APIs are experimental and may be subject to backwards-incompatible changes.
 [Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::

--- a/docs/develop/go/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/develop/go/workers/serverless-workers/aws-lambda.mdx
@@ -21,9 +21,9 @@ tags:
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-APIs are experimental and may be subject to backwards-incompatible changes.
+Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
+APIs are experimental and may change.
+[Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::
 

--- a/docs/develop/python/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/develop/python/workers/serverless-workers/aws-lambda.mdx
@@ -22,7 +22,8 @@ tags:
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
-APIs are experimental and may change.
+To request access during Pre-release, create a [support ticket](/cloud/support#support-ticket) or contact your account team.
+APIs are experimental and may be subject to backwards-incompatible changes.
 [Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::

--- a/docs/develop/python/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/develop/python/workers/serverless-workers/aws-lambda.mdx
@@ -21,9 +21,9 @@ tags:
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-APIs are experimental and may be subject to backwards-incompatible changes.
+Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
+APIs are experimental and may change.
+[Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::
 

--- a/docs/develop/typescript/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/develop/typescript/workers/serverless-workers/aws-lambda.mdx
@@ -22,7 +22,8 @@ tags:
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
-APIs are experimental and may change.
+To request access during Pre-release, create a [support ticket](/cloud/support#support-ticket) or contact your account team.
+APIs are experimental and may be subject to backwards-incompatible changes.
 [Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::

--- a/docs/develop/typescript/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/develop/typescript/workers/serverless-workers/aws-lambda.mdx
@@ -21,9 +21,9 @@ tags:
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-APIs are experimental and may be subject to backwards-incompatible changes.
+Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
+APIs are experimental and may change.
+[Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::
 

--- a/docs/encyclopedia/workers/serverless-workers.mdx
+++ b/docs/encyclopedia/workers/serverless-workers.mdx
@@ -22,7 +22,8 @@ import CaptionedImage from '@site/src/components/images/CaptionedImage';
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
-APIs are experimental and may change.
+To request access during Pre-release, create a [support ticket](/cloud/support#support-ticket) or contact your account team.
+APIs are experimental and may be subject to backwards-incompatible changes.
 [Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::

--- a/docs/encyclopedia/workers/serverless-workers.mdx
+++ b/docs/encyclopedia/workers/serverless-workers.mdx
@@ -21,9 +21,9 @@ import CaptionedImage from '@site/src/components/images/CaptionedImage';
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-APIs are experimental and may be subject to backwards-incompatible changes.
+Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
+APIs are experimental and may change.
+[Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::
 

--- a/docs/evaluate/development-production-features/serverless-workers/demo.mdx
+++ b/docs/evaluate/development-production-features/serverless-workers/demo.mdx
@@ -21,7 +21,8 @@ description: An interactive demo for Temporal Serverless Workers. Explore the co
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
-APIs are experimental and may change.
+To request access during Pre-release, create a [support ticket](/cloud/support#support-ticket) or contact your account team.
+APIs are experimental and may be subject to backwards-incompatible changes.
 [Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::

--- a/docs/evaluate/development-production-features/serverless-workers/demo.mdx
+++ b/docs/evaluate/development-production-features/serverless-workers/demo.mdx
@@ -20,9 +20,9 @@ description: An interactive demo for Temporal Serverless Workers. Explore the co
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-APIs are experimental and may be subject to backwards-incompatible changes.
+Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
+APIs are experimental and may change.
+[Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -27,7 +27,8 @@ This guide walks through deploying a Temporal [Serverless Worker](/serverless-wo
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
-APIs are experimental and may change.
+To request access during Pre-release, create a [support ticket](/cloud/support#support-ticket) or contact your account team.
+APIs are experimental and may be subject to backwards-incompatible changes.
 [Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -26,9 +26,9 @@ This guide walks through deploying a Temporal [Serverless Worker](/serverless-wo
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-APIs are experimental and may be subject to backwards-incompatible changes.
+Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
+APIs are experimental and may change.
+[Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/index.mdx
@@ -21,7 +21,8 @@ tags:
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
-APIs are experimental and may change.
+To request access during Pre-release, create a [support ticket](/cloud/support#support-ticket) or contact your account team.
+APIs are experimental and may be subject to backwards-incompatible changes.
 [Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::

--- a/docs/production-deployment/worker-deployments/serverless-workers/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/index.mdx
@@ -18,6 +18,14 @@ tags:
   - Serverless
 ---
 
+:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
+
+Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
+APIs are experimental and may change.
+[Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
+
+:::
+
 Serverless Workers let you run Temporal Workers on serverless compute like AWS Lambda. Deploy your Worker code to a
 serverless provider, configure a compute provider for the Worker Deployment Version, and Temporal invokes the Worker
 when Tasks arrive. There are no long-lived processes to provision or scale.

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -22,8 +22,7 @@ tags:
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-APIs are experimental and may be subject to backwards-incompatible changes.
+APIs are experimental and may change.
 
 :::
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -22,7 +22,7 @@ tags:
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-APIs are experimental and may change.
+APIs are experimental and may be subject to backwards-incompatible changes.
 
 :::
 

--- a/docs/troubleshooting/serverless-workers.mdx
+++ b/docs/troubleshooting/serverless-workers.mdx
@@ -22,7 +22,8 @@ tags:
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
-APIs are experimental and may change.
+To request access during Pre-release, create a [support ticket](/cloud/support#support-ticket) or contact your account team.
+APIs are experimental and may be subject to backwards-incompatible changes.
 [Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::

--- a/docs/troubleshooting/serverless-workers.mdx
+++ b/docs/troubleshooting/serverless-workers.mdx
@@ -21,9 +21,9 @@ tags:
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
-Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-APIs are experimental and may be subject to backwards-incompatible changes.
+Serverless Workers are in [Pre-release](/evaluate/development-production-features/release-stages#pre-release) and available to select Temporal Cloud customers.
+APIs are experimental and may change.
+[Sign up for updates](https://temporal.io/pages/serverless-workers-updates) to be notified when Serverless Workers reach Public Preview.
 
 :::
 


### PR DESCRIPTION
## What does this PR do?

- Add an availability callout for Serverless prerelease

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214714015772832">EDU-6335 docs: clarify serverless availability for cloud</a>
