### PR TITLE
Control Plane capitalization and connectivity

### DIFF
--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -19,7 +19,7 @@ tags:
   - Temporal Cloud
 ---
 
-Audit Logs is a feature of [Temporal Cloud](/cloud/overview) that provides forensic access information for a variety of operations in the Temporal Cloud control plane.
+Audit Logs is a feature of [Temporal Cloud](/cloud/overview) that provides forensic access information for a variety of operations in the Temporal Cloud Control Plane.
 
 Audit Logs answers "who, when, and what" questions about Temporal Cloud resources.
 These answers can help you evaluate the security of your organization, and they can provide information that you need to satisfy audit and compliance requirements.

--- a/docs/cloud/connectivity/index.mdx
+++ b/docs/cloud/connectivity/index.mdx
@@ -347,7 +347,7 @@ nc -zv vpce-0123456789abcdef-abc.us-east-1.vpce.amazonaws.com 7233
 
 ## Control plane connectivity
 
-Using the Temporal Cloud [web UI](/web-ui), [Terraform provider](/cloud/terraform-provider), [`tcld` CLI](/cloud/tcld), or [Cloud Ops APIs](/ops) requires network access to the Temporal Cloud control plane. 
+Using the Temporal Cloud [web UI](/web-ui), [Terraform provider](/cloud/terraform-provider), [`tcld` CLI](/cloud/tcld), or [Cloud Ops APIs](/ops) requires network access to the Temporal Cloud Control Plane. 
 
 ### Control plane hostnames
 
@@ -357,13 +357,13 @@ Different hostnames are used for different parts of the service.
 - `web.onboarding.tmprl.cloud` (required for Web UI)
 - `web.saas-api.tmprl.cloud` (required for Web UI)
 
-### AWS PrivateLink connectivity to Temporal Cloud control plane
+### AWS PrivateLink connectivity to Temporal Cloud Control Plane
 
