### PR TITLE
Clarify Text CSA tokenization behavior and add type selection guidance

### DIFF
--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -57,7 +57,8 @@ There are different options for partial string matching when the type of the Sea
 
 Search Attributes of type `Text` are [broken up into words](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) that match with the `=` operator.
 
-The standard tokenizer splits values on Unicode word boundaries — punctuation characters like `.`, `-`, `/`, `_`, and `:` act as delimiters.
+The standard tokenizer splits values on [Unicode word boundaries](https://unicode.org/reports/tr29/) — punctuation characters like `.`, `-`, `/`, and `:` act as delimiters.
+Underscores do not cause splits (`payment_retry` stays as one token).
 All tokens are lowercased.
 The following table shows how common value shapes are tokenized:
 

--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -56,15 +56,15 @@ There are different options for partial string matching when the type of the Sea
 #### Text
 
 `Text` Search Attributes support word-level search.
-Both stored values and query strings are broken into tokens by the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), and the `=` operator returns a result if any query token matches any indexed token.
+Both stored values and query strings are analyzed by the [Elasticsearch standard analyzer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-analyzer.html), and the `=` operator returns a result if any query token matches any indexed token.
 
 If you need exact matching on identifiers, UUIDs, or other structured strings, use `Keyword` instead.
 See [Choose a string type](/search-attribute#choose-a-string-type).
 
 ##### Tokenization {#text-tokenization}
 
-The standard tokenizer applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) to split values into tokens.
-All tokens are lowercased.
+The standard analyzer applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) to split values into tokens.
+All tokens are lowercased by the analyzer's lowercase filter.
 The splitting behavior depends on the delimiter:
 
 | Delimiter | Splits? | Example |
@@ -74,6 +74,8 @@ The splitting behavior depends on the delimiter:
 | Underscores (`_`) | No | `payment_retry_handler` → one token |
 | Dots between words (`.`) | No | `com.example.workflows.ProcessOrder` → one token |
 | Dots between digits (`.`) | No | `v1.2.3` → one token |
+
+A dot between a digit and a letter (for example, `v1.ProcessOrder`) may split into separate tokens.
 
 ##### Search matching {#text-search-matching}
 

--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -55,13 +55,17 @@ There are different options for partial string matching when the type of the Sea
 
 #### Text
 
-Search Attributes of type `Text` are [broken up into words](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) that match with the `=` operator.
-Two things determine whether a query matches: how values are **tokenized**, and how the search **matches tokens**.
+`Text` Search Attributes support word-level search.
+Both stored values and query strings are broken into tokens by the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), and the `=` operator returns a result if any query token matches any indexed token.
 
