### PR TITLE
Clarify Priority and Fairness dispatch order and add weight override CLI example

### DIFF
--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -517,19 +517,15 @@ There should only be one fairness weight assigned to each fairness key within a 
 
 ### Choosing between Priority, Fairness, and both
 
-- **Priority alone** when you need strict preemption — for example, break-glass or SEV-style overrides, or separating real-time Tasks from batch Tasks on a shared Worker pool.
+- **Priority alone** when you need strict priority ordering - for example, separating real-time Tasks from batch Tasks.
 - **Fairness alone** when you need tier or tenant isolation so no group is starved, but you don't need to preempt any group ahead of another.
-- **Both** when you have a tiered SLA hierarchy — Priority for the broad tier (for example, paid vs. free), Fairness for per-tenant equity within a tier.
-
-### Using Priority and Fairness together
+- **Both** when you have a tiered SLA hierarchy - Priority for the broad tier (for example, paid vs. free), Fairness for per-tenant equity within a tier.
 
 When you use Priority and Fairness together, the next Task to dispatch is chosen by walking three rules in order:
 
-1. **Priority tier (strict).** Tasks at a lower `priority_key` (higher priority) always dispatch before any Task at a higher `priority_key`, regardless of fairness keys or weights. A single priority-1 Task is dispatched before any priority-2 Task in the backlog.
-2. **Fairness key within a tier (weighted).** Within a priority tier, each fairness key is a virtual queue. Keys are dispatched proportional to their weights — a key with weight 2.0 is dispatched twice as often as a key with weight 1.0.
+1. **Priority tier (strict).** Tasks at a higher priority always dispatch before tasks at lower priorities, regardless of fairness keys or weights.
+2. **Fairness key within a tier (weighted).** Within a priority tier, each fairness key is a virtual queue. Keys are dispatched proportional to their weights — a key with weight 2.0 is dispatched twice as often as one with weight 1.0.
 3. **FIFO within a key.** Tasks that share a priority tier _and_ fairness key dispatch in the order they were enqueued.
-
-So if two Tasks have the same `priority_key`, the same `fairness_key`, and the same `fairness_weight`, the older one dispatches first.
 
 <EnlargeImage
   src="/img/develop/task-queue-priority-fairness/priority-fairness.png"

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -515,9 +515,21 @@ There should only be one fairness weight assigned to each fairness key within a 
 
 :::
 
+### Choosing between Priority, Fairness, and both
+
+- **Priority alone** when you need strict preemption — for example, break-glass or SEV-style overrides, or separating real-time Tasks from batch Tasks on a shared Worker pool.
+- **Fairness alone** when you need tier or tenant isolation so no group is starved, but you don't need to preempt any group ahead of another.
+- **Both** when you have a tiered SLA hierarchy — Priority for the broad tier (for example, paid vs. free), Fairness for per-tenant equity within a tier.
+
 ### Using Priority and Fairness together
 
-When you use Priority and Fairness together, Priority determines which "sub-queue" Tasks go into, and Fairness determines the order in which Tasks within each priority level are executed.
+When you use Priority and Fairness together, the next Task to dispatch is chosen by walking three rules in order:
+
+1. **Priority tier (strict).** Tasks at a lower `priority_key` (higher priority) always dispatch before any Task at a higher `priority_key`, regardless of fairness keys or weights. A single priority-1 Task is dispatched before any priority-2 Task in the backlog.
+2. **Fairness key within a tier (weighted).** Within a priority tier, each fairness key is a virtual queue. Keys are dispatched proportional to their weights — a key with weight 2.0 is dispatched twice as often as a key with weight 1.0.
+3. **FIFO within a key.** Tasks that share a priority tier _and_ fairness key dispatch in the order they were enqueued.
+
+So if two Tasks have the same `priority_key`, the same `fairness_key`, and the same `fairness_weight`, the older one dispatches first.
 
 <EnlargeImage
   src="/img/develop/task-queue-priority-fairness/priority-fairness.png"
@@ -596,6 +608,18 @@ In many cases, supplying the weight of a fairness key along with the key itself 
 You can override the weights of up to 1000 keys through the config API. When an override is set for a key, the weight attached to the Task, through Workflow or Activity priority metadata, will be ignored, and the overridden weight will be used instead.
 
 Weight overrides are stored per Task Queue, including type, so they must be set for both Workflow and Activity Task Queues to take effect for both.
