### PR TITLE
Update Standalone Activities release stage to Public Preview

### DIFF
--- a/docs/develop/ruby/activities/standalone-activities.mdx
+++ b/docs/develop/ruby/activities/standalone-activities.mdx
@@ -19,12 +19,9 @@ tags:
 description: Execute Activities independently without a Workflow using the Temporal Ruby SDK.
 ---
 
-:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
+import { ReleaseNoteHeader } from '@site/src/components';
 
-Temporal Ruby SDK support for [Standalone Activities](/standalone-activity) is at
-[Pre-release](/evaluate/development-production-features/release-stages#pre-release).
-
-:::
+<ReleaseNoteHeader featureName="standaloneActivity" />
 
 Standalone Activities are Activities that run independently, without being orchestrated by a
 Workflow. Instead of starting an Activity from within a Workflow Definition, you start a Standalone

--- a/docs/encyclopedia/activities/standalone-activity.mdx
+++ b/docs/encyclopedia/activities/standalone-activity.mdx
@@ -21,9 +21,9 @@ import { ReleaseNoteHeader } from '@site/src/components';
 
 <ReleaseNoteHeader
   featureName="standaloneActivity"
-  languages={["Go", "Python", "Java", ".NET", "TypeScript"]}
+  languages={["Go", "Python", "Java", ".NET", "TypeScript", "Ruby"]}
 >
-  Available in in [Temporal Cloud](#temporal-cloud-support) and in the [Temporal CLI](#temporal-cli-support) v1.7.0 or higher with Temporal Server v1.31.0 or higher.
+  Available in [Temporal Cloud](#temporal-cloud-support) and in the [Temporal CLI](#temporal-cli-support) v1.7.0 or higher with Temporal Server v1.31.0 or higher. Java SDK support is in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
 </ReleaseNoteHeader>
 
 See [limitations](#public-preview-limitations) below.

--- a/src/constants/featureReleaseTypes.js
+++ b/src/constants/featureReleaseTypes.js
@@ -1,6 +1,6 @@
 export const FEATURE_RELEASE_TYPES = {
   cloudCli: "prerelease",
-  standaloneActivity: "prerelease",
+  standaloneActivity: "publicPreview",
   nexus: "publicPreview",
   workflowStreams: "publicPreview",
   serverlessWorkers: "prerelease",


### PR DESCRIPTION
## Summary

- Change `standaloneActivity` from `prerelease` to `publicPreview` in `featureReleaseTypes.js`, updating Go, Python, TypeScript, .NET, and Ruby SDK pages.
- Java SDK page is unaffected — it uses a hardcoded `type="prerelease"` prop.
- Replace the `:::tip` admonition on the Ruby standalone activities page with the `ReleaseNoteHeader` component.
- Add Ruby to the encyclopedia page language list and note that Java SDK support is still in Pre-release.
- Fix "in in" typo on the encyclopedia page.

## Test plan

- [x] Preview Go, Python, TypeScript, .NET, Ruby standalone activities pages show "Public Preview"
- [x] Preview Java standalone activities page still shows "Pre-release"
- [x] Preview encyclopedia standalone activity page shows "Public Preview" with Java pre-release note

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215643795822007">EDU-6526 Update Standalone Activities release stage to Public Preview</a>