-##### Tokenization
+If you need exact matching on identifiers, UUIDs, or other structured strings, use `Keyword` instead.
+See [Choose a string type](/search-attribute#choose-a-string-type).
 
-Both stored values and query strings are broken into tokens by the [standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language.
-The splitting behavior is context-dependent and often surprising for structured identifiers:
+##### Tokenization {#text-tokenization}
+
+The standard tokenizer applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) to split values into tokens.
+All tokens are lowercased.
+The splitting behavior depends on the delimiter:
 
 | Delimiter | Splits? | Example |
 | --- | --- | --- |
@@ -71,12 +75,9 @@ The splitting behavior is context-dependent and often surprising for structured 
 | Dots between words (`.`) | No | `com.example.workflows.ProcessOrder` → one token |
 | Dots between digits (`.`) | No | `v1.2.3` → one token |
 
-All tokens are lowercased.
+##### Search matching {#text-search-matching}
 
-##### Search matching
-
-The `=` operator on `Text` Search Attributes uses **OR matching**: a result is returned if **any** query token matches **any** indexed token.
-This means the query string is tokenized using the same rules, and each resulting token is matched independently.
+The `=` operator on `Text` Search Attributes uses **OR matching**: the query string is tokenized using the same rules as above, and a result is returned if **any** query token matches **any** indexed token.
 
 For example, if you have a custom `Text` Search Attribute named `Description` with either of the following values—
 
@@ -98,17 +99,12 @@ Description = 'foobar'
 Description = 'foo'
 ```
 
-:::caution Text type is unreliable for structured identifiers
+Because the query string is also tokenized, a query like `= "processing-v2"` is split into `processing` and `v2`, matching any workflow that contains **either** token.
+This can return unexpected results when tokens are shared across different values.
 
-The combination of inconsistent tokenization and OR matching makes `Text` unreliable for structured data.
+:::note
 
-**Tokenization is inconsistent:** hyphens split, but underscores and dots between words do not.
-Searching for `= "retry"` matches `payment-retry-v2` (hyphen splits) but not `payment_retry_handler` (underscore does not).
-
-**OR matching causes false positives:** `= "processing-v2"` is tokenized into `processing` and `v2`, then returns any workflow that contains **either** token — matching both `order-processing-v2` and `payment-retry-v2`.
-
-Use the `Keyword` type for reliable exact matching on structured identifiers.
-See [Choose a string type](/search-attribute#choose-a-string-type) for a comparison of string-based Search Attribute types.
+Broader tokenizer and matching improvements for `Text` Search Attributes are being evaluated as part of future Visibility enhancements.
 
 :::
 

--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -60,15 +60,18 @@ Search Attributes of type `Text` are [broken up into words](https://www.elastic.
 The standard tokenizer applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language, not structured identifiers.
 The splitting behavior is context-dependent: hyphens cause splits, but dots and underscores typically do not.
 All tokens are lowercased.
+The query string is also tokenized, and the `=` operator returns a result if **any** query token matches **any** indexed token.
 
 The following table shows how the tokenizer handles common value shapes:
 
 | Stored value | Example query | Matches? | Why |
 | --- | --- | --- | --- |
 | `order-processing-v2` | `= "v2"` | Yes | Hyphens split: tokens are `order`, `processing`, `v2` |
-| `order-processing-v2` | `= "order-processing"` | No | `order-processing` is not a single token |
+| `order-processing-v2` | `= "order-processing-v2"` | Yes | But also matches `payment-retry-v2` because `v2` is a shared token |
 | `payment_retry_handler` | `= "retry"` | No | Underscores do not split: the entire value is one token |
-| `com.example.workflows.ProcessOrder` | `= "example"` | No | Dots between words do not split as expected |
+| `payment_retry_handler` | `= "payment_retry"` | No | Partial underscore-joined strings are not tokens either |
+| `com.example.workflows.ProcessOrder` | `= "example"` | No | Dots between words do not split |
+| `v1.2.3-beta` | `= "v1.2.3"` | Yes | Dot-digit sequences stay together; hyphen splits off `beta` |
 
 For example, if you have a custom `Text` Search Attribute named `Description` with either of the following values—
 
@@ -94,6 +97,7 @@ Description = 'foo'
 
 The standard tokenizer produces unpredictable results for structured data like dotted class names, hyphenated IDs, and snake_case identifiers.
 Some punctuation splits tokens (hyphens), some does not (underscores, dots between words), and mixed-delimiter strings produce especially surprising results.
+Additionally, the `=` operator uses **OR matching** across tokens: `= "order-processing-v2"` matches any workflow that contains `order`, `processing`, **or** `v2` as a token, which can return unexpected results.
 If you store structured identifiers in a Search Attribute, use the `Keyword` type for reliable exact matching.
 See [Choose a string type](/search-attribute#choose-a-string-type) for a comparison of string-based Search Attribute types.
 

--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -57,6 +57,16 @@ There are different options for partial string matching when the type of the Sea
 
 Search Attributes of type `Text` are [broken up into words](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) that match with the `=` operator.
 
+The standard tokenizer splits values on Unicode word boundaries — punctuation characters like `.`, `-`, `/`, `_`, and `:` act as delimiters.
+All tokens are lowercased.
+The following table shows how common value shapes are tokenized:
+
+| Stored value | Tokens produced |
+| --- | --- |
+| `com.example.workflows.payment.ProcessOrder` | `com`, `example`, `workflows`, `payment`, `processorder` |
+| `order-processing-v2` | `order`, `processing`, `v2` |
+| `/app/workflows/payment/retry` | `app`, `workflows`, `payment`, `retry` |
+
 For example, if you have a custom `Text` Search Attribute named `Description` with either of the following values—
 
 ```
@@ -76,6 +86,15 @@ Description = 'foobar'
 // Doesn't match
 Description = 'foo'
 ```
+
+:::caution Queries must match complete tokens
+
+Searches match individual tokens, not substrings that span across token boundaries.
+For example, `= "order-processing"` will not match a stored value of `order-processing-v2` because `order-processing` is not a single token — the tokenizer splits it into `order` and `processing` separately.
+If you need exact matching on structured identifiers, use the `Keyword` type instead.
+See [Choose a string type](/search-attribute#choose-a-string-type) for a comparison of string-based Search Attribute types.
+
+:::
 
 #### Keyword
 

--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -57,16 +57,18 @@ There are different options for partial string matching when the type of the Sea
 
 Search Attributes of type `Text` are [broken up into words](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) that match with the `=` operator.
 
-The standard tokenizer splits values on [Unicode word boundaries](https://unicode.org/reports/tr29/) — punctuation characters like `.`, `-`, `/`, and `:` act as delimiters.
-Underscores do not cause splits (`payment_retry` stays as one token).
+The standard tokenizer applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language, not structured identifiers.
+The splitting behavior is context-dependent: hyphens cause splits, but dots and underscores typically do not.
 All tokens are lowercased.
-The following table shows how common value shapes are tokenized:
 
-| Stored value | Tokens produced |
-| --- | --- |
-| `com.example.workflows.payment.ProcessOrder` | `com`, `example`, `workflows`, `payment`, `processorder` |
-| `order-processing-v2` | `order`, `processing`, `v2` |
-| `/app/workflows/payment/retry` | `app`, `workflows`, `payment`, `retry` |
+The following table shows how the tokenizer handles common value shapes:
+
+| Stored value | Example query | Matches? | Why |
+| --- | --- | --- | --- |
+| `order-processing-v2` | `= "v2"` | Yes | Hyphens split: tokens are `order`, `processing`, `v2` |
+| `order-processing-v2` | `= "order-processing"` | No | `order-processing` is not a single token |
+| `payment_retry_handler` | `= "retry"` | No | Underscores do not split: the entire value is one token |
+| `com.example.workflows.ProcessOrder` | `= "example"` | No | Dots between words do not split as expected |
 
 For example, if you have a custom `Text` Search Attribute named `Description` with either of the following values—
 
@@ -88,11 +90,11 @@ Description = 'foobar'
 Description = 'foo'
 ```
 
-:::caution Queries must match complete tokens
+:::caution Text type is unreliable for structured identifiers
 
-Searches match individual tokens, not substrings that span across token boundaries.
-For example, `= "order-processing"` will not match a stored value of `order-processing-v2` because `order-processing` is not a single token — the tokenizer splits it into `order` and `processing` separately.
-If you need exact matching on structured identifiers, use the `Keyword` type instead.
+The standard tokenizer produces unpredictable results for structured data like dotted class names, hyphenated IDs, and snake_case identifiers.
+Some punctuation splits tokens (hyphens), some does not (underscores, dots between words), and mixed-delimiter strings produce especially surprising results.
+If you store structured identifiers in a Search Attribute, use the `Keyword` type for reliable exact matching.
 See [Choose a string type](/search-attribute#choose-a-string-type) for a comparison of string-based Search Attribute types.
 
 :::

--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -56,22 +56,27 @@ There are different options for partial string matching when the type of the Sea
 #### Text
 
 Search Attributes of type `Text` are [broken up into words](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html) that match with the `=` operator.
+Two things determine whether a query matches: how values are **tokenized**, and how the search **matches tokens**.
 
-The standard tokenizer applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language, not structured identifiers.
-The splitting behavior is context-dependent: hyphens cause splits, but dots and underscores typically do not.
+##### Tokenization
+
+Both stored values and query strings are broken into tokens by the [standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language.
+The splitting behavior is context-dependent and often surprising for structured identifiers:
+
+| Delimiter | Splits? | Example |
+| --- | --- | --- |
+| Hyphens (`-`) | Yes | `order-processing-v2` → `order`, `processing`, `v2` |
+| Whitespace | Yes | `my business id` → `my`, `business`, `id` |
+| Underscores (`_`) | No | `payment_retry_handler` → one token |
+| Dots between words (`.`) | No | `com.example.workflows.ProcessOrder` → one token |
+| Dots between digits (`.`) | No | `v1.2.3` → one token |
+
 All tokens are lowercased.
-The query string is also tokenized, and the `=` operator returns a result if **any** query token matches **any** indexed token.
 
-The following table shows how the tokenizer handles common value shapes:
+##### Search matching
 
-| Stored value | Example query | Matches? | Why |
-| --- | --- | --- | --- |
-| `order-processing-v2` | `= "v2"` | Yes | Hyphens split: tokens are `order`, `processing`, `v2` |
-| `order-processing-v2` | `= "order-processing-v2"` | Yes | But also matches `payment-retry-v2` because `v2` is a shared token |
-| `payment_retry_handler` | `= "retry"` | No | Underscores do not split: the entire value is one token |
-| `payment_retry_handler` | `= "payment_retry"` | No | Partial underscore-joined strings are not tokens either |
-| `com.example.workflows.ProcessOrder` | `= "example"` | No | Dots between words do not split |
-| `v1.2.3-beta` | `= "v1.2.3"` | Yes | Dot-digit sequences stay together; hyphen splits off `beta` |
+The `=` operator on `Text` Search Attributes uses **OR matching**: a result is returned if **any** query token matches **any** indexed token.
+This means the query string is tokenized using the same rules, and each resulting token is matched independently.
 
 For example, if you have a custom `Text` Search Attribute named `Description` with either of the following values—
 
@@ -95,10 +100,14 @@ Description = 'foo'
 
 :::caution Text type is unreliable for structured identifiers
 
-The standard tokenizer produces unpredictable results for structured data like dotted class names, hyphenated IDs, and snake_case identifiers.
-Some punctuation splits tokens (hyphens), some does not (underscores, dots between words), and mixed-delimiter strings produce especially surprising results.
-Additionally, the `=` operator uses **OR matching** across tokens: `= "order-processing-v2"` matches any workflow that contains `order`, `processing`, **or** `v2` as a token, which can return unexpected results.
-If you store structured identifiers in a Search Attribute, use the `Keyword` type for reliable exact matching.
+The combination of inconsistent tokenization and OR matching makes `Text` unreliable for structured data.
+
+**Tokenization is inconsistent:** hyphens split, but underscores and dots between words do not.
+Searching for `= "retry"` matches `payment-retry-v2` (hyphen splits) but not `payment_retry_handler` (underscore does not).
+
+**OR matching causes false positives:** `= "processing-v2"` is tokenized into `processing` and `v2`, then returns any workflow that contains **either** token — matching both `order-processing-v2` and `payment-retry-v2`.
+
+Use the `Keyword` type for reliable exact matching on structured identifiers.
 See [Choose a string type](/search-attribute#choose-a-string-type) for a comparison of string-based Search Attribute types.
 
 :::

--- a/docs/encyclopedia/visibility/list-filter.mdx
+++ b/docs/encyclopedia/visibility/list-filter.mdx
@@ -65,17 +65,21 @@ See [Choose a string type](/search-attribute#choose-a-string-type).
 
 The standard analyzer applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) to split values into tokens.
 All tokens are lowercased by the analyzer's lowercase filter.
-The splitting behavior depends on the delimiter:
 
-| Delimiter | Splits? | Example |
+Most punctuation and whitespace act as delimiters.
+For example, `order-processing-v2` produces three tokens: `order`, `processing`, `v2`.
+
+The following characters do **not** split when they appear between two letters or between two digits:
+
+| Character | Example | Tokens |
 | --- | --- | --- |
-| Hyphens (`-`) | Yes | `order-processing-v2` → `order`, `processing`, `v2` |
-| Whitespace | Yes | `my business id` → `my`, `business`, `id` |
-| Underscores (`_`) | No | `payment_retry_handler` → one token |
-| Dots between words (`.`) | No | `com.example.workflows.ProcessOrder` → one token |
-| Dots between digits (`.`) | No | `v1.2.3` → one token |
+| Underscores (`_`) | `payment_retry_handler` | one token |
+| Dots (`.`) | `com.example.workflows.ProcessOrder` | one token |
+| Colons (`:`) | `alpha:bravo` | one token |
+| Apostrophes (`'`) | `it's` | one token |
 
-A dot between a digit and a letter (for example, `v1.ProcessOrder`) may split into separate tokens.
+Dots and colons between digits also stay connected (`v1.2.3` → one token).
+However, a dot or colon between a digit and a letter does split: `v1.ProcessOrder` → `v1`, `processorder`.
 
 ##### Search matching {#text-search-matching}
 

--- a/docs/encyclopedia/visibility/search-attributes.mdx
+++ b/docs/encyclopedia/visibility/search-attributes.mdx
@@ -187,14 +187,13 @@ Temporal offers three string-based Search Attribute types with different indexin
 | **KeywordList** | List of single tokens | `=`, `!=`, `IN` | Multi-value tags, labels |
 | **Text** | Tokenized into individual words | `=` (matches any individual token) | Free-form descriptions, notes |
 
-:::caution Text type splits values at punctuation
+:::caution Text type is unreliable for structured identifiers
 
-The `Text` type uses the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which splits values at punctuation characters (`.`, `-`, `/`, `:`, and others) and lowercases each token.
-Underscores do not cause splits (`payment_retry` stays as one token).
-For example, `order-processing-v2` becomes the tokens `[order, processing, v2]`.
-A query for `= "order-processing"` will not match because `order-processing` is not a single token.
+The `Text` type uses the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language.
+The splitting behavior is context-dependent and often surprising for structured data: hyphens cause splits, but dots and underscores typically do not.
+For example, searching for `= "v2"` matches a stored value of `order-processing-v2`, but searching for `= "retry"` does not match `payment_retry_handler`.
 
-Use `Keyword` for structured identifiers such as workflow type names, hyphenated IDs, file paths, and host:port pairs.
+Use `Keyword` for structured identifiers such as workflow type names, hyphenated IDs, file paths, and dotted class names.
 See [Text matching in List Filters](/list-filter#text) for details on how tokenization affects queries.
 
 :::

--- a/docs/encyclopedia/visibility/search-attributes.mdx
+++ b/docs/encyclopedia/visibility/search-attributes.mdx
@@ -159,12 +159,7 @@ Note:
 - **Double** is backed up by `scaled_float` Elasticsearch type with scale factor 10000 (4 decimal digits).
 - **Datetime** is backed up by `date` type with milliseconds precision in Elasticsearch 6 and `date_nanos` type with nanoseconds precision in Elasticsearch 7.
 - **Int** is 64-bit integer (`long` Elasticsearch type).
-- **Keyword** and **Text** types are concepts taken from Elasticsearch. Each word in a **Text** is considered a searchable keyword.
-  For a UUID, that can be problematic because Elasticsearch indexes each portion of the UUID separately.
-  To have the whole string considered as a searchable keyword, use the **Keyword** type.
-  For example, if the key `ProductId` has the value of `2dd29ab7-2dd8-4668-83e0-89cae261cfb1`:
-  - As a **Keyword** it would be matched only by `ProductId = "2dd29ab7-2dd8-4668-83e0-89cae261cfb1`.
-  - As a **Text** it would be matched by `ProductId = 2dd8`, which could cause unwanted matches.
+- With Temporal Server v1.19 and earlier, the **Keyword** type can store a list of values.
 - With Temporal Server v1.20 and later, the **Keyword** type supports only a single value.
   To store a list of values, use **KeywordList**.
 
@@ -181,6 +176,33 @@ If you are storing lists in **Int** attributes, consider either migrating to **K
 :::
 
 - The **Text** type cannot be used in the "Order By" clause.
+
+#### Choose a string type {#choose-a-string-type}
+
+Temporal offers three string-based Search Attribute types with different indexing and matching behavior.
+
+| Type | Indexing | Supported operators | Best for |
+| --- | --- | --- | --- |
+| **Keyword** | Stored as a single token | `=`, `!=`, `IN`, `STARTS_WITH`, `BETWEEN`, `ORDER BY` | Identifiers, UUIDs, enum values, structured strings |
+| **KeywordList** | List of single tokens | `=`, `!=`, `IN` | Multi-value tags, labels |
+| **Text** | Tokenized into individual words | `=` (matches any individual token) | Free-form descriptions, notes |
+
+:::caution Text type splits values at punctuation
+
+The `Text` type uses the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which splits values at punctuation characters (`.`, `-`, `/`, `_`, `:`, and others) and lowercases each token.
+For example, `order-processing-v2` becomes the tokens `[order, processing, v2]`.
+A query for `= "order-processing"` will not match because `order-processing` is not a single token.
+
+Use `Keyword` for structured identifiers such as workflow type names, hyphenated IDs, file paths, and host:port pairs.
+See [Text matching in List Filters](/list-filter#text) for details on how tokenization affects queries.
+
+:::
+
+:::note
+
+Broader tokenizer and exact-matching improvements are being evaluated as part of future Visibility enhancements.
+
+:::
 
 #### Custom Search Attributes limits {#custom-search-attribute-limits}
 

--- a/docs/encyclopedia/visibility/search-attributes.mdx
+++ b/docs/encyclopedia/visibility/search-attributes.mdx
@@ -189,7 +189,8 @@ Temporal offers three string-based Search Attribute types with different indexin
 
 :::caution Text type splits values at punctuation
 
-The `Text` type uses the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which splits values at punctuation characters (`.`, `-`, `/`, `_`, `:`, and others) and lowercases each token.
+The `Text` type uses the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which splits values at punctuation characters (`.`, `-`, `/`, `:`, and others) and lowercases each token.
+Underscores do not cause splits (`payment_retry` stays as one token).
 For example, `order-processing-v2` becomes the tokens `[order, processing, v2]`.
 A query for `= "order-processing"` will not match because `order-processing` is not a single token.
 

--- a/docs/encyclopedia/visibility/search-attributes.mdx
+++ b/docs/encyclopedia/visibility/search-attributes.mdx
@@ -190,11 +190,13 @@ Temporal offers three string-based Search Attribute types with different indexin
 :::caution Text type is unreliable for structured identifiers
 
 The `Text` type uses the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language.
-The splitting behavior is context-dependent and often surprising for structured data: hyphens cause splits, but dots and underscores typically do not.
-The `=` operator also uses OR matching across tokens, so `= "order-processing-v2"` matches any workflow containing `order`, `processing`, **or** `v2` — returning false positives.
+There are two problems for structured data:
+
+1. **Tokenization is inconsistent:** hyphens split tokens, but underscores and dots between words do not. Searching for `= "retry"` matches `payment-retry-v2` but not `payment_retry_handler`.
+2. **Search uses OR matching:** the `=` operator returns results if **any** query token matches **any** indexed token. `= "processing-v2"` matches any workflow containing `processing` **or** `v2`, returning false positives.
 
 Use `Keyword` for structured identifiers such as workflow type names, hyphenated IDs, file paths, and dotted class names.
-See [Text matching in List Filters](/list-filter#text) for details on how tokenization affects queries.
+See [Text matching in List Filters](/list-filter#text) for details.
 
 :::
 

--- a/docs/encyclopedia/visibility/search-attributes.mdx
+++ b/docs/encyclopedia/visibility/search-attributes.mdx
@@ -191,7 +191,7 @@ Temporal offers three string-based Search Attribute types with different indexin
 
 The `Text` type uses the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language.
 The splitting behavior is context-dependent and often surprising for structured data: hyphens cause splits, but dots and underscores typically do not.
-For example, searching for `= "v2"` matches a stored value of `order-processing-v2`, but searching for `= "retry"` does not match `payment_retry_handler`.
+The `=` operator also uses OR matching across tokens, so `= "order-processing-v2"` matches any workflow containing `order`, `processing`, **or** `v2` — returning false positives.
 
 Use `Keyword` for structured identifiers such as workflow type names, hyphenated IDs, file paths, and dotted class names.
 See [Text matching in List Filters](/list-filter#text) for details on how tokenization affects queries.

--- a/docs/encyclopedia/visibility/search-attributes.mdx
+++ b/docs/encyclopedia/visibility/search-attributes.mdx
@@ -179,30 +179,27 @@ If you are storing lists in **Int** attributes, consider either migrating to **K
 
 #### Choose a string type {#choose-a-string-type}
 
-Temporal offers three string-based Search Attribute types with different indexing and matching behavior.
+Temporal offers three string-based Search Attribute types.
+The right choice depends on what you store and how you need to search for it.
 
-| Type | Indexing | Supported operators | Best for |
-| --- | --- | --- | --- |
-| **Keyword** | Stored as a single token | `=`, `!=`, `IN`, `STARTS_WITH`, `BETWEEN`, `ORDER BY` | Identifiers, UUIDs, enum values, structured strings |
-| **KeywordList** | List of single tokens | `=`, `!=`, `IN` | Multi-value tags, labels |
-| **Text** | Tokenized into individual words | `=` (matches any individual token) | Free-form descriptions, notes |
+- **Use `Keyword`** when you need exact matching on a single value — workflow type names, UUIDs, hyphenated IDs, dotted class names, file paths, enum values, or any structured identifier.
+  `Keyword` stores the value as-is and supports `=`, `!=`, `IN`, `STARTS_WITH`, `BETWEEN`, and `ORDER BY`.
+- **Use `KeywordList`** when you need to store and match against multiple values on a single attribute — tags, labels, or categories.
+  `KeywordList` supports `=`, `!=`, and `IN`.
+- **Use `Text`** only for free-form, human-readable content where you want word-level search — descriptions, notes, or error messages.
+  `Text` tokenizes values into individual words and uses OR matching with the `=` operator.
+  See [Text matching in List Filters](/list-filter#text) for details on how tokenization and matching work.
 
-:::caution Text type is unreliable for structured identifiers
+:::tip
 
-The `Text` type uses the [Elasticsearch standard tokenizer](https://www.elastic.co/guide/en/elasticsearch/reference/current/analysis-standard-tokenizer.html), which applies [Unicode word boundary rules](https://unicode.org/reports/tr29/) designed for natural language.
-There are two problems for structured data:
-
-1. **Tokenization is inconsistent:** hyphens split tokens, but underscores and dots between words do not. Searching for `= "retry"` matches `payment-retry-v2` but not `payment_retry_handler`.
-2. **Search uses OR matching:** the `=` operator returns results if **any** query token matches **any** indexed token. `= "processing-v2"` matches any workflow containing `processing` **or** `v2`, returning false positives.
-
-Use `Keyword` for structured identifiers such as workflow type names, hyphenated IDs, file paths, and dotted class names.
-See [Text matching in List Filters](/list-filter#text) for details.
+Most custom Search Attributes store structured identifiers, so `Keyword` is the right default choice.
+Choose `Text` only when you specifically need word-level search on prose-like content.
 
 :::
 
 :::note
 
-Broader tokenizer and exact-matching improvements are being evaluated as part of future Visibility enhancements.
+Broader tokenizer and exact-matching improvements for `Text` Search Attributes are being evaluated as part of future Visibility enhancements.
 
 :::
 


### PR DESCRIPTION
## Summary
- Adds a **"Choose a string type"** section to the Search Attributes page with a comparison table for Keyword vs KeywordList vs Text, including indexing behavior, supported operators, and best-use guidance
- Expands the **Text matching** section in the List Filter page with concrete tokenization examples showing how common value shapes (dotted class names, hyphenated IDs, file paths) are split into tokens
- Adds caution admonitions on both pages warning that Text type splits structured identifiers at punctuation, with cross-links between the two pages
- Adds a forward-looking note that broader tokenizer improvements are being evaluated as part of future Visibility enhancements

## Context
Customers frequently create Text CSAs for structured identifiers (workflow type names, UUIDs, hyphenated IDs) expecting exact-match or substring behavior, then hit confusing search failures because the standard tokenizer silently splits at punctuation. The existing docs mention the distinction briefly but don't explain the implications clearly enough to prevent this mistake.

## Test plan
- [x] `npm run build` succeeds with no errors
- [x] Built HTML verified: tables, admonitions, and cross-links render correctly on both pages
- [ ] Visual review of `/search-attribute#choose-a-string-type`
- [ ] Visual review of `/list-filter#text`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1214950351015754">EDU-6394 Clarify Text CSA tokenization behavior and add type selection guidance</a>
