### PR TITLE
Add Text Search Attribute list-of-values migration path

### DIFF
--- a/docs/encyclopedia/visibility/search-attributes.mdx
+++ b/docs/encyclopedia/visibility/search-attributes.mdx
@@ -167,6 +167,7 @@ Note:
 
 Storing a list of values in any single-value Search Attribute type — for example, multiple strings in a **Keyword** or **Text** attribute, or multiple integers in an **Int** attribute — is deprecated.
 **KeywordList** is the only type designed to store a list of values.
+
 New namespaces on Temporal Cloud are already blocked from using this pattern. Existing Namespaces that rely on it will need to migrate before Sep. 30, 2026. After that date, Workflow Executions with invalid Search Attribute values will fail. 
 This pattern was unintended behavior inherited from the underlying Elasticsearch encoding, not a supported feature.
 

--- a/docs/encyclopedia/visibility/search-attributes.mdx
+++ b/docs/encyclopedia/visibility/search-attributes.mdx
@@ -165,12 +165,18 @@ Note:
 
 :::warning List-of-values deprecation for non-list types
 
-Storing a list of values in a non-list Search Attribute type (such as multiple strings in a **Keyword** attribute) is deprecated.  
+Storing a list of values in any single-value Search Attribute type — for example, multiple strings in a **Keyword** or **Text** attribute, or multiple integers in an **Int** attribute — is deprecated.
+**KeywordList** is the only type designed to store a list of values.
 New namespaces on Temporal Cloud are already blocked from using this pattern. Existing Namespaces that rely on it will need to migrate before Sep. 30, 2026. After that date, Workflow Executions with invalid Search Attribute values will fail. 
 This pattern was unintended behavior inherited from the underlying Elasticsearch encoding, not a supported feature.
 
-If you are currently storing lists in **Keyword** attributes, migrate to **KeywordList**.
-If you are storing lists in **Int** attributes, consider either migrating to **KeywordList** (storing integers as strings, with string-based comparison only) or splitting into multiple individual **Int** attributes.
+To migrate, choose the path that matches the type you store today:
+
+- **Keyword:** Migrate to **KeywordList**.
+- **Int:** Either migrate to **KeywordList** (store integers as strings, with string-based comparison only) or split the list into multiple individual **Int** attributes.
+- **Text:** Concatenate the list values into a single space-delimited string (for example, store `["wf-1", "wf-2"]` as `"wf-1 wf-2"`).
+  Because **Text** tokenizes values into words, a filter such as `SourceWorkflowIds = 'wf-1'` still matches.
+  If you only need exact matching rather than word-level search, migrate to **KeywordList** instead.
 
 
 :::


### PR DESCRIPTION
## Summary
Expands the existing list-of-values deprecation warning on the Search Attributes encyclopedia page to:
- Clarify that **KeywordList** is the only Search Attribute type designed to store a list of values.
- State that the deprecation applies to *all* single-value types (Keyword, Int, **and Text**), not just Keyword/Int.
- Add a migration recipe for **Text** attributes that currently store an array: concatenate into a space-delimited string to preserve word-level matching, or move to KeywordList for exact-match-only.

## Why
Strict type validation now rejects arrays stored in single-value Search Attribute types. The existing docs only covered Keyword and Int migrations, leaving Text users with no guidance — a gap surfaced by a customer whose Text attribute holding a string array began failing with `BadSearchAttributes`. Text users are especially affected because, unlike Keyword/Int, they can't be detected by scanning stored values.

## Checklist
- [x] Follows STYLE.md guidelines
- [x] Frontmatter unchanged (edit to existing page)
- [x] Links to related documentation (existing Text matching link retained)
- [x] No new pages, so sidebars.js unchanged
- [x] No new internal links introduced

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215539579537746">EDU-6503 Add Text Search Attribute list-of-values migration path</a>
