### PR TITLE
Moved TypeScript Standalone Activities to Public Preview

### DIFF
--- a/docs/develop/typescript/activities/standalone-activities.mdx
+++ b/docs/develop/typescript/activities/standalone-activities.mdx
@@ -22,7 +22,7 @@ description: Execute Activities independently without a Workflow using the Tempo
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
 Temporal TypeScript SDK support for [Standalone Activities](/standalone-activity) is at
-[Pre-release](/evaluate/development-production-features/release-stages#pre-release).
+[Public Preview](/evaluate/development-production-features/release-stages#public-preview).
 
 :::
 


### PR DESCRIPTION
## What does this PR do?
As of [TypeScript SDK v1.18.0](https://github.com/temporalio/sdk-typescript/releases/tag/v1.18.0), Standalone Activities are in Public Preview.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215634376202652">EDU-6521 Moved TypeScript Standalone Activities to Public Preview</a>
