### PR TITLE
List all Python integrations on /develop/python landing page

### DIFF
--- a/docs/develop/python/index.mdx
+++ b/docs/develop/python/index.mdx
@@ -81,6 +81,12 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 ## [Integrations](/develop/python/integrations)
 
 - [Braintrust integration](/develop/python/integrations/braintrust)
+- [Google ADK integration](https://adk.dev/integrations/temporal/)
+- [LangGraph integration](/develop/python/integrations/langgraph)
+- [LangSmith integration](/develop/python/integrations/langsmith)
+- [OpenAI Agents SDK integration](https://github.com/temporalio/sdk-python/blob/main/temporalio/contrib/openai_agents/README.md)
+- [Pydantic AI integration](https://ai.pydantic.dev/durable_execution/temporal/)
+- [Tenuo integration](https://tenuo.ai/temporal)
 
 ## Temporal Python Technical Resources
 


### PR DESCRIPTION
## Summary
- The `/develop/python` landing page only linked to the Braintrust integration, even though several more have shipped since (Google ADK, LangGraph, LangSmith, OpenAI Agents SDK, Pydantic AI, Tenuo).
- Updates the integrations list on that landing page to match what's already shown in `docs/develop/python/integrations/index.mdx` and the sidebar.
- Strands Agents is intentionally omitted from this PR — it's being added separately.

## Test plan
- [ ] `yarn start` and confirm the new bullets render on `/develop/python` and all links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215037891271947">EDU-6409 List all Python integrations on &#x2F;develop&#x2F;python landing page</a>
