### PR TITLE
Document service account namespace permission behavior

### DIFF
--- a/docs/cloud/get-started/service-accounts.mdx
+++ b/docs/cloud/get-started/service-accounts.mdx
@@ -159,7 +159,15 @@ The Service Account is deleted when it is no longer visible in the output of the
 
 ### Update a Service Account {/* #update */}
 
-Update a Service Account's description using the Temporal Cloud UI or tcld.
+Update a Service Account using the Temporal Cloud UI or tcld.
+
+:::note Account roles and Namespace Permissions
+
+Service Accounts with the Account Owner or Global Admin account-level role automatically have Namespace Admin access to
+all Namespaces. Do not add explicit Namespace Permissions while using either role. To move a Service Account from Global
+Admin to a lower-privilege account role, update the Account Level Role and desired Namespace Permissions together.
+
+:::
 
 <Tabs groupId="service-account">
   <TabItem value="cloud-ui" label="Using the Cloud UI">


### PR DESCRIPTION
## Summary

Adds a note to the Service Account update docs explaining that Account Owner and Global Admin service accounts already have Namespace Admin access to all Namespaces.

The note also tells readers not to add explicit Namespace Permissions while using those account-level roles, and to update the Account Level Role and desired Namespace Permissions together when moving a Service Account to a lower-privilege role.

## Validation

- `npm run build`
- `git diff --check`

Vale was not run because there is no local `vale` binary in this checkout, and `npx vale docs/cloud/get-started/service-accounts.mdx` fails because npm has no package versions for `vale`.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215349209771024">EDU-6464 [codex] Document service account namespace permission behavior</a>
