### PR TITLE
Disable forwarding setting for Temporal Cloud HA

### DIFF
--- a/docs/cloud/high-availability/enable.mdx
+++ b/docs/cloud/high-availability/enable.mdx
@@ -1,9 +1,9 @@
 ---
 id: enable
-title: Enable High Availability
-sidebar_label: Enable High Availability
+title: Enable and manage High Availability
+sidebar_label: Enable and manage High Availability
 slug: /cloud/high-availability/enable
-description: Get started with HA features
+description: Add a replica to a Namespace to enable High Availability, then manage forwarding behavior and automatic failover settings.
 ---
 
 import { ToolTipTerm } from '@site/src/components';
@@ -126,6 +126,123 @@ Follow these steps to change the replica location:
 2. [Add a new replica](#upgrade) to your Namespace.
 
 You will receive an email alert once your Namespace is ready for use.
+
+## Change the forwarding behavior {/* #change-forwarding-behavior */}
+
+Requests that reach the passive replica can be [forwarded](/cloud/high-availability/#request-forwarding) to the active region, and responses sent back to the Worker or Client. The `disablePassivePollerForwarding` Namespace setting controls this behavior for Worker poll traffic.
+
+With `disablePassivePollerForwarding` enabled, Worker polls that reach a passive replica are not forwarded, and these Workers do not execute Workflows or Activities. Workers connected to such a passive replica receive a `NamespaceNotActive` error on poll requests. These Workers stay connected and will start executing Workflows and Activities if the replica becomes active.
+
+Client APIs (Start, Signal, Cancel, Terminate, Query, and the equivalent Activity APIs) are forwarded to the active region regardless of this setting, with responses sent back to the Client.
+
+Same-region replicas are not affected by this setting.
+
+:::info
+
+To see which endpoints route to which replica, see [How requests reach the replica](/cloud/high-availability/ha-connectivity#how-requests-reach-the-replica).
+
+:::
+
+`disablePassivePollerForwarding` can be set through the [Cloud Ops API](/ops), the [cloud-api SDK](https://github.com/temporalio/cloud-sdk-go), or the [`temporal cloud` CLI extension](/cli/cloud). Use one of the recipes below.
+
+### Set the forwarding behavior with the `temporal cloud` CLI {/* #set-forwarding-cli */}
+
+Use the [`temporal cloud namespace ha update`](/cli/command-reference/cloud/namespace#ha-update) command:
+
+```bash
+temporal cloud namespace ha update \
+    --namespace <namespace>.<account> \
+    --disable-passive-poller-forwarding true
+```
+
+Set the flag to `false` to re-enable forwarding.
+
+### Set the forwarding behavior with the Cloud Ops API {/* #set-forwarding-curl */}
+
+This recipe uses `curl` against the Cloud Ops API. Because `UpdateNamespace` replaces the entire Namespace spec, it fetches the current spec, merges in the new value, and posts it back with the current `resourceVersion`. The `jq` filter preserves any other High Availability fields you have set (such as `disableManagedFailover`).
+
+Set the Cloud Ops API key and Namespace ID. The Namespace ID is in `<namespace>.<account>` format (the full identifier shown in the Cloud Web UI):
+
+```bash
+export TEMPORAL_CLOUD_OPS_API_KEY='<your-api-key>'
+export NS='<namespace>.<account>'
+```
+
+Fetch the current spec:
+
+```bash
+curl -sS "https://saas-api.tmprl.cloud/cloud/namespaces/$NS" \
+  -H "Authorization: Bearer $TEMPORAL_CLOUD_OPS_API_KEY" > /tmp/ns.json
+```
+
+Build the update payload. Set the value to `true` to disable forwarding, or `false` to restore the default:
+
+```bash
+jq --arg rv "$(jq -r '.namespace.resourceVersion' /tmp/ns.json)" '{
+  spec: (.namespace.spec
+    | .highAvailability = ((.highAvailability // {}) + {disablePassivePollerForwarding: true})),
+  resourceVersion: $rv
+}' /tmp/ns.json > /tmp/ns-update.json
+```
+
+Post the update. The response contains an `asyncOperation` ID; the change is complete when `GET /cloud/operations/<id>` reports a terminal state.
+
+```bash
+curl -sS -X POST "https://saas-api.tmprl.cloud/cloud/namespaces/$NS" \
+  -H "Authorization: Bearer $TEMPORAL_CLOUD_OPS_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/ns-update.json
+```
+
+Verify the current value:
+
+```bash
+curl -sS "https://saas-api.tmprl.cloud/cloud/namespaces/$NS" \
+  -H "Authorization: Bearer $TEMPORAL_CLOUD_OPS_API_KEY" \
+  | jq '.namespace.spec.highAvailability.disablePassivePollerForwarding'
+```
+
+A result of `null` means the field has never been set, which is equivalent to `false` — proto3 JSON omits default-`false` values from responses.
+
+## Enable or disable automatic failovers {/* #automatic-failovers */}
+
+When a Temporal Cloud Namespace has a replica in a different region or cloud, Temporal Cloud automatically fails over the Namespace to its replica in the event of an outage. _This is the recommended and default option._
+
+If you prefer to disable automatic failovers and handle your own failovers, follow these instructions:
+
+:::warning Disabling automatic failovers voids Temporal's RTO
+
+With automatic failovers disabled, Temporal Cloud cannot fail your Namespace over to its replica during an outage. You take responsibility for detecting outages and [triggering a failover](/cloud/high-availability/failovers/manage#trigger-failover) yourself. Temporal's [20-minute RTO](/cloud/rpo-rto) does not apply while this setting is disabled.
+
+:::
+
+<Tabs>
+
+<TabItem value="webui" label="Web UI">
+
+1. Navigate to the Namespace detail page in Temporal Cloud.
+1. Choose the "Disable Temporal-initiated failovers" option.
+
+</TabItem>
+
+<TabItem value="tcldcli" label="tcld">
+
+To disable automatic failovers, run the following command in your terminal:
+
+```
+tcld namespace update-high-availability \
+    --namespace <namespace_id>.<account_id> \
+    --disable-auto-failover=true
+```
+
+If using API key authentication with the `--api-key` flag, you must add it directly after the tcld command and before
+`namespace update-high-availability`.
+
+</TabItem>
+
+</Tabs>
+
+To restore the default behavior, unselect the option in the Web UI or change `true` to `false` in the CLI command.
 
 ## Disable High Availability (remove a replica) {/* #disable */}
 

--- a/docs/cloud/high-availability/failovers/index.mdx
+++ b/docs/cloud/high-availability/failovers/index.mdx
@@ -24,19 +24,18 @@ When a Namespace with [High Availability](/cloud/high-availability) is disrupted
 over the Namespace from the primary to the replica. This lets in-flight Workflow Executions continue, new Workflow
 Executions start, and closed Workflow Executions be inspected, all with minimal interruptions or data loss.
 
-Returning control from the replica to the primary is called a <ToolTipTerm term="failback" />. After a Temporal-managed
+Returning control from the replica to the primary is called a <ToolTipTerm term="failback" />. After an automatic
 failover, Temporal automatically fails back to the original region once it is healthy, unless you
-[opt out](/cloud/high-availability/failovers/manage#after-a-temporal-managed-failover). See
+[opt out](/cloud/high-availability/failovers/manage#after-an-automatic-failover). See
 [Failbacks](/cloud/high-availability/failovers/manage#failbacks) for details.
 
 ## Automatic failover
 
 Temporal Cloud offers managed outage detection and failover to all Namespaces that use High Availability.
-Temporal-managed failovers, also known as "automatic failovers," keep your Namespace available without manual
-intervention. Temporal aims to both detect the outage and complete a failover in minutes from when the outage began,
+These automatic failovers keep your Namespace available without manual intervention. Temporal aims to both detect the outage and complete a failover in minutes from when the outage began,
 according to the stated [Recovery Time Objective (RTO)](/cloud/rpo-rto).
 
-After a Temporal-managed failover, the Namespace will have a replica in its original region. Once the original region is
+After an automatic failover, the Namespace will have a replica in its original region. Once the original region is
 healthy again, Temporal Cloud automatically performs a [failback](/cloud/high-availability/failovers/manage#failbacks),
 moving the Namespace back to its original region.
 
@@ -45,8 +44,8 @@ moving the Namespace back to its original region.
   title="On failover, the replica becomes active and the Namespace endpoint directs access to it."
 />
 
-To opt out of Temporal-managed failovers and their RTO, you can
-[disable automated failovers](/cloud/high-availability/failovers/manage#disabling-temporal-initiated).
+To opt out of automatic failovers and their RTO, you can
+[disable automatic failovers](/cloud/high-availability/enable#automatic-failovers).
 
 ### Conditions that trigger an automatic failover
 
@@ -65,7 +64,7 @@ regional outage.
 
 :::info
 
-The following list gives a general idea of the conditions that trigger a Temporal-managed failover. This is not an
+The following list gives a general idea of the conditions that trigger an automatic failover. This is not an
 exhaustive list, and it may change over time.
 
 :::
@@ -81,7 +80,7 @@ exhaustive list, and it may change over time.
 You can also [manually trigger a failover](/cloud/high-availability/failovers/manage#trigger-failover) based on your own
 monitoring or for failover testing.
 
-Most Namespaces with High Availability are well-served by Temporal-managed failovers. The cases where a manual failover
+Most Namespaces with High Availability are well-served by automatic failovers. The cases where a manual failover
 is warranted are:
 
 - **Testing failover or migrating to a new region.** A manual failover is the standard way to exercise your failover
@@ -89,7 +88,7 @@ is warranted are:
 - **An outage that affects only your systems.** If an outage is contained to your application, Workers, or other
   infrastructure, and Temporal Cloud is not affected, Temporal will not initiate a failover on your behalf. Detect the
   outage with your own monitoring and trigger a failover yourself.
-- **Failing over more aggressively during a regional outage.** Even with Temporal-managed failovers enabled, you can
+- **Failing over more aggressively during a regional outage.** Even with automatic failovers enabled, you can
   trigger a failover yourself if you detect a regional outage before Temporal does. Whichever failover happens first
   takes effect, and the later one is a no-op. A user-triggered failover does not conflict with Temporal's automatic
   failover.
@@ -124,7 +123,7 @@ The failover process is the same whether it is triggered automatically by Tempor
 
 After any failover, whether triggered by you or by Temporal, an event appears in both the [Temporal Cloud Web UI](https://cloud.temporal.io/namespaces) (on the Namespace detail page) and in your audit logs. The audit log entry uses the `"operation": "FailoverNamespace"` event. Temporal Cloud [notifies you via email](/cloud/notifications#admin-notifications) whenever a failover occurs.
 
-After a Temporal-managed failover, Temporal automatically fails back to the original region once the region is healthy, unless you [opt out](/cloud/high-availability/failovers/manage#after-a-temporal-managed-failover). After a user-triggered failover, the Namespace stays in the replica region until a user triggers another failover. See [failback options](/cloud/high-availability/failovers/manage#failbacks) for details.
+After an automatic failover, Temporal automatically fails back to the original region once the region is healthy, unless you [opt out](/cloud/high-availability/failovers/manage#after-an-automatic-failover). After a user-triggered failover, the Namespace stays in the replica region until a user triggers another failover. See [failback options](/cloud/high-availability/failovers/manage#failbacks) for details.
 
 ## Split-brain scenario
 

--- a/docs/cloud/high-availability/failovers/manage.mdx
+++ b/docs/cloud/high-availability/failovers/manage.mdx
@@ -131,82 +131,54 @@ on-call team is automatically paged to intervene and force the failover to compl
 
 Failback behavior depends on whether the failover was automatic or manually triggered.
 
-### After a Temporal-managed failover
+### After an automatic failover {/* #after-an-automatic-failover */}
 
-After a Temporal-managed failover, Temporal Cloud automatically fails back to the original region once the region is
+After an automatic failover, Temporal Cloud automatically fails back to the original region once the region is
 healthy. No action is required from you. Follow [Temporal's status page](https://status.temporal.io) for updates on the
 original region's health.
 
 If you prefer to manage failback yourself, you have two options:
 
 - **Opt out of automatic failback (manage failback manually):** After the automatic failover has completed,
-  [disable Temporal-managed failovers](#disabling-temporal-initiated) on the Namespace to prevent Temporal from
-  automatically failing back. When you're ready to return to the original region,
-  [trigger a failover](#trigger-failover) to that region and then re-enable Temporal-managed failovers.
+  [disable automatic failovers](/cloud/high-availability/enable#automatic-failovers) on the Namespace to prevent
+  Temporal from automatically failing back. When you're ready to return to the original region,
+  [trigger a failover](#trigger-failover) to that region and then re-enable automatic failovers.
 
 - **Stay on the new region permanently ("fail forward"):** After the automatic failover has completed,
   [trigger a failover](#trigger-failover) to the region that is already active. This tells Temporal that you want to
-  treat the new region as your primary for as long as it's healthy. Temporal-managed automatic failovers remain enabled,
+  treat the new region as your primary for as long as it's healthy. Automatic failovers remain enabled,
   so Temporal will still protect you if the new region has an outage.
 
 ### After a user-triggered failover
 
-If you triggered a failover yourself during an outage (instead of relying on a Temporal-managed failover), Temporal will
+If you triggered a failover yourself during an outage (instead of relying on an automatic failover), Temporal will
 _not_ automatically fail back for you. You must [trigger a failover](#trigger-failover) back to the original region when
 it is healthy. Monitor [Temporal's status page](https://status.temporal.io) for updates on region health.
 
-Automatic failback is only available after Temporal-managed (automatic) failovers.
+Automatic failback is only available when the most recent failover was automatic.
 
 ### How to check whether your Namespace will be automatically failed back
 
 If you are not sure whether your Namespace will be automatically failed back, check the list of failovers in the
 Temporal Cloud Web UI on your Namespace's detail page:
 
-- If the most recent failover was **Temporal-triggered**, then Temporal will automatically fail back the Namespace when
+- If the most recent failover was **automatic**, then Temporal will fail the Namespace back when
   the original region is healthy.
 - If the most recent failover was **user-triggered**, then the Namespace will _not_ be automatically failed back. You
   must trigger the failback yourself.
-
-## Disable Temporal-initiated failovers {/* #disabling-temporal-initiated */}
-
-When you add a replica to a Namespace, Temporal Cloud automatically fails over the Namespace to its replica in the event
-of an outage. _This is the recommended and default option._
-
-If you prefer to disable Temporal-initiated failovers and handle your own failovers, follow these instructions:
-
-<Tabs>
-
-<TabItem value="webui" label="Web UI">
-
-1. Navigate to the Namespace detail page in Temporal Cloud.
-1. Choose the "Disable Temporal-initiated failovers" option.
-
-</TabItem>
-
-<TabItem value="tcldcli" label="tcld">
-
-To disable Temporal-initiated failovers, run the following command in your terminal:
-
-```
-tcld namespace update-high-availability \
-    --namespace <namespace_id>.<account_id> \
-    --disable-auto-failover=true
-```
-
-If using API key authentication with the `--api-key` flag, you must add it directly after the tcld command and before
-`namespace update-high-availability`.
-
-</TabItem>
-
-</Tabs>
-
-To restore the default behavior, unselect the option in the Web UI or change `true` to `false` in the CLI command.
 
 ## Workers and failovers {/* #worker */}
 
 Enabling High Availability for Namespaces does not require specific Worker configuration. When a Namespace fails over to
 the replica, the DNS redirection orchestrated by Temporal ensures that your existing Workers continue to poll the
-Namespace without interruption.
+Namespace without interruption. Temporal Cloud forwards their requests from the passive replica to the active region and
+the responses back, so Workers keep running through a failover.
+
+To route Workers to the passive region's replica, see [How requests reach the replica](/cloud/high-availability/ha-connectivity#how-requests-reach-the-replica).
+
+To stop forwarding Worker polls to the active region, see [Change the forwarding behavior](/cloud/high-availability/enable#change-forwarding-behavior).
+
+To disable automatic failovers, see [Enable or disable automatic failovers](/cloud/high-availability/enable#automatic-failovers).
 
 When a Namespace fails over to a replica in a different region, Workers will be communicating cross-region.
 

--- a/docs/cloud/high-availability/ha-connectivity.mdx
+++ b/docs/cloud/high-availability/ha-connectivity.mdx
@@ -75,6 +75,24 @@ Consider a Namespace replicated across `us-east-1` (initially active) and `us-we
 The Namespace Endpoint moves with the active region via an updated CNAME — no Client changes required.
 The Regional Endpoints do not change their targets on failover: each continues to route to the replica that lives in its region.
 
+## How requests reach the replica {/* #how-requests-reach-the-replica */}
+
+A request can reach the passive replica in three ways:
+
+- **Through the passive region's Regional Endpoint.** A [Regional Endpoint](#regional-endpoint) is pinned to its region, so the Regional Endpoint of the region that currently holds the passive replica connects to the passive replica.
+- **Through a PrivateLink or Private Service Connect endpoint in the passive region.** A VPC Endpoint or PSC endpoint in the passive region routes to the passive replica.
+- **Through the Namespace Endpoint during a failover.** When a Namespace fails over, two things happen in parallel:
+  1. The replica becomes active, and the former active becomes a replica.
+  2. The Namespace Endpoint changes to point at the replica's region, and the Worker re-resolves the Namespace Endpoint to connect to the new active region via DNS.
+
+  If #1 completes before #2, a Worker that was connected to the former active before the failover will stay connected to it even after it becomes the replica. The Worker will change to point at the new active when the DNS changes propagate and the Client re-resolves DNS (typically 30 seconds, though up to 5 minutes, bounded by Temporal Cloud's maximum connection lifetime).
+
+By default, Temporal Cloud transparently forwards any request that reaches the passive replica to the active region, and the response back.
+
+To learn what forwarding does, see [Request forwarding](/cloud/high-availability/#request-forwarding).
+
+To stop forwarding Worker polls on a Namespace, see [Change the forwarding behavior](/cloud/high-availability/enable#change-forwarding-behavior).
+
 ## How to use PrivateLink with High Availability features
 
 :::tip

--- a/docs/cloud/high-availability/index.mdx
+++ b/docs/cloud/high-availability/index.mdx
@@ -3,7 +3,7 @@ id: index
 title: High Availability
 sidebar_label: High Availability
 slug: /cloud/high-availability
-description: Temporal Cloud's Namespace with High Availability features offers automated failover, synchronized data, and replication for workloads requiring disaster-tolerant deployment and 99.99% uptime.
+description: Temporal Cloud's Namespace with High Availability features offers automatic failover, synchronized data, and replication for workloads requiring disaster-tolerant deployment and 99.99% uptime.
 tags:
   - Temporal Cloud
   - Production
@@ -59,7 +59,7 @@ High Availability features extend Temporal Cloud's replication across regions an
 
 - **Real-time replication** — Temporal replicates your Namespace across distant regions or cloud providers with no performance impact to your Workers or Workflows.
 - **Automatic failover with 20-minute RTO** — Temporal manages failover with a 20-minute [RTO](/cloud/rpo-rto). You can also [trigger failover](/cloud/high-availability/failovers) manually at any time, for example for testing.
-- **Transparent DNS routing** — On failover, DNS reroutes your [Namespace Endpoint](/cloud/namespaces#access-namespaces) to the active region. Requests that reach the replica are forwarded to the active region automatically.
+- **Transparent DNS routing** — On failover, DNS reroutes your [Namespace Endpoint](/cloud/namespaces#access-namespaces) to the active region. [Requests that reach the replica are forwarded to the active region automatically](#request-forwarding).
 - **Sub-1-minute RPO** — In a failover during an outage, the [Recovery Point Objective](/cloud/rpo-rto) is under one minute.
 - **Real-time lag monitoring** — Monitor your Namespace's replication lag in real time to understand your current RPO.
 - **Conflict resolution** — If the two regions are not fully in sync at the time of failover, Temporal's conflict resolution process reconciles discrepancies and ensures data integrity.
@@ -92,6 +92,18 @@ For the highest level of reliability, distribute your dependencies across region
 Using physically separated regions improves the fault tolerance of your application.
 
 :::
+
+## Request forwarding {/* #request-forwarding */}
+
+A Namespace with High Availability features replicates across two regions, with one replica active and one passive at any moment. The active replica accepts reads and writes; the passive replica receives replicated state asynchronously and stands ready for failover.
+
+When a request reaches the passive replica — for example, through the passive region's Regional Endpoint — Temporal Cloud forwards the request transparently to the active replica and the response back to the Worker. This allows Workers and Clients to connect to the passive region during healthy times, and when an outage hits, start processing Workflows immediately after a failover.
+
+Forwarding adds a cross-region hop, so requests that travel through the passive replica complete with higher average latency than requests that reach the active replica directly.
+
+To route Workers to the passive region's replica, see [How requests reach the replica](/cloud/high-availability/ha-connectivity#how-requests-reach-the-replica).
+
+To disable passive region replica forwarding, see [Change the forwarding behavior](/cloud/high-availability/enable#change-forwarding-behavior).
 
 ## Service levels and recovery objectives
 

--- a/docs/cloud/rto-rpo.mdx
+++ b/docs/cloud/rto-rpo.mdx
@@ -38,9 +38,9 @@ features the Namespace has enabled.
 ## RTO and RPO summary
 
 The following table summarizes the RTO and RPO targets for each type of outage. These targets apply to Namespaces that
-have Temporal-initiated failovers enabled, which is the default. Temporal-initiated failovers are triggered by
+have automatic failovers enabled, which is the default. Automatic failovers are triggered by
 Temporal's tooling and on-call engineers without user action. Users can always initiate a failover independently. In an
-outage, a user-initiated failover will not cancel out or reverse a Temporal-initiated failover.
+outage, a user-initiated failover will not cancel out or reverse an automatic failover.
 
 These targets are for unplanned cloud outages and do not apply to user-initiated failovers during healthy periods, such
 as DR drills. Read about [triggering a failover](/cloud/high-availability/failovers/manage#trigger-failover) to see how a Namespace failover
@@ -55,7 +55,7 @@ performs during healthy periods.
 
 :::tip
 
-Temporal highly recommends keeping Temporal-initiated failovers enabled. When Temporal-initiated failovers are
+Temporal highly recommends keeping automatic failovers enabled. When automatic failovers are
 _disabled,_ Temporal Cloud cannot set an RPO and RTO for that Namespace, because it cannot control when or if the user
 will trigger a failover.
 
@@ -112,7 +112,7 @@ that case, Namespaces in the region may be impacted, including those using
 
 When an AZ fails, Temporal may also trigger a failover on Namespaces that have High Availability enabled, as a
 precaution in case the outage scope expands. You can opt out of this behavior by
-[disabling Temporal-managed failovers](/cloud/high-availability/failovers/manage#disabling-temporal-initiated) on the Namespace.
+[disabling automatic failovers](/cloud/high-availability/enable#automatic-failovers) on the Namespace.
 
 :::
 
@@ -151,7 +151,7 @@ Namespaces in real-world incidents.
 
 #### RTO and RPO
 
-When using Same-region Replication, Multi-region Replication, or Multi-cloud Replication for Temporal-managed failover:
+When using Same-region Replication, Multi-region Replication, or Multi-cloud Replication for automatic failover:
 
 - **RTO under 20 minutes.** Temporal detects the disruption and fails the Namespace over to its replica cell.
 - **RPO under 1 minute.** Asynchronous replication keeps the replica close to the active cell.
@@ -171,7 +171,7 @@ fail over and continue serving Workflows. Same-region Replication does not prote
 the replica resides in the same region.
 
 **SLA inclusion:** Included in the [SLA](/cloud/sla) calculation only for Namespaces that have Multi-region Replication
-or Multi-cloud Replication enabled with Temporal-managed failovers — in those cases, Temporal can mitigate the outage.
+or Multi-cloud Replication enabled with automatic failovers — in those cases, Temporal can mitigate the outage.
 For Namespaces without these features, a Cloud Region outage is excluded from the SLA calculation, as it is beyond
 Temporal's control to mitigate.
 
@@ -184,7 +184,7 @@ Temporal Cloud's regional failover kept customer Namespaces running.
 
 #### RTO and RPO
 
-When using Multi-region Replication or Multi-cloud Replication for Temporal-managed failover:
+When using Multi-region Replication or Multi-cloud Replication for automatic failover:
 
 - **RTO under 20 minutes.** Temporal detects the regional disruption and fails the Namespace over to its replica in
   another region.
@@ -209,7 +209,7 @@ is potentially affected.
 entirely, so the Namespace can fail over even when an entire cloud provider goes down.
 
 **SLA inclusion:** Included in the [SLA](/cloud/sla) calculation only for Namespaces that have Multi-cloud Replication
-enabled with Temporal-managed failovers — in those cases, Temporal can mitigate the outage. For Namespaces without this
+enabled with automatic failovers — in those cases, Temporal can mitigate the outage. For Namespaces without this
 feature, a cloud-wide outage is excluded from the SLA calculation, as it is beyond Temporal's control to mitigate.
 
 Cloud-wide outages are the rarest category, but they
@@ -218,7 +218,7 @@ keep Namespaces running through such events.
 
 #### RTO and RPO
 
-When using Multi-cloud Replication for Temporal-managed failover:
+When using Multi-cloud Replication for automatic failover:
 
 - **RTO under 20 minutes.** Temporal detects the cloud-wide disruption and fails the Namespace over to its replica in a
   different cloud provider.
@@ -271,11 +271,11 @@ failing over any other regional dependencies your application relies on, such as
 
 To achieve the lowest possible recovery times, Temporal recommends that you:
 
-- Keep Temporal-initiated failovers enabled on your Namespace (the default)
+- Keep automatic failovers enabled on your Namespace (the default)
 - Invest in a process to detect outages and trigger a manual failover.
 
-You can trigger manual failovers on your Namespaces even if Temporal-initiated failovers are enabled. There are several
-benefits to combining a manual failover process with Temporal-initiated failovers:
+You can trigger manual failovers on your Namespaces even if automatic failovers are enabled. There are several
+benefits to combining a manual failover process with automatic failovers:
 
 - You can detect outages that Temporal doesn't. In the cloud, regional outages don't affect all services equally. It's
   possible that Temporal--and the services it depends on--are unaffected by the outage, even while your Workers or other
@@ -294,7 +294,7 @@ benefits to combining a manual failover process with Temporal-initiated failover
   that fails over more eagerly than Temporal does. For example, you could trigger a manual failover at the first sign of
   a possible disruption, before knowing whether there's a true regional outage.
 
-- Even if you have robust tooling to detect an outage and trigger a failover, leaving Temporal-initiated failovers
+- Even if you have robust tooling to detect an outage and trigger a failover, leaving automatic failovers
   enabled provides a "safety net" in case your automation misses an outage. It also gives Temporal leeway to
   preemptively fail over your Namespace if we detect that it may be disrupted soon, e.g., by a rolling failure that has
   impacted other Namespaces but not yours, yet.
@@ -310,7 +310,7 @@ and apply in different situations.
 | How is it measured?               | The achieved recovery time is measured in terms of minutes per outage.                                                                                                                                                                                       | The achieved service error rate is measured in terms of error rate per month.                                                                                                                                                                                                                                                                                                                                                                                                  |
 | How is the calculation performed? | The achieved recovery time in a given outage is the total time between when a disruption to a Namespace began and when the Namespace was restored to full functionality, either after a failover to a healthy region or after the outage has been mitigated. | Temporal measures the percentage of requests to Temporal Cloud that fail, and applies a [formula](/cloud/sla) to get the final percentage for the month.                                                                                                                                                                                                                                                                                                                       |
 | Do partial degradations count?    | Most outages contain periods of **partial degradation** where some percentage of Namespace operations fail while the rest complete as normal. When they disrupt a Namespace, periods of partial degradation count in the calculation of the recovery time.   | Partial degradations only partially count for the service error rate calculation. A 5-minute window with a 10% error rate would count less than a 5-minute window with a 100% error rate.                                                                                                                                                                                                                                                                                      |
-| What is excluded?                 | For partial degradations, what counts as a disruption to a Namespace is subject to Temporal's expert judgment, but a good rule of thumb is a service error rate >=10%.                                                                                       | We exclude outages that are out of Temporal's control to mitigate, e.g., a failure of the underlying cloud provider infrastructure that affects a Namespace without High Availability and Temporal-initiated failovers enabled. If a Namespace has the relevant High Availability feature and has Temporal-initiated failovers enabled, then Temporal can act to mitigate the outage and it does usually count against the SLA. Full exclusions on the [SLA page](/cloud/sla). |
+| What is excluded?                 | For partial degradations, what counts as a disruption to a Namespace is subject to Temporal's expert judgment, but a good rule of thumb is a service error rate >=10%.                                                                                       | We exclude outages that are out of Temporal's control to mitigate, e.g., a failure of the underlying cloud provider infrastructure that affects a Namespace without High Availability and automatic failovers enabled. If a Namespace has the relevant High Availability feature and has automatic failovers enabled, then Temporal can act to mitigate the outage and it does usually count against the SLA. Full exclusions on the [SLA page](/cloud/sla). |
 
 The following examples illustrate the RTO and SLA calculations for different types of outages in a regional outage. These
 hypothetical Namespaces are based on actual Temporal Cloud performance in a


### PR DESCRIPTION
## What does this PR do?

1. Document a new setting for HA: `disablePassivePollerForwarding` which disables forwarding behavior
2. Polish / clarify how forwarding behavior works in HA
3. Change a few straggling instances of "Temporal-managed failover" -> "automatic failover"

## Notes to reviewers

Some internal context:
* https://app.notion.com/p/temporalio/Launch-Readiness-New-Namespace-Config-for-Active-Hot-Standby-HA-2fb8fc5677388021b320cda6f04d0325?source=copy_link
* https://app.notion.com/p/temporalio/docs-Active-Hot-Standby-Setting-36d8fc567738804da9a4d819142e209b?source=copy_link

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215605597451003">EDU-6514 Disable forwarding setting for Temporal Cloud HA</a>
