### PR TITLE
Correct link text for Ruby production debugging section

### DIFF
--- a/docs/develop/ruby/best-practices/debugging.mdx
+++ b/docs/develop/ruby/best-practices/debugging.mdx
@@ -20,7 +20,7 @@ tags:
 This page shows how to do the following:
 
 - [Debug in a development environment](#debug-in-a-development-environment)
-- [Debug in a development production](#debug-in-a-development-environment)
+- [Debug in a production environment](#debug-in-a-production-environment)
 
 ## Debug in a development environment {#debug-in-a-development-environment}
 


### PR DESCRIPTION
## What does this PR do?
Corrects a mistyped link in the ruby debugging documentation.  Previously the link text was wrong, "Debug in a development production" rather than "Debug in a production environment" and the link was to the incorrect section.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215035173997019">EDU-6407 Correct link text for Ruby production debugging section</a>
