### PR TITLE
Fix link to certificate page, add link to API key page in manual migration doc

### DIFF
--- a/docs/cloud/migrate/manual.mdx
+++ b/docs/cloud/migrate/manual.mdx
@@ -39,7 +39,7 @@ To migrate your Workflows to Temporal Cloud, you need to change some parameters 
 The changes needed to direct your Workflow to your Temporal Cloud
 Namespace are only a few lines of code, including:
 
-- [Add your SSL certificate and private key](/cloud/saml) associated with your Namespace.
+- Add your [SSL certificate and private key](/cloud/certificates) or [API key](/cloud/api-keys) associated with your Namespace.
 - [Copy the Cloud-hosted endpoint](/cloud/namespaces#temporal-cloud-grpc-endpoint) from the Namespace detail Web page.
   The endpoint uses this format: `<namespace_id>.<account_id>.tmprl.cloud:port`.
 - [Connect to Temporal Cloud](/cloud/get-started) with your Client.


### PR DESCRIPTION
## What does this PR do?

Fix link to certificate page, add link to API key page in manual migration doc

## Notes to reviewers

The prior link to /cloud/saml was incorrect

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215562539138380">EDU-6505 Fix link to certificate page, add link to API key page in manual migration doc</a>
