### PR TITLE
Add asia-southeast2 to documentation

### DIFF
--- a/docs/cloud/references/regions/gcpregions.md
+++ b/docs/cloud/references/regions/gcpregions.md
@@ -71,3 +71,14 @@
   - `aws-ap-south-2`
   - `aws-ap-southeast-1`
   - `aws-ap-southeast-2`
+
+### Asia Pacific - Jakarta (`asia-southeast2`)
+
+- **Cloud API Code**: `gcp-asia-southeast2`
+- **Regional Endpoint**: `gcp-asia-southeast2.region.tmprl.cloud`
+- **Private Service Connect Service Attachment URI**: `projects/prod-bsbyrfwqqq885qkcr3s43y524/regions/asia-southeast2/serviceAttachments/pl-c3ayi`
+- **Same Region Replication**:  Not Available
+- **Multi-Region Replication**:
+  - None
+- **Multi-Cloud Replication**:
+  - None

--- a/docs/cloud/references/regions/private-service.md
+++ b/docs/cloud/references/regions/private-service.md
@@ -1,5 +1,6 @@
-| Region                 | Private Service Connect Service Name                                                      |
-| ---------------------- | ----------------------------------------------------------------------------------------- |
-| `asia-south1`          | `projects/prod-d5spc2sfeshws33bg33vwdef7/regions/asia-south1/serviceAttachments/pl-7w7tw` |
-| `us-central1`          | `projects/prod-d9ch6v2ybver8d2a8fyf7qru9/regions/us-central1/serviceAttachments/pl-5xzn`   |
-| `us-west1   `          | `projects/prod-rbe76zxxzydz4cbdz2xt5b59q/regions/us-west1/serviceAttachments/pl-94w0x`    |
+| Region                 | Private Service Connect Service Name                                                          |
+| ---------------------- | ----------------------------------------------------------------------------------------------|
+| `asia-south1`          | `projects/prod-d5spc2sfeshws33bg33vwdef7/regions/asia-south1/serviceAttachments/pl-7w7tw`     |
+| `asia-southeast2`      | `projects/prod-bsbyrfwqqq885qkcr3s43y524/regions/asia-southeast2/serviceAttachments/pl-c3ayi` |
+| `us-central1`          | `projects/prod-d9ch6v2ybver8d2a8fyf7qru9/regions/us-central1/serviceAttachments/pl-5xzn`      |
+| `us-west1   `          | `projects/prod-rbe76zxxzydz4cbdz2xt5b59q/regions/us-west1/serviceAttachments/pl-94w0x`        |


### PR DESCRIPTION
## What does this PR do?

Adds GCP Jakarta (`asia-southeast2`) to docs.

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215093135863067">EDU-6413 Add asia-southeast2 to documentation</a>
