### PR TITLE
fix: hide expand caret for integration pages when no children are present; use release stage header for integrations

### DIFF
--- a/docs/develop/java/integrations/spring-ai.mdx
+++ b/docs/develop/java/integrations/spring-ai.mdx
@@ -19,18 +19,15 @@ tags:
 description: Build durable AI agents in Java with the Temporal Spring AI integration.
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 [Spring AI](https://docs.spring.io/spring-ai/reference/) is an agent framework for Java applications — chat clients, tool calling, vector stores, embeddings, and MCP servers, all wired through Spring Boot. 
 
 The [Temporal Spring AI integration](https://central.sonatype.com/artifact/io.temporal/temporal-spring-ai) makes Spring AI agents durable: model calls run through Temporal Activities recorded in Event history, and tools are dispatched per their type so each kind lands in the right place in Workflow execution — Activity stubs and Nexus stubs as durable operations, `@SideEffectTool` classes wrapped in `Workflow.sideEffect`, and plain tools running directly in Workflow code. Agents retry on failure and replay deterministically without changing how you write Spring AI code.
 
 The integration is built on the Temporal Java SDK's [Plugin system](/develop/plugins-guide) and is distributed as the `io.temporal:temporal-spring-ai` module alongside the existing [Spring Boot integration](/develop/java/integrations/spring-boot-integration).
 
-:::info
-
-The Spring AI Integration is in Public Preview. Refer to the
-[Temporal product release stages guide](/evaluate/development-production-features/release-stages) for more information.
-
-:::
+<ReleaseNoteHeader type="publicPreview" />
 
 ## Prerequisites
 

--- a/docs/develop/java/integrations/spring-boot.mdx
+++ b/docs/develop/java/integrations/spring-boot.mdx
@@ -1,7 +1,7 @@
 ---
 id: spring-boot
 title: Spring Boot integration - Java SDK
-sidebar_label: Spring Boot integration
+sidebar_label: Spring Boot
 slug: /develop/java/integrations/spring-boot-integration
 toc_max_heading_level: 2
 keywords:

--- a/docs/develop/python/integrations/braintrust.mdx
+++ b/docs/develop/python/integrations/braintrust.mdx
@@ -18,6 +18,8 @@ description:
   Add LLM observability and prompt management to Python Workflows using the Temporal Python SDK and Braintrust.
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 Temporal's integration with [Braintrust](https://braintrust.dev) gives you full observability into your AI agent
 Workflows—tracing every LLM call, managing prompts without code deploys, and tracking costs across models.
 
@@ -28,13 +30,7 @@ iterate on prompts in a UI, and measure whether changes improve outcomes.
 The integration connects these capabilities with minimal code changes. Every Workflow and Activity becomes a span in
 Braintrust, and every LLM call is traced with inputs, outputs, tokens, and latency.
 
-:::info
-
-The Temporal Python SDK integration with Braintrust is currently in
-[Public Preview](/evaluate/development-production-features/release-stages#public-preview). Refer to the
-[Temporal product release stages guide](/evaluate/development-production-features/release-stages) for more information.
-
-:::
+<ReleaseNoteHeader type="publicPreview" />
 
 All code snippets in this guide are taken from the
 [deep research sample](https://github.com/braintrustdata/braintrust-cookbook/blob/main/examples/TemporalDeepResearch/TemporalDeepResearch.mdx). Refer to the sample for the

--- a/docs/develop/python/integrations/langgraph.mdx
+++ b/docs/develop/python/integrations/langgraph.mdx
@@ -18,6 +18,8 @@ description:
   Run LangGraph AI agent workflows with durable execution using the Temporal Python SDK and LangGraph plugin.
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 Temporal's integration with [LangGraph](https://www.langchain.com/langgraph) gives your LangGraph AI agent workflows
 durable execution, automatic retries, and timeouts via the Temporal platform.
 
@@ -26,12 +28,7 @@ The plugin supports both the LangGraph **Graph API** (`StateGraph` with nodes an
 directly inside the Workflow — Activity nodes get configurable timeouts and retry policies, while Workflow nodes run
 inline and must be deterministic.
 
-:::info
-
-The Temporal Python SDK integration with LangGraph is currently at an experimental release stage. The API may change in
-future versions.
-
-:::
+<ReleaseNoteHeader type="prerelease" />
 
 Code snippets in this guide are taken from the
 [LangGraph plugin samples](https://github.com/temporalio/samples-python/tree/main/langgraph_plugin). Refer to the

--- a/docs/develop/python/integrations/strands-agents.mdx
+++ b/docs/develop/python/integrations/strands-agents.mdx
@@ -17,17 +17,14 @@ tags:
 description: Run Strands Agents AI workflows with durable execution using the Temporal Python SDK and Strands plugin.
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 Temporal's integration with [Strands Agents](https://strandsagents.com/) is an [SDK Plugin](/develop/plugins-guide) that
 gives your Strands agents [Durable Execution](/temporal#durable-execution) via the Temporal platform. The plugin routes
 model invocations, tool calls, MCP tool calls, and hooks through Temporal Activities, so every step your agent takes is
 recorded in Workflow history and can survive crashes, restarts, and infrastructure failures.
 
-:::info
-
-The Temporal Python SDK integration with Strands Agents is currently at an experimental release stage. The API may
-change in future versions.
-
-:::
+<ReleaseNoteHeader type="publicPreview" />
 
 Code snippets in this guide are taken from the
 [Strands Agents plugin samples](https://github.com/temporalio/samples-python/tree/main/strands_plugin). Refer to the

--- a/docs/develop/ruby/integrations/rails-integration.mdx
+++ b/docs/develop/ruby/integrations/rails-integration.mdx
@@ -1,7 +1,7 @@
 ---
 id: rails-integration
 title: Rails integration - Ruby SDK
-sidebar_label: Rails integration
+sidebar_label: Rails
 description: Use the Temporal Ruby SDK with Ruby on Rails, including conventions for ActiveRecord, ActiveModel, and handling lazy/eager loading.
 keywords:
   - rails

--- a/docs/develop/typescript/integrations/ai-sdk.mdx
+++ b/docs/develop/typescript/integrations/ai-sdk.mdx
@@ -1,7 +1,7 @@
 ---
 id: ai-sdk
 title: AI SDK by Vercel integration
-sidebar_label: AI SDK by Vercel integration
+sidebar_label: AI SDK by Vercel
 toc_max_heading_level: 2
 keywords:
   - ai

--- a/docs/develop/typescript/integrations/ai-sdk.mdx
+++ b/docs/develop/typescript/integrations/ai-sdk.mdx
@@ -14,6 +14,8 @@ tags:
 description: Implement AI applications in TypeScript using the Temporal TypeScript SDK and the AI SDK.
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 Temporal's integration with [Vercel's AI SDK](https://ai-sdk.dev/) lets you use the AI SDK's API directly in Workflow
 code while Temporal handles Durable Execution.
 
@@ -27,12 +29,7 @@ All code snippets in this guide are taken from the TypeScript SDK
 [ai-sdk samples](https://github.com/temporalio/samples-typescript/tree/main/ai-sdk). Refer to the samples for the
 complete code and run them locally.
 
-:::info
-
-The Vercel AI SDK Integration is in Public Preview. Refer to the
-[Temporal product release stages guide](/evaluate/development-production-features/release-stages) for more information.
-
-:::
+<ReleaseNoteHeader type="publicPreview" />
 
 ## Prerequisites
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -1376,11 +1376,19 @@ code {
   width: 40px;
 }
 
-/* Hide integration sidebar children unless the current page is one of them */
+/* Hide integration sidebar children and caret unless a child page is active */
 .sidebar-integrations > .menu__list > .menu__list-item {
   display: none;
 }
 
 .sidebar-integrations > .menu__list > .menu__list-item:has(.menu__link--active) {
   display: block;
+}
+
+.sidebar-integrations > .menu__list-item-collapsible > .menu__caret {
+  display: none;
+}
+
+.sidebar-integrations:has(.menu__list > .menu__list-item .menu__link--active) > .menu__list-item-collapsible > .menu__caret {
+  display: flex;
 }


### PR DESCRIPTION
## Summary
- Fixes an issue where the integration parent page shows a non-functional expand logo. 
- Replace ad-hoc `:::info` and `:::tip` admonitions with the `ReleaseNoteHeader` component on 5 integration guide pages for consistent release stage presentation.
- Update Strands Agents from experimental to Public Preview.

### Pages updated

| Page | Previous | Now |
|---|---|---|
| Spring AI (Java) | `:::info` Public Preview | `<ReleaseNoteHeader type="publicPreview" />` |
| Braintrust (Python) | `:::info` Public Preview | `<ReleaseNoteHeader type="publicPreview" />` |
| AI SDK (TypeScript) | `:::info` Public Preview | `<ReleaseNoteHeader type="publicPreview" />` |
| Strands Agents (Python) | `:::info` experimental | `<ReleaseNoteHeader type="publicPreview" />` |
| LangGraph (Python) | `:::info` experimental | `<ReleaseNoteHeader type="prerelease" />` |

LangSmith was already updated on main and is not included in this PR.

## Test plan
- [ ] Verify each page renders the ReleaseNoteHeader banner in both light and dark mode
- [ ] Confirm the release stage link in the pill navigates to the correct anchor on the release stages page
- [ ] Check that Strands Agents shows "Public Preview" instead of "experimental"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215738157892842">EDU-6544 Use ReleaseNoteHeader component for integration release stages</a>