+
+Set overrides with `temporal task-queue config set` (CLI v1.7.0 or later):
+
+```
+temporal task-queue config set \
+    --task-queue my-task-queue \
+    --task-queue-type activity \
+    --fairness-key-weight premium=5.0 \
+    --fairness-key-weight basic=1.0
+```
+
+To unset a single key's override, pass `key=default`. To clear all overrides on the Task Queue, use `--fairness-key-weight-clear-all`.
 
 ### Limitations of Fairness
 

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -580,9 +580,9 @@ temporal task-queue config set \
     --fairness-key-rps-limit-reason "per-key limit"
 ```
 
-Whole queue rate limits: applies to the whole queue regardless of the fairness key. This is the same setting as is exposed through the [Worker Options](/develop/worker-tuning-reference#io-configuration-options) in the SDKs, and when set via the API, takes precedence over the limit set through Worker Options.
+**Whole queue rate limits:** applies to the whole queue regardless of the fairness key. This is the same setting as is exposed through the [Worker Options](/develop/worker-tuning-reference#io-configuration-options) in the SDKs, and when set via the API, takes precedence over the limit set through Worker Options.
 
-Fairness key rate limits: The per-fairness-key rate limit works in conjunction with Task Queue Fairness. If you think of Fairness as dividing the queue into one virtual queue for each key, then the per-fairness-key rate limit is a limit on each individual virtual queue. Some important notes on the per-fairness-key limit:
+**Fairness key rate limits:** The per-fairness-key rate limit works in conjunction with Task Queue Fairness. If you think of Fairness as dividing the queue into one virtual queue for each key, then the per-fairness-key rate limit is a limit on each individual virtual queue. Some important notes on the per-fairness-key limit:
 
 - The whole queue limit and per-fairness-key limit may be set independently: none, one or the other, or both may be set. If both are set, then the more restrictive one applies.
 - The per-fairness-key limit for a key is scaled by the fairness weight assigned to that key. So if the per-fairness-key limit for a queue is set to 10, then all keys with the default weight (1.0) will have a limit of 10 tasks/second. But if a particular key is given a weight of 2.5, then the per-key rate limit for that key will be 25 tasks/second.

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -527,6 +527,8 @@ When you use Priority and Fairness together, the next Task to dispatch is chosen
 2. **Fairness key within a tier (weighted).** Within a priority tier, each fairness key is a virtual queue. Keys are dispatched proportional to their weights - a key with weight 2.0 is dispatched twice as often as one with weight 1.0.
 3. **FIFO within a key.** Tasks that share a priority tier _and_ fairness key dispatch in the order they were enqueued.
 
+These rules apply within a Task Queue partition. See [Limitations of Fairness](#limitations-of-fairness) for how partitioning can affect ordering.
+
 <EnlargeImage
   src="/img/develop/task-queue-priority-fairness/priority-fairness.png"
   alt="Flowchart of how Priority and Fairness combine: poller checks priority levels in order, then within each level Fairness selects a virtual queue weighted by fairness weight"
@@ -601,6 +603,7 @@ Set overrides with `temporal task-queue config set`:
 temporal task-queue config set \
     --task-queue my-task-queue \
     --task-queue-type activity \
+    --namespace my-namespace \
     --fairness-key-weight premium=5.0 \
     --fairness-key-weight basic=1.0
 ```

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -580,7 +580,7 @@ temporal task-queue config set \
     --fairness-key-rps-limit-reason "per-key limit"
 ```
 
-Whole queue rate limits: applies to the whole queue regardless of the fairness key. This is the same setting as is exposed through the Worker Options in the SDKs, and when set via the API, takes precedence over the limit set through Worker Options.
+Whole queue rate limits: applies to the whole queue regardless of the fairness key. This is the same setting as is exposed through the [Worker Options](/develop/worker-tuning-reference#io-configuration-options) in the SDKs, and when set via the API, takes precedence over the limit set through Worker Options.
 
 Fairness key rate limits: The per-fairness-key rate limit works in conjunction with Task Queue Fairness. If you think of Fairness as dividing the queue into one virtual queue for each key, then the per-fairness-key rate limit is a limit on each individual virtual queue. Some important notes on the per-fairness-key limit:
 

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -595,7 +595,7 @@ You can override the weights of up to 1000 keys through the config API. When an 
 
 Weight overrides are stored per Task Queue, including type, so they must be set for both Workflow and Activity Task Queues to take effect for both.
 
-Set overrides with `temporal task-queue config set` (CLI v1.7.0 or later):
+Set overrides with `temporal task-queue config set`:
 
 ```
 temporal task-queue config set \

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -567,17 +567,7 @@ In both directions, the existing backlog is dispatched before any new Tasks queu
 
 ### Set rate limits at the Task Queue level
 
