### PR TITLE
ci: fix preview URL slug for branch names containing +

### DIFF
--- a/bin/preview-url-from-vercel.js
+++ b/bin/preview-url-from-vercel.js
@@ -9,6 +9,7 @@ function branchToSlug(branchName) {
   return branchName
     .toLowerCase()
     .replace(/_/g, '')
+    .replace(/\+/g, '')
     .replace(/[^a-z0-9]/g, '-')
     .replace(/-+/g, '-')
     .replace(/^-/, '')


### PR DESCRIPTION
## Summary
- Vercel strips `+` from branch names when generating preview subdomains, but `branchToSlug` was replacing `+` with `-`, producing mismatched URLs (e.g. `feat-integrations` instead of `featintegrations`).
- Added an explicit `.replace(/\+/g, '')` before the catch-all substitution so the generated URL matches what Vercel actually deploys.

## Test plan
- [ ] Verify that `branchToSlug('worktree-feat+integrations-grid')` produces `worktree-featintegrations-grid`
- [ ] Confirm preview links in PR comments match the actual Vercel deployment URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215515806345423">EDU-6497 Fix preview URL slug for branch names containing +</a>
