### PR TITLE
Document that exports auto-disable after 5 consecutive days of failure

### DIFF
--- a/docs/cloud/export.mdx
+++ b/docs/cloud/export.mdx
@@ -181,7 +181,7 @@ is the time the export uploads to object storage, not the Workflow completion ti
 
 :::note
 
-An export configuration that fails for 5 consecutive days is automatically disabled.
+An export configuration that fails for 7 consecutive days is automatically disabled.
 
 :::
 

--- a/docs/cloud/export.mdx
+++ b/docs/cloud/export.mdx
@@ -179,6 +179,12 @@ is the time the export uploads to object storage, not the Workflow completion ti
 3. **Email**:
    - Emails are sent to `Namespace Administrator`, `Account Owner`, and `Global Administrator` roles when a Workflow History Export job fails due to a user related error (such as Object Store permissions issue).
 
+:::note
+
+An export configuration that fails for 5 consecutive days is automatically disabled.
+
+:::
+
 ## Working with exported files
 
 Use the proto schema defined [here](https://github.com/temporalio/api/blob/main/temporal/api/export/v1/message.proto) to deserialize exported files.


### PR DESCRIPTION
## What

Adds a note to the **Monitor export progress** section of the Cloud Export docs explaining that an export configuration which fails for 5 consecutive days is automatically disabled.

## Why

Users monitoring export health need to know that repeated failures will eventually disable the export, not just keep retrying indefinitely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215567669384386">EDU-6508 Document that exports auto-disable after 5 consecutive days of failure</a>
