### PR TITLE
Just some link updates in the footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -136,7 +136,7 @@ module.exports = async function createConfigAsync() {
               },
               {
                 label: 'Twitter',
-                href: 'https://twitter.com/temporalio',
+                href: 'https://x.com/temporalio',
               },
               {
                 label: 'YouTube',
@@ -144,7 +144,7 @@ module.exports = async function createConfigAsync() {
               },
               {
                 label: 'About the docs',
-                href: 'https://github.com/temporalio/documentation/blob/master/README.md',
+                href: 'https://github.com/temporalio/documentation/blob/main/README.md',
               },
             ],
           },
@@ -157,10 +157,6 @@ module.exports = async function createConfigAsync() {
               {
                 label: 'Meetups',
                 href: 'https://temporal.io/community#events',
-              },
-              {
-                label: 'Workshops',
-                href: 'https://temporal.io/community#workshops',
               },
               {
                 label: 'Support forum',
@@ -184,7 +180,7 @@ module.exports = async function createConfigAsync() {
               },
               {
                 label: 'Use cases',
-                href: 'https://temporal.io/use-cases',
+                href: 'https://temporal.io/in-use',
               },
               {
                 label: 'Newsletter signup',
@@ -200,11 +196,11 @@ module.exports = async function createConfigAsync() {
               },
               {
                 label: 'Privacy policy',
-                to: 'https://temporal.io/global-privacy-policy',
+                href: 'https://temporal.io/global-privacy-policy',
               },
               {
                 label: 'Terms of service',
-                href: 'https://docs.temporal.io/pdf/temporal-tos-2021-07-24.pdf',
+                href: 'https://temporal.io/terms-of-service',
               },
               {
                 label: "We're hiring",


### PR DESCRIPTION
## What does this PR do?
Just noticed the workshops link in the footer is dead, fixed our own "master" → "main" GitHub change, updated the terms of use link to match the main site. 

So, points terms of service at [Terms of Service](https://temporal.io/terms-of-service)
Removes workshops link, there's no heading/anchor for that on the community page
Fixes GitHub link from https://github.com/temporalio/documentation/blob/master/README.md to fix the branch name
Updates use cases link to avoid the redirect from /use-cases to /in-use (leaving the name as is, because I think it is a common term and will help discovery through multiple phrases)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215390960587759">EDU-6468 Just some link updates in the footer</a>
