### PR TITLE
Remove export metrics mention from monitor section

### DIFF
--- a/docs/cloud/export.mdx
+++ b/docs/cloud/export.mdx
@@ -176,10 +176,7 @@ is the time the export uploads to object storage, not the Workflow completion ti
    - Usage Dashboard:
       - Actions from the Export Job are included in the [Usage Dashboard](/cloud/actions-usage).
 
-3. **Metrics**:
-   - Export-related metrics are available from the [Cloud metrics endpoint](/cloud/metrics/), specifically the metric `temporal_cloud_v1_total_action_count` with the label `is_background="true"`.
-
-4. **Email**:
+3. **Email**:
    - Emails are sent to `Namespace Administrator`, `Account Owner`, and `Global Administrator` roles when a Workflow History Export job fails due to a user related error (such as Object Store permissions issue).
 
 ## Working with exported files


### PR DESCRIPTION
## Summary
- Removes the **Metrics** item from the "Monitor export progress" section in `docs/cloud/export.mdx`
- Renumbers the **Email** item accordingly
Context: 
https://temporalio.atlassian.net/servicedesk/customer/portal/274/ONCA-26
we don't have metrics support at this moment


🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215441276869687">EDU-6478 Remove export metrics mention from monitor section</a>
