### PR TITLE
Rust SDK: fix typo in Activities page title

### DIFF
--- a/docs/develop/rust/activities/index.mdx
+++ b/docs/develop/rust/activities/index.mdx
@@ -1,6 +1,6 @@
 ---
 id: index
-title: Activities - TypeScript SDK
+title: Activities - Rust SDK
 sidebar_label: Activities
 description:
   This section explains how to implement Activities with the Rust SDK


### PR DESCRIPTION
## What does this PR do?

Fixes typo on Rust SDK Activities page where the title incorrectly says TypeScript SDK.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214720207563467">EDU-6336 Rust SDK: fix typo in Activities page title</a>