-When you're starting to scale your Temporal Services, you may decide to set [Requests Per Second (RPS)](/references/dynamic-configuration#service-level-rps-limits) limits to test your workload or experiment with provisioning benchmarks. You can set the RPS limit at the Task Queue level with `queue-rps-limit` in the CLI.
-
-The whole queue rate limits the dispatch rate of Tasks regardless of the fairness key. Tasks won't be dispatched faster than the specified limit when averaged over a few seconds, although you may see small bursts due to partitioning.
-
-:::note
-
-The whole queue rate limit is the same feature that's available through the Worker Options in the SDKs. If it's set through the API, that limit takes precedence over the limit set through Worker Options.
-
-:::
-
-If you want to make sure that a specific fairness key has limits to throttle Tasks, you can also set an RPS limit based on fairness keys with `fairness-key-rps-limit-default` in the CLI. This could be how you distinguish customer tiers in a way that only allows a defined number of Tasks to be processed by that tier.
+Within a Task Queue, you can set dispatch rate limits for the whole queue using `queue-rps-limit` and for each fairness key using `fairness-key-rps-limit-default`.
 
 ```
 temporal task-queue config set \
@@ -590,7 +580,9 @@ temporal task-queue config set \
     --fairness-key-rps-limit-reason "per-key limit"
 ```
 
-The per-fairness-key rate limit works in conjunction with Task Queue Fairness. If you think of Fairness as dividing the queue into one virtual queue for each key, then the per-fairness-key rate limit is a limit on each individual virtual queue. Some important notes on the per-fairness-key limit:
+Whole queue rate limits: applies to the whole queue regardless of the fairness key. This is the same setting as is exposed through the Worker Options in the SDKs, and when set via the API, takes precedence over the limit set through Worker Options.
+
+Fairness key rate limits: The per-fairness-key rate limit works in conjunction with Task Queue Fairness. If you think of Fairness as dividing the queue into one virtual queue for each key, then the per-fairness-key rate limit is a limit on each individual virtual queue. Some important notes on the per-fairness-key limit:
 
 - The whole queue limit and per-fairness-key limit may be set independently: none, one or the other, or both may be set. If both are set, then the more restrictive one applies.
 - The per-fairness-key limit for a key is scaled by the fairness weight assigned to that key. So if the per-fairness-key limit for a queue is set to 10, then all keys with the default weight (1.0) will have a limit of 10 tasks/second. But if a particular key is given a weight of 2.5, then the per-key rate limit for that key will be 25 tasks/second.
@@ -598,8 +590,6 @@ The per-fairness-key rate limit works in conjunction with Task Queue Fairness. I
 - Usually there isn't actually any blocking, but there can be when the fairness weight for a key is changed between when a Task is scheduled and when it's dispatched. If the fairness weight for a key is lowered, for example, the new lower per-key rate limit will be respected. Since those Tasks were originally scheduled with the higher rate, they will block other Tasks as they're dispatched. This limitation will be improved in the future.
 
 ### Fairness weight overrides
-
-In many cases, supplying the weight of a fairness key along with the key itself is straightforward. In some situations, it's convenient to leave the weights out of client code and instead control the weights of a small number of keys through a config API.
 
 You can override the weights of up to 1000 keys through the config API. When an override is set for a key, the weight attached to the Task, through Workflow or Activity priority metadata, will be ignored, and the overridden weight will be used instead.
 

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -524,7 +524,7 @@ There should only be one fairness weight assigned to each fairness key within a 
 When you use Priority and Fairness together, the next Task to dispatch is chosen by walking three rules in order:
 
 1. **Priority tier (strict).** Tasks at a higher priority always dispatch before tasks at lower priorities, regardless of fairness keys or weights.
-2. **Fairness key within a tier (weighted).** Within a priority tier, each fairness key is a virtual queue. Keys are dispatched proportional to their weights — a key with weight 2.0 is dispatched twice as often as one with weight 1.0.
+2. **Fairness key within a tier (weighted).** Within a priority tier, each fairness key is a virtual queue. Keys are dispatched proportional to their weights - a key with weight 2.0 is dispatched twice as often as one with weight 1.0.
 3. **FIFO within a key.** Tasks that share a priority tier _and_ fairness key dispatch in the order they were enqueued.
 
 <EnlargeImage


### PR DESCRIPTION
Three changes to docs/develop/task-queue-priority-fairness.mdx:

1. **Dispatch order made explicit.** Replaced the "Using Priority and Fairness together" section with "Choosing between Priority, Fairness, and both" - covers when each mode fits and spells out the three-rule dispatch order (priority tier, then fairness weight, then FIFO within a key).

2. **Rate limits section tightened.** Removed throat-clearing intro, restructured into bolded "Whole queue rate limits" and "Fairness key rate limits" labels, linked Worker Options to the worker-tuning-reference page.

3. **Weight override CLI example added.** The "Fairness weight overrides" section previously said overrides are set "through the config API" without showing how. Added a `temporal task-queue config set --fairness-key-weight` example.

Motivated by [this customer Slack thread](https://temporaltechnologies.slack.com/archives/C0748KDH2DD/p1779899719317389?thread_ts=1779898503.202859&cid=C0748KDH2DD) asking five clarifying questions about this page.