### PR TITLE
Add env variable reference as subpage of environment configuration

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -1076,7 +1076,18 @@ module.exports = {
             },
           ],
         },
-        'develop/environment-configuration',
+        {
+          type: 'category',
+          label: 'Environment configuration',
+          collapsed: true,
+          link: {
+            type: 'doc',
+            id: 'develop/environment-configuration',
+          },
+          items: [
+            'references/client-environment-configuration',
+          ],
+        },
         'develop/activity-retry-simulator',
         'develop/worker-performance',
         'develop/worker-tuning-reference',


### PR DESCRIPTION
## Summary
- Add the environment configuration variable reference page as a child of the Environment configuration page in the sidebar
- The reference page remains in the References section as well

## Test plan
- [ ] Preview sidebar navigation shows the reference page nested under Environment configuration
- [x] `npm run build` passes

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215641856781412">EDU-6524 Add env variable reference as subpage of environment configuration</a>
