### PR TITLE
[codex] Derive cloud region counts from region docs

### DIFF
--- a/docs/evaluate/temporal-cloud/overview.mdx
+++ b/docs/evaluate/temporal-cloud/overview.mdx
@@ -16,6 +16,8 @@ tags:
   - Temporal Cloud
 ---
 
+import CloudRegionCount from '@site/src/components/elements/CloudRegionCount';
+
 Temporal Cloud is a fully managed durable execution platform.
 It handles the complexity of running Temporal at scale—persistence, replication, upgrades, and availability—so you can focus on building applications.
 
@@ -68,8 +70,8 @@ The control plane uses Temporal itself (durable execution) to orchestrate these 
 
 Temporal Cloud runs on both AWS and GCP:
 
-- **14 AWS regions** spanning North America, Europe, Asia Pacific, and South America
-- **5 GCP regions** in North America, Europe, and Asia Pacific
+- <strong><CloudRegionCount provider="aws" /> AWS regions</strong> spanning North America, Europe, Asia Pacific, and South America
+- <strong><CloudRegionCount provider="gcp" /> GCP regions</strong> in North America, Europe, and Asia Pacific
 
 You can create Namespaces in any supported region.
 For disaster recovery, you can replicate across regions within a cloud provider or across cloud providers entirely.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -346,6 +346,15 @@ module.exports = async function createConfigAsync() {
         };
       },
       [
+        './plugins/cloud-region-counts',
+        {
+          regionFiles: {
+            aws: 'docs/cloud/references/regions/awsregions.md',
+            gcp: 'docs/cloud/references/regions/gcpregions.md',
+          },
+        },
+      ],
+      [
         'docusaurus-pushfeedback',
         {
           project: '6c1ptrxbky',

--- a/plugins/cloud-region-counts/index.js
+++ b/plugins/cloud-region-counts/index.js
@@ -1,0 +1,41 @@
+const fs = require('fs');
+const path = require('path');
+
+module.exports = function cloudRegionCountsPlugin(context, options = {}) {
+  const regionFiles = options.regionFiles || {};
+
+  const resolveRegionFile = (filePath) =>
+    path.isAbsolute(filePath) ? filePath : path.join(context.siteDir, filePath);
+
+  const countRegions = (filePath) => {
+    const source = fs.readFileSync(filePath, 'utf8');
+    return (source.match(/^###\s+/gm) || []).length;
+  };
+
+  const resolvedRegionFiles = Object.fromEntries(
+    Object.entries(regionFiles).map(([provider, filePath]) => [
+      provider,
+      resolveRegionFile(filePath),
+    ])
+  );
+
+  return {
+    name: 'cloud-region-counts',
+    getPathsToWatch() {
+      return Object.values(resolvedRegionFiles);
+    },
+    async loadContent() {
+      const counts = Object.fromEntries(
+        Object.entries(resolvedRegionFiles).map(([provider, filePath]) => [
+          provider,
+          countRegions(filePath),
+        ])
+      );
+
+      return { counts };
+    },
+    async contentLoaded({ content, actions }) {
+      actions.setGlobalData(content);
+    },
+  };
+};

--- a/src/components/elements/CloudRegionCount.js
+++ b/src/components/elements/CloudRegionCount.js
@@ -1,0 +1,8 @@
+import { usePluginData } from '@docusaurus/useGlobalData';
+
+export default function CloudRegionCount({ provider }) {
+  const data = usePluginData('cloud-region-counts');
+  const count = data?.counts?.[provider];
+
+  return count ?? 0;
+}


### PR DESCRIPTION
## What changed

- Added a small Docusaurus plugin that reads the AWS and GCP region reference Markdown files during build and exposes provider counts through plugin global data.
- Added a `CloudRegionCount` component that renders those counts in the Temporal Cloud overview page.
- Replaced the hard-coded AWS/GCP region counts in `/cloud/overview` with the derived counts.

## Why

The overview page had a separate hard-coded GCP region count that drifted from the canonical `/cloud/regions` source. This keeps the overview count tied to the same reference files used by the service regions page.

## Validation

- `yarn build`
- Verified generated `build/cloud/overview/index.html` renders `14 AWS regions` and `6 GCP regions`.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215173650602622">EDU-6432 [codex] Derive cloud region counts from region docs</a>
