### PR TITLE
Add docusaurus-plugin-copy-page-button

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -444,6 +444,7 @@ module.exports = async function createConfigAsync() {
           ],
         },
       ],
+      'docusaurus-plugin-copy-page-button',
     ],
     future: {
       v4: true,

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "clsx": "^1.1.1",
     "comlink": "^4.4.2",
     "concurrently": "^8.2.2",
+    "docusaurus-plugin-copy-page-button": "^0.6.2",
     "docusaurus-plugin-llms": "^0.2.0",
     "docusaurus-pushfeedback": "^1.0.3",
     "js-yaml": "^4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5794,6 +5794,11 @@ doctrine@^2.1.0:
   dependencies:
     esutils "^2.0.2"
 
+docusaurus-plugin-copy-page-button@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/docusaurus-plugin-copy-page-button/-/docusaurus-plugin-copy-page-button-0.6.2.tgz#fee47fa75f77ab634d90694c47e832ce9dadcc6c"
+  integrity sha512-RbldmCJ6FEYx515ptp1Ei9WwQAQyK6ty5UaHVaSlOyBfh/Nm+wu+6y3g/V7sVejBrMCxpGLnAuIJn3h8nqdjcQ==
+
 docusaurus-plugin-llms@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.2.2.tgz#3461e8295d18d4057cf0fbcf5e3feac561ea6fd1"


### PR DESCRIPTION
## Summary

Adds [`docusaurus-plugin-copy-page-button`](https://www.npmjs.com/package/docusaurus-plugin-copy-page-button) to docs.temporal.io so readers can copy any page as clean markdown — useful when piping workflow/activity API or troubleshooting context into ChatGPT, Claude, Perplexity, or Gemini.

The plugin auto-injects a small "Copy page" button + dropdown into the doc page's table-of-contents area. The dropdown offers:

- Copy as markdown
- View as markdown
- Open in ChatGPT / Claude / Perplexity / Gemini

Live preview of the UI: https://portdeveloper.github.io/copy-page-button-showcase/

## Relationship to existing LLM features

Temporal docs already does great work on machine-readable content:

- `docusaurus-plugin-llms` generates `/llms.txt`, `/llms-full.txt`, and the custom `llms-quickstart.txt` / `llms-api-reference.txt` corpus files.
- The custom `plugins/markdown-pages` plugin makes every page available at `<path>.md`.

This PR doesn't replace or duplicate any of that — those remain perfect for whole-corpus consumption and agent fetching. The plugin adds the UI affordance: a reader on a specific page can grab just that page's markdown, or one-click open it in ChatGPT/Claude/Perplexity/Gemini for a focused conversation. Build output confirms all existing corpus files still generate.

## Adoption

The plugin currently ships on docs sites for React Native (just merged via facebook/react-native-website#5085), Puppeteer, Arbitrum, Cardano, Sui, Ethereum execution-apis, and several others — full list in the [project README](https://github.com/portdeveloper/docusaurus-plugin-copy-page-button#used-by).

## Changes

- Added `'docusaurus-plugin-copy-page-button'` to the `plugins` array in `docusaurus.config.js`
- Added `docusaurus-plugin-copy-page-button@^0.6.2` to `dependencies`
- Resulting `yarn.lock` updates

`yarn build` passes — existing `llms.txt`, `llms-full.txt`, custom corpus files, and `markdown-pages` output all still generate.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215107981131369">EDU-6425 Add docusaurus-plugin-copy-page-button</a>
