### PR TITLE
Fix old examples that used Regional endpoint -> Namespace endpoint

### DIFF
--- a/docs/cli/command-reference/config.mdx
+++ b/docs/cli/command-reference/config.mdx
@@ -88,7 +88,7 @@ Assign a value to a property and store it in the config file:
 ```
 temporal config set \
     --prop address \
-    --value us-west-2.aws.api.temporal.io:7233
+    --value your-namespace.a1b2c.tmprl.cloud:7233
 ```
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.

--- a/docs/cloud/get-started/api-keys.mdx
+++ b/docs/cloud/get-started/api-keys.mdx
@@ -372,11 +372,11 @@ your shell (recommended). The CLI automatically picks up the `TEMPORAL_API_KEY` 
 
 In addition to the API key, the following client options are required:
 
-- `--address`: Provide the Namespace's gRPC endpoint from the Namespace UI's gRPC endpoint box.
-  - For API key connections, use the format `<region>.<cloud_provider>.api.temporal.io:7233`.
+- `--address`: Provide `<namespace>.<account_id>.tmprl.cloud:7233` using your Namespace's info.
+  - This can be copied from the Namespace UI's "Connect" box. 
   - You can set the address using an environment variable.
-- `--namespace`: Provide the `namespace.accountId` from the top of the Namespace page in the UI.
-  - Use the format `<namespace_id>.<account_id>`.
+- `--namespace`: Provide `<namespace>.<account_id>` using your Namespace's info.
+  - This can be copied from the top of the Namespace UI.
   - This can be set using an environment variable.
 
 For example, to connect to Temporal Cloud from the CLI using an environment variable for the API key:
@@ -384,8 +384,8 @@ For example, to connect to Temporal Cloud from the CLI using an environment vari
 ```bash
 export TEMPORAL_API_KEY=<key-secret>
 temporal workflow list \
-    --address <endpoint> \
-    --namespace <namespace_id>.<account_id>
+    --address <namespace>.<account_id>.tmprl.cloud:7233 \
+    --namespace <namespace>.<account_id>
 ```
 
 :::tip ENVIRONMENT VARIABLES

--- a/docs/develop/dotnet/activities/standalone-activities.mdx
+++ b/docs/develop/dotnet/activities/standalone-activities.mdx
@@ -448,7 +448,7 @@ export TEMPORAL_TLS_CLIENT_KEY_PATH='path/to/your/client.key'
 Set these environment variables with values from your Temporal Cloud API key settings:
 
 ```
-export TEMPORAL_ADDRESS=<region>.<cloud_provider>.api.temporal.io:7233
+export TEMPORAL_ADDRESS=<your-namespace>.<your-account-id>.tmprl.cloud:7233
 export TEMPORAL_NAMESPACE=<your-namespace>.<your-account-id>
 export TEMPORAL_API_KEY=<your-api-key>
 ```

--- a/docs/develop/environment-configuration.mdx
+++ b/docs/develop/environment-configuration.mdx
@@ -125,7 +125,7 @@ temporal config set --prop address --value "localhost:7233"
 temporal config set --prop namespace --value "default"
 
 # Configure a Temporal Cloud profile that authenticates with an API key
-temporal --profile prod config set --prop address --value "<region>.<cloud_provider>.api.temporal.io:7233"
+temporal --profile prod config set --prop address --value "<namespace_id>.<account_id>.tmprl.cloud:7233"
 temporal --profile prod config set --prop namespace --value "<namespace_id>.<account_id>"
 temporal --profile prod config set --prop api_key --value "<your-api-key>"
 ```
@@ -137,7 +137,7 @@ This example shows how to set up a more advanced Temporal Cloud profile with TLS
 
 ```bash
 # Base API key properties (replace the placeholders)
-temporal --profile prod config set --prop address --value "<region>.<cloud_provider>.api.temporal.io:7233"
+temporal --profile prod config set --prop address --value "<namespace_id>.<account_id>.tmprl.cloud:7233"
 temporal --profile prod config set --prop namespace --value "<namespace_id>.<account_id>"
 temporal --profile prod config set --prop api_key --value "<your-api-key>"
 

--- a/docs/develop/go/activities/standalone-activities.mdx
+++ b/docs/develop/go/activities/standalone-activities.mdx
@@ -431,7 +431,7 @@ export TEMPORAL_TLS_CLIENT_KEY_PATH='path/to/your/client.key'
 Set these environment variables with values from your Temporal Cloud API key settings:
 
 ```
-export TEMPORAL_ADDRESS=<region>.<cloud_provider>.api.temporal.io:7233
+export TEMPORAL_ADDRESS=<your-namespace>.<your-account-id>.tmprl.cloud:7233
 export TEMPORAL_NAMESPACE=<your-namespace>.<your-account-id>
 export TEMPORAL_API_KEY=<your-api-key>
 ```

