### PR TITLE
chore(encyclopedia): removed outdated section with old repo link

### DIFF
--- a/docs/encyclopedia/data-conversion/key-management.mdx
+++ b/docs/encyclopedia/data-conversion/key-management.mdx
@@ -45,7 +45,3 @@ It is recommended that operators estimate the encryption rate of a key and use t
 Key rotation should generally be transparent to the Temporal Data Converter implementation. Temporal's `Encode()` and `Decode()` steps only need to trigger as expected, and Temporal has no knowledge of how or when you are generating your encryption keys.
 
 You should design your Encode and Decode steps to accept all the necessary parameters for your key management, such as the key version, alongside your payloads. Like the Data Converters, keys should be mapped to a Namespace in Temporal.
-
-### Using Vault for Key Management
-
-[This repository](https://github.com/zboralski/codecserver) provides a robust and complete example of using Temporal with HashiCorp's [Vault](https://www.vaultproject.io/) secrets engine.


### PR DESCRIPTION
## What does this PR do?

Removes the `Using Vault for Key Management` section from the Key management page based on a user report issue with the repo link. Since the repo no longer exists, this section is outdated.

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215396659953377">EDU-6465 chore(encyclopedia): removed outdated section with old repo link</a>
