### PR TITLE
Document repeated-key convention for OpenMetrics array query params

### DIFF
--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -160,6 +160,18 @@ To account for metric data latency, this endpoint returns metrics from the curre
 | `namespaces` | string array | Filter to specific Namespaces. Supports wildcards (e.g., `production-*`) |
 | `metrics` | string array | Filter to specific metrics |
 
+Array parameters use repeated keys. To pass multiple values, repeat the parameter name once per value:
+
+```shell
+/v1/metrics?namespaces=prod-payments&namespaces=prod-orders
+```
+
+The `namespaces` and `metrics` parameters can be combined, and each may be repeated independently:
+
+```shell
+/v1/metrics?namespaces=prod-payments&namespaces=prod-orders&metrics=temporal_cloud_v1_workflow_success_count&metrics=temporal_cloud_v1_approximate_backlog_count
+```
+
 #### Response Headers
 
 | Header | Description |
@@ -286,6 +298,9 @@ You can isolate only the metrics/namespaces you need.  For example, the followin
 ```shell
 # Only specific namespaces matching the wildcard pattern
 /v1/metrics?namespaces=production-*
+
+# Multiple namespaces
+/v1/metrics?namespaces=prod-payments&namespaces=prod-orders
 
 # Only specific metrics
 /v1/metrics?metrics=temporal_cloud_v1_workflow_success_count


### PR DESCRIPTION
## Summary
- The `namespaces` and `metrics` query parameters on `GET /v1/metrics` were documented as "string array" with no example of how to pass multiple values.
- Multi-value array encoding is not standardized across APIs (some use commas, some repeated keys, some bracketed indices), so users (and their AI assistants) were guessing wrong.
- Adds an example showing the repeated-key convention (`?namespaces=ns1&namespaces=ns2`) under the Query Parameters table, and a multi-namespace line to the Filtering at Scrape Time examples.

## Test plan
- [ ] Visual review of rendered docs page on the Vercel preview
- [ ] Confirm code samples render correctly in the shell fence

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215213800059748">EDU-6439 Document repeated-key convention for OpenMetrics array query params</a>