--- a/docs/develop/go/nexus/feature-guide.mdx
+++ b/docs/develop/go/nexus/feature-guide.mdx
@@ -679,7 +679,7 @@ Run the handler Worker:
 cd handler
 
 go run ./worker \
-  -target-host <region>.<cloud_provider>.api.temporal.io:7233 \
+  -target-host <your-target-namespace.account>.tmprl.cloud:7233 \
   -namespace <your-target-namespace.account> \
   -api-key <your-api-key>
 ```
@@ -690,7 +690,7 @@ Run the caller Worker:
 cd caller
 
 go run ./worker \
-  -target-host <region>.<cloud_provider>.api.temporal.io:7233 \
+  -target-host <your-caller-namespace.account>.tmprl.cloud:7233 \
   -namespace <your-caller-namespace.account> \
   -api-key <your-api-key>
 ```
@@ -701,7 +701,7 @@ go run ./worker \
 cd caller
 
 go run ./starter \
-  -target-host <region>.<cloud_provider>.api.temporal.io:7233 \
+  -target-host <your-caller-namespace.account>.tmprl.cloud:7233 \
   -namespace <your-caller-namespace.account> \
   -api-key <your-api-key>
 ```

--- a/docs/develop/java/activities/standalone-activities.mdx
+++ b/docs/develop/java/activities/standalone-activities.mdx
@@ -433,7 +433,7 @@ export TEMPORAL_TLS_CLIENT_KEY_PATH='path/to/your/client.key'
 Set these environment variables with values from your Temporal Cloud API key settings:
 
 ```
-export TEMPORAL_ADDRESS=<region>.<cloud_provider>.api.temporal.io:7233
+export TEMPORAL_ADDRESS=<your-namespace>.<your-account-id>.tmprl.cloud:7233
 export TEMPORAL_NAMESPACE=<your-namespace>.<your-account-id>
 export TEMPORAL_API_KEY=<your-api-key>
 ```

--- a/docs/develop/python/activities/standalone-activities.mdx
+++ b/docs/develop/python/activities/standalone-activities.mdx
@@ -462,7 +462,7 @@ export TEMPORAL_TLS_CLIENT_KEY_PATH='path/to/your/client.key'
 Set these environment variables with values from your Temporal Cloud API key settings:
 
 ```
-export TEMPORAL_ADDRESS=<region>.<cloud_provider>.api.temporal.io:7233
+export TEMPORAL_ADDRESS=<your-namespace>.<your-account-id>.tmprl.cloud:7233
 export TEMPORAL_NAMESPACE=<your-namespace>.<your-account-id>
 export TEMPORAL_API_KEY=<your-api-key>
 ```

--- a/docs/develop/ruby/activities/standalone-activities.mdx
+++ b/docs/develop/ruby/activities/standalone-activities.mdx
@@ -396,7 +396,7 @@ export TEMPORAL_TLS_CLIENT_KEY_PATH='path/to/your/client.key'
 Set these environment variables with values from your Temporal Cloud API key settings:
 
 ```
-export TEMPORAL_ADDRESS=<region>.<cloud_provider>.api.temporal.io:7233
+export TEMPORAL_ADDRESS=<your-namespace>.<your-account-id>.tmprl.cloud:7233
 export TEMPORAL_NAMESPACE=<your-namespace>.<your-account-id>
 export TEMPORAL_API_KEY=<your-api-key>
 ```

--- a/docs/develop/typescript/activities/standalone-activities.mdx
+++ b/docs/develop/typescript/activities/standalone-activities.mdx
@@ -428,7 +428,7 @@ export TEMPORAL_TLS_CLIENT_KEY_PATH='path/to/your/client.key'
 Set these environment variables with values from your Temporal Cloud API key settings:
 
 ```
-export TEMPORAL_ADDRESS=<region>.<cloud_provider>.api.temporal.io:7233
+export TEMPORAL_ADDRESS=<your-namespace>.<your-account-id>.tmprl.cloud:7233
 export TEMPORAL_NAMESPACE=<your-namespace>.<your-account-id>
 export TEMPORAL_API_KEY=<your-api-key>
 ```


### PR DESCRIPTION
## What does this PR do?

* Namespace Endpoint is now the recommended endpoint, especially for beginners. (It works for both API Keys and mTLS.)
* Some examples used the Regional Endpoint; this fixes them to use the Namespace endpoint, which provides a better user experience.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215785644951118">EDU-6555 Fix old instance of regional endpoint</a>
