### PR TITLE
Update Grafana Cloud OpenMetrics integration steps

### DIFF
--- a/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
@@ -52,16 +52,18 @@ If you only ingest Cloud metrics, you will miss many worker-side bottlenecks. Fo
 
 ### Grafana Cloud
 
-Grafana Cloud provides a serverless integration with the OpenMetrics endpoint. It scrapes metrics, stores them in Grafana Cloud, and ships a default dashboard for visualizing them.
+Grafana Cloud provides a serverless integration that scrapes the OpenMetrics endpoint, stores metrics in Grafana Cloud, and ships a prebuilt **Temporal overview** dashboard.
 
-1. In Grafana Cloud, go to **Connections → Add new connection** and search for **Temporal Cloud**.
-2. On the integration page, paste your Temporal Cloud API key into the **API Key** field.
-3. Add `metrics.temporal.io` to **Allowed hosts** so Grafana Cloud can reach the endpoint.
-4. Click **Install** to enable the integration and import the pre-built dashboard.
+1. In Grafana Cloud, go to **Connections** and select the **Temporal Cloud** tile.
+2. On the **Configuration** page, add a scrape job: give it a name, paste your Temporal Cloud API key, and set the scrape interval (default 1 minute - lower intervals increase data points per minute and cost).
+3. Click **Test Connection** to verify authentication, then **Save** to start collecting metrics.
+4. Click **Install** to deploy the prebuilt dashboards.
+
+Add a separate scrape job per account to monitor multiple accounts from one Grafana Cloud instance.
 
 If the dashboard shows no data after a few minutes, confirm the API key's Service Account has the **Metrics Read-Only** role and that the endpoint is reachable using the `curl` check from the [Quickstart](/cloud/metrics/openmetrics#quickstart).
 
-For Grafana-side details, see the [Grafana Cloud integration page](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-temporal/).
+For full configuration, dashboards, and changelog, see the [Grafana Cloud integration page](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-temporal/).
 
 ### ClickStack
 


### PR DESCRIPTION
## What

Updates the **Grafana Cloud** section in `docs/cloud/metrics/openmetrics/metrics-integrations.mdx` to match the partner's [integration reference](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-temporal/).

## Why

The existing steps didn't reflect Grafana Cloud's actual flow. Notably, the "Add `metrics.temporal.io` to Allowed hosts" step does not exist in the partner docs.

## Changes

- Replace the old connection flow with the real **scrape-job** configuration (name, API key, scrape interval, Test Connection, Save).
- Drop the incorrect "Allowed hosts" step.
- Note the scrape interval default (1 minute) and its DPM/cost implication.
- Add the per-account scrape-job pattern for monitoring multiple accounts.
- Name the prebuilt **Temporal overview** dashboard.
- Keep instructions summary-level with a pointer to the Grafana page for full config, dashboards, and changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215770840736289">EDU-6551 Update Grafana Cloud OpenMetrics integration steps</a>