-Temporal Cloud supports [AWS PrivateLink](https://aws.amazon.com/privatelink/) connections to the control plane, which allows access from applications running in VPCs that cannot egress to the public internet. Temporal Cloud does **not** support restricting an account so that private connectivity is the sole connectivity method to the control plane; the control plane is always accessible via public internet.
+Temporal Cloud supports [AWS PrivateLink](https://aws.amazon.com/privatelink/) connections to the Control Plane, which allows access from applications running in VPCs that cannot egress to the public internet. Temporal Cloud does **not** support restricting an account so that private connectivity is the sole connectivity method to the Control Plane; the Control Plane is always accessible via public internet.
 
 Control plane access is always securely authenticated via [API keys](/cloud/api-keys#overview) or JWT tokens, regardless of how you choose to connect.
 
-To set up a PrivateLink connection to the Temporal Cloud control plane, follow [these instructions](/cloud/connectivity/aws-connectivity), but use the control plane endpoint information below:
+To set up a PrivateLink connection to the Temporal Cloud Control Plane, follow [these instructions](/cloud/connectivity/aws-connectivity), but use the Control Plane endpoint information below:
 
 | Hostname               | Region      | Control Plane PrivateLink Service Name                    |
 | ---------------------- | ----------- | --------------------------------------------------------- |
@@ -371,11 +371,21 @@ To set up a PrivateLink connection to the Temporal Cloud control plane, follow [
 
 The control plane PrivateLink endpoint includes a [private DNS name](https://docs.aws.amazon.com/vpc/latest/privatelink/manage-dns-names.html), which lets your clients use the PrivateLink connection without having to set up private DNS or having to override client configuration. To use the DNS name, make sure your VPC has the `Enable DNS hostnames` and `Enable DNS support` options enabled. If you cannot use the DNS name, you can also manually [set up private DNS](/cloud/connectivity/aws-connectivity#configuring-private-dns-for-aws-privatelink) or [override the server and TLS settings on your clients](/cloud/connectivity#update-dns-or-clients-to-use-private-connectivity).
 
-:::caution Finish client setup
+:::caution Finish client setup to programmatically access Temporal Cloud Control Plane over PrivateLink
 
-After creating a private connection, you must use the provided DNS name, set up private DNS, or update the configuration of all clients you want to use the private connection.
+For Temporal clients to access the Control Plane over AWS PrivateLink, you must either use the provided DNS name, set up private DNS, or update the client configuration, as described above.
 
-Without this step, your clients may connect to the control plane over the internet if they were previously using public connectivity, or they will not be able to connect at all.
+Without this step, your clients may connect to the Temporal Cloud Control Plane over the internet, or they may not connect at all.
 :::
 
-The control plane is also accessible via the PrivateLink endpoint in AWS us-west-2 that can be used for namespace traffic, but we strongly recommend using the control-plane specific endpoint for control plane traffic.
+#### Extend the Control Plane PrivateLink endpoint to other AWS regions with VPC Peering
+
+The Temporal Cloud Control Plane PrivateLink Service is only exposed in `us-west-2`. To reach the Control Plane privately from another AWS region, set up a us-west-2 VPC with a VPC Endpoint to the Control Plane, then [VPC-Peer](https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html) that VPC to your other-region VPCs.
+
+To set this up:
+
+1. Create a VPC in `us-west-2`.
+2. Create the [VPC Endpoint](https://docs.aws.amazon.com/vpc/latest/privatelink/concepts.html) to the Control Plane in that us-west-2 VPC, using the service name from the table above. Follow the [standard PrivateLink setup steps](/cloud/connectivity/aws-connectivity), but use the Control Plane service name.
+3. Peer the us-west-2 VPC to each VPC in another region that needs Control Plane access. [VPC Peering shares VPC Endpoints](https://docs.aws.amazon.com/vpc/latest/peering/peering-configurations-partial-access.html) across peered VPCs, which gives each peered VPC a private path to the Control Plane.
+
+Peering is per-VPC, so you must peer the us-west-2 VPC to every VPC that needs Control Plane access. There is no limit on how many regions you can extend to using this approach.

--- a/docs/cloud/connectivity/index.mdx
+++ b/docs/cloud/connectivity/index.mdx
@@ -361,7 +361,7 @@ Different hostnames are used for different parts of the service.
 
 Temporal Cloud supports [AWS PrivateLink](https://aws.amazon.com/privatelink/) connections to the Control Plane, which allows access from applications running in VPCs that cannot egress to the public internet. Temporal Cloud does **not** support restricting an account so that private connectivity is the sole connectivity method to the Control Plane; the Control Plane is always accessible via public internet.
 
-Control plane access is always securely authenticated via [API keys](/cloud/api-keys#overview) or JWT tokens, regardless of how you choose to connect.
+Control Plane access is always securely authenticated via [API keys](/cloud/api-keys#overview) or JWT tokens, regardless of how you choose to connect.
 
 To set up a PrivateLink connection to the Temporal Cloud Control Plane, follow [these instructions](/cloud/connectivity/aws-connectivity), but use the Control Plane endpoint information below:
 
@@ -369,7 +369,7 @@ To set up a PrivateLink connection to the Temporal Cloud Control Plane, follow [
 | ---------------------- | ----------- | --------------------------------------------------------- |
 | `saas-api.tmprl.cloud` | `us-west-2` | `com.amazonaws.vpce.us-west-2.vpce-svc-0c57a5930b6f6be0e` |
 
-The control plane PrivateLink endpoint includes a [private DNS name](https://docs.aws.amazon.com/vpc/latest/privatelink/manage-dns-names.html), which lets your clients use the PrivateLink connection without having to set up private DNS or having to override client configuration. To use the DNS name, make sure your VPC has the `Enable DNS hostnames` and `Enable DNS support` options enabled. If you cannot use the DNS name, you can also manually [set up private DNS](/cloud/connectivity/aws-connectivity#configuring-private-dns-for-aws-privatelink) or [override the server and TLS settings on your clients](/cloud/connectivity#update-dns-or-clients-to-use-private-connectivity).
+The Control Plane PrivateLink endpoint includes a [private DNS name](https://docs.aws.amazon.com/vpc/latest/privatelink/manage-dns-names.html), which lets your clients use the PrivateLink connection without having to set up private DNS or having to override client configuration. To use the DNS name, make sure your VPC has the `Enable DNS hostnames` and `Enable DNS support` options enabled. If you cannot use the DNS name, you can also manually [set up private DNS](/cloud/connectivity/aws-connectivity#configuring-private-dns-for-aws-privatelink) or [override the server and TLS settings on your clients](/cloud/connectivity#update-dns-or-clients-to-use-private-connectivity).
 
 :::caution Finish client setup to programmatically access Temporal Cloud Control Plane over PrivateLink
 

--- a/docs/cloud/high-availability/failovers/index.mdx
+++ b/docs/cloud/high-availability/failovers/index.mdx
@@ -70,7 +70,7 @@ exhaustive list, and it may change over time.
 
 :::
 
-- Whether Temporal Cloud's services in the cell are reachable from the control plane.
+- Whether Temporal Cloud's services in the cell are reachable from the Control Plane.
 - The average latency of inbound RPC calls (excluding long-polling APIs) to Temporal services in the cell.
 - The percentage of inbound RPC calls that returned errors related to server health.
 - The average latency of calls from Temporal Cloud's services in the cell to its persistence layer.

--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -2,7 +2,7 @@
 id: operation-api
 title: Cloud Ops API
 sidebar_label: Cloud Ops API
-description: The Temporal Cloud Operations API (Cloud Ops) allows programmatic management of Temporal Cloud control plane resources.
+description: The Temporal Cloud Operations API (Cloud Ops) allows programmatic management of Temporal Cloud Control Plane resources.
 slug: /ops
 toc_max_heading_level: 4
 keywords:
@@ -18,7 +18,7 @@ The Temporal Cloud Operations API is in [Public Preview](/evaluate/development-p
 
 :::
 
-The Temporal Cloud Operations API, or the Cloud Ops API, is an open source, public [HTTP API](https://saas-api.tmprl.cloud/docs/httpapi.html#description/introduction) and [gRPC API](https://github.com/temporalio/cloud-api/tree/main) for programmatically managing Temporal Cloud control plane resources, including [Namespaces](/cloud/namespaces), [Users](/cloud/users), [Service Accounts](/cloud/service-accounts), [API keys](/cloud/api-keys), and others. The Temporal Cloud [Terraform Provider](/cloud/terraform-provider), [tcld CLI](/cloud/tcld), and Web UI all use the Cloud Ops API.
+The Temporal Cloud Operations API, or the Cloud Ops API, is an open source, public [HTTP API](https://saas-api.tmprl.cloud/docs/httpapi.html#description/introduction) and [gRPC API](https://github.com/temporalio/cloud-api/tree/main) for programmatically managing Temporal Cloud Control Plane resources, including [Namespaces](/cloud/namespaces), [Users](/cloud/users), [Service Accounts](/cloud/service-accounts), [API keys](/cloud/api-keys), and others. The Temporal Cloud [Terraform Provider](/cloud/terraform-provider), [tcld CLI](/cloud/tcld), and Web UI all use the Cloud Ops API.
 
 ## Develop applications with the Cloud Ops API
 
@@ -151,7 +151,7 @@ The Temporal Cloud Operations API implements rate limiting to ensure system stab
 
 **Total rate limit: 160 requests per second (RPS)**
 
-This limit applies to all requests made to the Temporal Cloud control plane by any client (tcld, UI, Cloud Ops API) or identity type (user, service account) within your account. The total account throughput cannot exceed the limit regardless of the number of users or service accounts making requests.
+This limit applies to all requests made to the Temporal Cloud Control Plane by any client (tcld, UI, Cloud Ops API) or identity type (user, service account) within your account. The total account throughput cannot exceed the limit regardless of the number of users or service accounts making requests.
 
 ### Per-identity rate limits
 
@@ -169,7 +169,7 @@ This limits the number of concurrent asynchronous operations that can be in-flig
 
 ### Important considerations
 
-- Rate limits are enforced across all Temporal Cloud control plane operations
+- Rate limits are enforced across all Temporal Cloud Control Plane operations
 - Multiple clients used by the same identity (user or service account) share the same rate limit
 - Authentication method (SSO, API keys) does not affect rate limiting
 - These limits help ensure system stability and prevent any single account or identity from overwhelming the service

--- a/docs/cloud/terraform-provider.mdx
+++ b/docs/cloud/terraform-provider.mdx
@@ -465,7 +465,7 @@ For example, to change the allowed caller Namespaces on a Nexus Endpoint:
    ```
 
    Upon completion, you will see a success message indicating your Nexus Endpoint has been updated. It may take several
-   seconds to update a Nexus Endpoint in the control plane which is visible from the Temporal UI or tcld CLI.
+   seconds to update a Nexus Endpoint in the Control Plane which is visible from the Temporal UI or tcld CLI.
    Propagation of Nexus Endpoint changes to the data plane may take longer, but usually complete in less than one
    minute.
 

--- a/docs/evaluate/temporal-cloud/overview.mdx
+++ b/docs/evaluate/temporal-cloud/overview.mdx
@@ -27,7 +27,7 @@ The platform stores encrypted Workflow state and orchestrates execution, while y
 
 ## How Temporal Cloud works
 
-Temporal Cloud operates as the control plane for your distributed applications:
+Temporal Cloud operates as the Control Plane for your distributed applications:
 
 1. **Your environment**: You run Workers that execute your Workflow and Activity code. These can be deployed anywhere—Kubernetes, VMs, serverless, on-premises.
 2. **Temporal Cloud**: Manages Workflow state, Event History, task queuing, and scheduling. All data is encrypted in transit and at rest.
@@ -58,7 +58,7 @@ This design limits blast radius and enables independent scaling.
 
 **Data plane**: Where your Workflows execute. Each cell processes Workflow operations, persists state, and manages task queues. The data plane is optimized for low latency and high throughput.
 
-**Control plane**: Manages provisioning, configuration, and lifecycle operations. When you create a Namespace, the control plane:
+**Control plane**: Manages provisioning, configuration, and lifecycle operations. When you create a Namespace, the Control Plane:
 1. Selects an appropriate cell in your chosen region
 2. Provisions database resources and roles
 3. Generates and deploys mTLS certificates


### PR DESCRIPTION
## What does this PR do?

* Explains how to connect to the Control Plane privately from other AWS regions besides us-west-2
* Capitalizes the Temporal Cloud Control Plane, which is a standard thing that we should capitalize.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215313070655850">EDU-6456 Control Plane capitalization and connectivity</a>
