### PR TITLE
docs: add Temporal Cloud and 101 course callouts to quickstart pages

### DIFF
--- a/docs/develop/dotnet/set-up.mdx
+++ b/docs/develop/dotnet/set-up.mdx
@@ -327,6 +327,11 @@ If everything is working correctly, you should see:
 
 
 <CallToAction href="https://learn.temporal.io/getting_started/dotnet/first_program_in_dotnet/">
-  <h3>Next: Run your first Temporal Application</h3>
+  <h3>Run your first Temporal Application</h3>
   <p>Create a basic Workflow and run it with the Temporal .NET SDK</p>
+</CallToAction>
+
+<CallToAction href="https://learn.temporal.io/courses/">
+  <h3>Take a Temporal 101 course</h3>
+  <p>Learn Temporal concepts and build your first application with a guided course</p>
 </CallToAction>

--- a/docs/develop/go/set-up.mdx
+++ b/docs/develop/go/set-up.mdx
@@ -335,6 +335,11 @@ If everything is working correctly, you should see:
 - Workflow Execution details in the [Temporal Web UI](http://localhost:8233)
 
 <CallToAction href="https://learn.temporal.io/getting_started/go/first_program_in_go/">
-  <h3>Next: Run your first Temporal Application</h3>
+  <h3>Run your first Temporal Application</h3>
   <p>Create a basic Workflow and run it with the Temporal Go SDK</p>
+</CallToAction>
+
+<CallToAction href="https://learn.temporal.io/courses/">
+  <h3>Take a Temporal 101 course</h3>
+  <p>Learn Temporal concepts and build your first application with a guided course</p>
 </CallToAction>

--- a/docs/develop/java/set-up.mdx
+++ b/docs/develop/java/set-up.mdx
@@ -489,6 +489,11 @@ If everything is working correctly, you should see:
 - Workflow Execution details in the [Temporal Web UI](http://localhost:8233)
 
 <CallToAction href="https://learn.temporal.io/getting_started/java/first_program_in_java/">
-  <h3>Next: Run your first Temporal Application</h3>
+  <h3>Run your first Temporal Application</h3>
   <p>Create a basic Workflow and run it with the Temporal Java SDK</p>
+</CallToAction>
+
+<CallToAction href="https://learn.temporal.io/courses/">
+  <h3>Take a Temporal 101 course</h3>
+  <p>Learn Temporal concepts and build your first application with a guided course</p>
 </CallToAction>

--- a/docs/develop/php/set-up.mdx
+++ b/docs/develop/php/set-up.mdx
@@ -453,6 +453,11 @@ If everything is working correctly, you should see:
 - Workflow Execution details in the [Temporal Web UI](http://localhost:8233)
 
 <CallToAction href="https://learn.temporal.io/getting_started/php/hello_world_in_php/">
-  <h3>Next: Run your first Temporal Application</h3>
+  <h3>Run your first Temporal Application</h3>
   <p>Create a basic Workflow and run it with the Temporal PHP SDK</p>
+</CallToAction>
+
+<CallToAction href="https://learn.temporal.io/courses/">
+  <h3>Take a Temporal 101 course</h3>
+  <p>Learn Temporal concepts and build your first application with a guided course</p>
 </CallToAction>

--- a/docs/develop/python/set-up.mdx
+++ b/docs/develop/python/set-up.mdx
@@ -293,6 +293,11 @@ If everything is working correctly, you should see:
 - Workflow Execution details in the [Temporal Web UI](http://localhost:8233)
 
 <CallToAction href="https://learn.temporal.io/getting_started/python/first_program_in_python/">
-  <h3>Next: Run your first Temporal Application</h3>
+  <h3>Run your first Temporal Application</h3>
   <p>Create a basic Workflow and run it with the Temporal Python SDK</p>
+</CallToAction>
+
+<CallToAction href="https://learn.temporal.io/courses/">
+  <h3>Take a Temporal 101 course</h3>
+  <p>Learn Temporal concepts and build your first application with a guided course</p>
 </CallToAction>

--- a/docs/develop/ruby/set-up.mdx
+++ b/docs/develop/ruby/set-up.mdx
@@ -286,6 +286,11 @@ If everything is working correctly, you should see:
 - Workflow Execution details in the [Temporal Web UI](http://localhost:8233)
 
 <CallToAction href="https://learn.temporal.io/getting_started/ruby/first_program_in_ruby/">
-  <h3>Next: Run your first Temporal Application</h3>
+  <h3>Run your first Temporal Application</h3>
   <p>Create a basic Workflow and run it with the Temporal Ruby SDK</p>
+</CallToAction>
+
+<CallToAction href="https://learn.temporal.io/courses/">
+  <h3>Take a Temporal 101 course</h3>
+  <p>Learn Temporal concepts and build your first application with a guided course</p>
 </CallToAction>

--- a/docs/develop/rust/quickstart.mdx
+++ b/docs/develop/rust/quickstart.mdx
@@ -15,6 +15,7 @@ hide_table_of_contents: true
 ---
 
 import { SetupSteps, SetupStep, CodeSnippet } from '@site/src/components/elements/SetupSteps';
+import { CallToAction } from '@site/src/components/elements/CallToAction';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
@@ -305,3 +306,8 @@ Now that you have the basics working, explore the following resources to build m
 - [Develop an Activity](/develop/rust/activities/basics) - Understand activity patterns and best practices
 - [Worker Processes](/develop/rust/workers/worker-process) - Configure and scale workers
 - [Using the Temporal Client](/develop/rust/client/temporal-client) - Start workflows and interact with the Temporal Service
+
+<CallToAction href="https://learn.temporal.io/courses/">
+  <h3>Take a Temporal 101 course</h3>
+  <p>Learn Temporal concepts and build your first application with a guided course</p>
+</CallToAction>

--- a/docs/develop/typescript/set-up.mdx
+++ b/docs/develop/typescript/set-up.mdx
@@ -328,6 +328,11 @@ If everything is working correctly, you should see:
 </details>
 
 <CallToAction href="https://learn.temporal.io/getting_started/typescript/first_program_in_typescript/">
-  <h3>Next: Run your first Temporal Application</h3>
+  <h3>Run your first Temporal Application</h3>
   <p>Create a basic Workflow and run it with the Temporal TypeScript SDK</p>
+</CallToAction>
+
+<CallToAction href="https://learn.temporal.io/courses/">
+  <h3>Take a Temporal 101 course</h3>
+  <p>Learn Temporal concepts and build your first application with a guided course</p>
 </CallToAction>

--- a/docs/quickstarts.mdx
+++ b/docs/quickstarts.mdx
@@ -11,7 +11,7 @@ import { CallToAction } from "@site/src/components/elements/CallToAction";
 
 # Quickstarts
 
-Choose your language to get started quickly.
+Choose your language to get started locally. If you're using Temporal Cloud, check out [Get started with Temporal Cloud](/cloud/get-started).
 
 <QuickstartCards
   items={[


### PR DESCRIPTION
## What does this PR do?
- Adds a Cloud mention to the quickstarts landing page: "If you're using Temporal Cloud, check out Get started with Temporal Cloud."
- Adds two CTAs at the bottom of each language setup page (Go, Python, TypeScript, Java, .NET, PHP, Ruby, Rust): one linking to the first-program tutorial, one linking to the Temporal 101 courses

Closes [#4464](https://github.com/temporalio/documentation/issues/4464)

## Notes to reviewers


<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214720850225254">EDU-6337 docs: add Temporal Cloud and 101 course callouts to quickstart pages</a>
