### PR TITLE
Add Workflow Streams documentation for the Go SDK

### DIFF
--- a/docs/develop/go/index.mdx
+++ b/docs/develop/go/index.mdx
@@ -46,6 +46,7 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 - [Timers](/develop/go/workflows/timers)
 - [Dynamic Workflow](/develop/go/workflows/dynamic-workflow)
 - [Versioning](/develop/go/workflows/versioning)
+- [Workflow Streams](/develop/go/workflows/workflow-streams)
 
 ## [Activities](/develop/go/activities)
 

--- a/docs/develop/go/workflows/index.mdx
+++ b/docs/develop/go/workflows/index.mdx
@@ -29,3 +29,4 @@ import * as Components from '@site/src/components';
 - [Timers](/develop/go/workflows/timers)
 - [Dynamic Workflow](/develop/go/workflows/dynamic-workflow)
 - [Versioning](/develop/go/workflows/versioning)
+- [Workflow Streams](/develop/go/workflows/workflow-streams)

--- a/docs/develop/go/workflows/workflow-streams.mdx
+++ b/docs/develop/go/workflows/workflow-streams.mdx
@@ -62,7 +62,6 @@ func OrderWorkflow(ctx workflow.Context, input OrderInput) error {
 		return err
 	}
 	// ... rest of the workflow
-	_ = stream
 	return nil
 }
 ```
@@ -510,7 +509,6 @@ func ChatWorkflow(ctx workflow.Context, input ChatInput) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	_ = stream
 
 	subscriberDone := false
 	ackCh := workflow.GetSignalChannel(ctx, "subscriber-acknowledged-terminator")

--- a/docs/develop/go/workflows/workflow-streams.mdx
+++ b/docs/develop/go/workflows/workflow-streams.mdx
@@ -598,4 +598,3 @@ A few choices in this shape are deliberate:
 - [Workflow Streams samples (samples-go)](https://github.com/temporalio/samples-go/tree/main/workflowstreams): runnable scenarios covering basic publish/subscribe, reconnecting subscribers, external publishers, bounded logs, and LLM streaming.
 - [`workflowstreams` API reference](https://pkg.go.dev/go.temporal.io/sdk/contrib/workflowstreams).
 - [Workflow message passing](/develop/go/workflows/message-passing): Signals, Updates, and Queries that Workflow Streams is built on.
-</content>

--- a/docs/develop/go/workflows/workflow-streams.mdx
+++ b/docs/develop/go/workflows/workflow-streams.mdx
@@ -1,0 +1,601 @@
+---
+id: workflow-streams
+title: Workflow Streams - Go SDK
+sidebar_label: Workflow Streams
+toc_max_heading_level: 4
+keywords:
+  - workflow streams
+  - streaming
+  - signals
+  - updates
+  - queries
+  - go sdk
+tags:
+  - Workflows
+  - Messages
+  - Streaming
+  - Go SDK
+  - Temporal SDKs
+description: Stream events from a Workflow to subscribers using the Temporal Go SDK Workflow Streams contrib module.
+---
+
+import { ReleaseNoteHeader } from '@site/src/components';
+
+<ReleaseNoteHeader featureName="workflowStreams" />
+
+**Workflow Streams** is a Temporal Go SDK `contrib` library that gives a Workflow a durable, offset-addressed event channel built on Temporal's basic message primitives: Signals, Updates, and Queries.
+It batch-publishes events to amortize per-Signal cost, deduplicates batches for exactly-once delivery to the log, supports topic filtering, and carries state across Continue-As-New for long-running streams.
+
+Use [Workflow Streams](/workflow-streams) when you want outside observers to follow the progress of a Workflow and its Activities: updating a UI as an AI agent works, surfacing status from a payment or order pipeline, or reporting intermediate results from a data job. It is not suited to ultra-low-latency cases like real-time voice, and it targets modest fan-out: tens of publishers and subscribers per Workflow, not thousands.
+
+The Workflow hosts the event log. Publishers append events — the Workflow itself, Activities, or external processes via `Client`. Subscribers attach to the Workflow Id, optionally filter by **topic** (a string label set when publishing; topics are implicit and created on first publish), and consume events by long-polling from an offset they store.
+
+**Looking for...**
+
+- [Enabling streaming on a Workflow](#enable-streaming-on-a-workflow)
+- [Publishing from a Workflow](#publish-from-a-workflow)
+- [Publishing from a client](#publish-from-a-client)
+- [Subscribing to a stream](#subscribe)
+- [Continue-As-New](#continue-as-new)
+- [Deduplication window settings](#deduplication-window)
+- [Best practices](#best-practices)
+- [An example of streaming LLM output](#stream-llm-output)
+
+## Enable streaming on a Workflow
+
+The library ships as `go.temporal.io/sdk/contrib/workflowstreams`. Enable streaming by constructing a `WorkflowStream` once at the top of your Workflow function, before any blocking call. Construction must happen there because the stream's handlers have to be registered before the first publish Signal arrives. Doing it after a blocking call would miss any publishes that arrived before the run body resumed.
+
+```go
+import (
+	"go.temporal.io/sdk/contrib/workflowstreams"
+	"go.temporal.io/sdk/workflow"
+)
+
+type OrderInput struct {
+	OrderID     string
+	StreamState *workflowstreams.WorkflowStreamState
+}
+
+func OrderWorkflow(ctx workflow.Context, input OrderInput) error {
+	stream, err := workflowstreams.NewWorkflowStream(ctx, input.StreamState)
+	if err != nil {
+		return err
+	}
+	// ... rest of the workflow
+	_ = stream
+	return nil
+}
+```
+
+`NewWorkflowStream` creates the in-memory event log and registers the publish Signal, subscribe Update, and offset Query handlers on the current Workflow. The `priorState` argument is `nil` on a fresh start and a `*WorkflowStreamState` after a Continue-As-New rollover (see [Continue-As-New](#continue-as-new)).
+
+Construct exactly one `WorkflowStream` per Workflow. The constructor re-registers the handlers unconditionally on every call, so constructing more than one on the same Workflow registers duplicate handlers. The Go SDK doesn't expose an inspection API for existing handlers, so the library can't raise an exception on a duplicate the way the Python SDK does.
+
+## Publish from a Workflow
+
+Bind a [topic name](/workflow-streams#topics) with `stream.Topic(name)`, then call `Publish()` on the returned `*WorkflowTopicHandle` to append events. Repeated calls with the same name return the same handle.
+
+```go
+type StatusEvent struct {
+	State    string
+	Progress int
+	Detail   string
+}
+
+func OrderWorkflow(ctx workflow.Context, input OrderInput) error {
+	stream, err := workflowstreams.NewWorkflowStream(ctx, input.StreamState)
+	if err != nil {
+		return err
+	}
+	status := stream.Topic("status")
+
+	if err := status.Publish(StatusEvent{State: "validating", Detail: "checking inventory"}); err != nil {
+		return err
+	}
+	if err := workflow.ExecuteActivity(ctx, ValidateOrder, input.OrderID).Get(ctx, nil); err != nil {
+		return err
+	}
+
+	if err := status.Publish(StatusEvent{State: "charging", Progress: 33, Detail: "authorizing payment"}); err != nil {
+		return err
+	}
+	if err := workflow.ExecuteActivity(ctx, ChargePayment, input.OrderID).Get(ctx, nil); err != nil {
+		return err
+	}
+
+	if err := status.Publish(StatusEvent{State: "shipping", Progress: 66, Detail: "dispatching to warehouse"}); err != nil {
+		return err
+	}
+	if err := workflow.ExecuteActivity(ctx, DispatchOrder, input.OrderID).Get(ctx, nil); err != nil {
+		return err
+	}
+
+	return status.Publish(StatusEvent{State: "completed", Progress: 100})
+}
+```
+
+`Publish()` runs the payload converter to encode each value. The codec chain (encryption, compression, etc.) runs once on the Signal or Update envelope that carries the batch, never per item, so encryption and compression are applied exactly once each direction.
+
+Unlike the Python and TypeScript SDKs, Go topics carry no per-topic type binding. A topic handle is bound only to a name; published values are `any` and subscribers decode each item from its raw payload (see [Subscribe](#subscribe)). To customize per-item serialization, pass `workflowstreams.WithPayloadConverters(...)` to `NewWorkflowStream`, and use the matching converters on the subscriber side.
+
+## Publish from a client
+
+Any process that has a Temporal Client and the target Workflow Id can publish to that Workflow's stream by constructing a `Client`. This is the general pattern and covers HTTP backends, starters, one-off scripts, other Workflows' Activities, and standalone Activities.
+
+Construct one with:
+
+```go
+workflowstreams.NewClient(temporalClient, workflowID, workflowstreams.Options{})
+```
+
+Then use it the same way you would the Workflow-side handle: bind a topic, publish through it, and `defer client.Close(ctx)` to flush on scope exit.
+
+When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state — see [Delivery semantics](/workflow-streams#delivery-semantics).
+
+```go
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/contrib/workflowstreams"
+)
+
+func PublishStatus(ctx context.Context, temporalClient client.Client, workflowID string) error {
+	streamClient := workflowstreams.NewClient(temporalClient, workflowID, workflowstreams.Options{
+		BatchInterval: 200 * time.Millisecond,
+	})
+	defer streamClient.Close(ctx)
+
+	status := streamClient.Topic("status")
+	status.Publish(StatusEvent{State: "started"}, false)
+	// ...
+	// Buffer is flushed automatically on Close.
+	return nil
+}
+```
+
+Inside an Activity scheduled by a Workflow, `workflowstreams.NewClientFromActivity()` infers the Temporal Client and the parent Workflow Id from the Activity context, so you don't have to thread them through the Activity's input:
+
+```go
+import (
+	"context"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/contrib/workflowstreams"
+)
+
+type Delta struct {
+	Text string
+}
+
+func StreamDeltas(ctx context.Context, orderID string) error {
+	streamClient, err := workflowstreams.NewClientFromActivity(ctx, workflowstreams.Options{})
+	if err != nil {
+		return err
+	}
+	defer streamClient.Close(ctx)
+
+	deltas := streamClient.Topic("delta")
+	for delta := range generateDeltas(orderID) {
+		deltas.Publish(delta, false)
+		activity.RecordHeartbeat(ctx)
+	}
+	// Buffer is flushed automatically on Close.
+	return nil
+}
+```
+
+For a [standalone Activity](/develop/go/activities) (one started directly via the Client rather than from a Workflow), there is no parent Workflow context to infer, so `NewClientFromActivity()` returns an error. Fall back to the general pattern with `activity.GetClient(ctx)` and the target Workflow Id threaded through the Activity's input.
+
+Two operations give the application explicit control over when batches ship: the `forceFlush` argument on a publish for latency, and `client.Flush(ctx)` for confirmation that prior publications have landed.
+
+Pass `true` as the `forceFlush` argument on a publish to wake the background flusher so the current buffer ships without waiting for the next interval. The flusher only runs while the client is open (between construction and `Close`). The call returns immediately after appending to the buffer and signaling the flusher. It doesn't wait for delivery to the Workflow or to subscribers:
+
+```go
+deltas.Publish(delta, true)
+```
+
+Use it for latency-sensitive events: the first delta of a response so the user sees something fast, or punctuated events like `RETRY` and `STATUS_CHANGE`. See [Tuning](/workflow-streams#tuning) for the trade-off against history pressure.
+
+Use `client.Flush(ctx)` when you need a mid-stream barrier. Successful completion of the flush is proof that the Temporal server has received all prior publications, so subsequent work that depends on those events being durable can proceed. The client stays open for further publishing afterward. `Close` already flushes on its way out, so the explicit call is only for barriers in the middle:
+
+```go
+streamClient := workflowstreams.NewClient(temporalClient, workflowID, workflowstreams.Options{})
+defer streamClient.Close(ctx)
+deltas := streamClient.Topic("delta")
+
+for _, delta := range firstPhase() {
+	deltas.Publish(delta, false)
+}
+
+if err := streamClient.Flush(ctx); err != nil {
+	return err
+}
+checkpointID, err := recordPhaseOneComplete(ctx) // only safe once phase-one events are durable
+if err != nil {
+	return err
+}
+
+for _, delta := range secondPhase(checkpointID) {
+	deltas.Publish(delta, false)
+}
+```
+
+`Publish()` is non-blocking and applies no backpressure. From an Activity or other client, it appends to the client's in-memory buffer and returns. From inside a Workflow, it appends synchronously to the in-memory log. [Subscribers](/workflow-streams#subscribing) pull from the Workflow's log on their own schedule, so a slow subscriber doesn't slow down [publishers](/workflow-streams#publishing). If a publisher emits faster than batches can ship to the server, the buffer grows: the process uses more memory, the stream falls further behind real time, and at the limit Signals can't keep up.
+
+If your application needs to bound this (to cap memory, to keep the stream close to real time, or to apply a policy when the publisher overruns the network), apply that policy upstream of `Publish()`. The choice (block, drop, error, sample) is application-specific, and Workflow Streams doesn't pick one for you.
+
+## Subscribe
+
+[Subscribing](/workflow-streams#subscribing) uses the same client construction as publishing: `workflowstreams.NewClient(temporalClient, workflowID, opts)` from any process that has a Temporal Client, or `NewClientFromActivity()` inside an Activity. Subscribing from an Activity is less common in practice, so the general client case is the primary example below.
+
+Once you have a client, range over `client.Subscribe()`, the counterpart to `Publish()`. It returns an [`iter.Seq2`](https://pkg.go.dev/iter#Seq2) iterator that yields a `WorkflowStreamItem` and an error on each step. Each item's `Data` is the raw payload; decode it at the call site with a payload converter.
+
+```go
+import (
+	"context"
+	"fmt"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/contrib/workflowstreams"
+	"go.temporal.io/sdk/converter"
+)
+
+func WatchOrder(ctx context.Context, temporalClient client.Client, orderID string) error {
+	stream := workflowstreams.NewClient(temporalClient, orderID, workflowstreams.Options{})
+
+	for item, err := range stream.Subscribe(ctx, workflowstreams.SubscribeOptions{Topics: []string{"status"}}) {
+		if err != nil {
+			return err
+		}
+		var evt StatusEvent
+		if err := converter.GetDefaultDataConverter().FromPayload(item.Data, &evt); err != nil {
+			return err
+		}
+		fmt.Printf("[%3d%%] %s: %s\n", evt.Progress, evt.State, evt.Detail)
+		if evt.State == "completed" {
+			break
+		}
+	}
+	return nil
+}
+```
+
+`SubscribeOptions` controls the subscription: `Topics` filters by name (empty or nil means all topics), `FromOffset` resumes from a stored global offset (zero means the beginning), and `PollCooldown` sets the minimum interval between polls. The iterator handles re-polling, pagination when a poll response hits the ~1 MB cap, and Workflow-side log truncation transparently. A single-topic convenience method, `streamClient.Topic("status").Subscribe(ctx, fromOffset)`, is equivalent to passing one name in `Topics`.
+
+A subscriber doesn't need `Close()` because the background flusher only runs for publishers.
+
+### Heterogeneous topics
+
+Every item arrives as a raw `*commonpb.Payload` in `item.Data`, so a single subscription naturally consumes multiple topics whose payload types differ. Pass the topic names in `SubscribeOptions.Topics` (or leave it empty for every topic on the stream), dispatch on `item.Topic`, and decode into the matching type:
+
+```go
+for item, err := range stream.Subscribe(ctx, workflowstreams.SubscribeOptions{Topics: []string{"status", "progress"}}) {
+	if err != nil {
+		return err
+	}
+	switch item.Topic {
+	case "status":
+		var evt StatusEvent
+		if err := converter.GetDefaultDataConverter().FromPayload(item.Data, &evt); err != nil {
+			return err
+		}
+		fmt.Printf("[status] %s: %s\n", evt.State, evt.Detail)
+	case "progress":
+		var evt ProgressEvent
+		if err := converter.GetDefaultDataConverter().FromPayload(item.Data, &evt); err != nil {
+			return err
+		}
+		fmt.Printf("[progress] %s\n", evt.Message)
+	}
+}
+```
+
+A single iterator over multiple topics also avoids the cancellation race that two concurrent subscribers would create. Because `item.Data` is the raw payload, it's also the right shape when you want to forward the bytes through to another system without decoding them.
+
+### Closing the stream {/* #closing-the-stream */}
+
+A subscriber's `for ... range` doesn't know when the publisher is done. How you [close a stream](/workflow-streams#closing-the-stream) depends on what the application needs. As one example, a common pattern combines two pieces:
+
+1. **An in-band terminator.** The Workflow or its Activity publishes a sentinel event the subscriber recognizes and breaks on. In the `WatchOrder` example above, `StatusEvent{State: "completed"}` is the minimal form, and the consumer's `if evt.State == "completed" { break }` is the matching half. Each subscription decides what its own end-of-stream marker is.
+2. **A brief overlap before the Workflow returns.** A poll Update that is still in flight when the Workflow returns is surfaced to the iterator and consumed silently, and no new polls can complete after that. If the Workflow returns immediately after publishing the terminator, subscribers may miss it.
+
+There are two ways to provide that overlap.
+
+- [Fixed sleep](/workflow-streams#fixed-sleep). Sleep between the terminator and the return so any in-flight poll has time to fetch the terminator before the Workflow exits:
+
+  ```go
+  // at the end of the workflow function
+  if err := status.Publish(StatusEvent{State: "completed", Progress: 100}); err != nil {
+  	return err
+  }
+  if err := workflow.Sleep(ctx, 30*time.Second); err != nil {
+  	return err
+  }
+  return nil
+  ```
+- [Acknowledgment handshake](/workflow-streams#acknowledgment-handshake). The subscriber sends a Signal once it has the terminator; the Workflow waits up to a timeout, returning as soon as the ack arrives:
+
+  ```go
+  func ChatWorkflow(ctx workflow.Context, input ChatInput) (string, error) {
+  	stream, err := workflowstreams.NewWorkflowStream(ctx, input.StreamState)
+  	if err != nil {
+  		return "", err
+  	}
+
+  	subscriberDone := false
+  	ackCh := workflow.GetSignalChannel(ctx, "subscriber-acknowledged-terminator")
+  	workflow.Go(ctx, func(ctx workflow.Context) {
+  		ackCh.Receive(ctx, nil)
+  		subscriberDone = true
+  	})
+
+  	// ... do work and publish events ...
+
+  	// Returns true if the ack arrived, false on timeout — either way, fall through.
+  	_, _ = workflow.AwaitWithTimeout(ctx, 30*time.Second, func() bool { return subscriberDone })
+  	return result, nil
+  }
+  ```
+
+The full pattern is wired into the [Stream LLM output](#stream-llm-output) example below.
+
+You can [inspect the terminal status](/workflow-streams#inspecting-terminal-status). `Subscribe()` ends cleanly when the Workflow reaches `COMPLETED`, `FAILED`, `CANCELED`, `TERMINATED`, or `TIMED_OUT`, but doesn't distinguish among them. If your application needs to know which (to display success or failure to the user, log the outcome, or decide whether to retry), call `temporalClient.DescribeWorkflowExecution(ctx, workflowID, "")` after the loop returns to inspect the Workflow's status.
+
+## Continue-As-New {/* #continue-as-new */}
+
+[Continue-As-New](/workflow-streams#continue-as-new) following requires the client retained from `NewClient()` or `NewClientFromActivity()`, which re-target the Workflow Id across runs.
+
+To roll a long-running streaming Workflow over without subscribers seeing a gap, carry both your application state and the stream state across the boundary. Add a `*WorkflowStreamState` field to your Workflow input, pass it to `NewWorkflowStream`, and return `stream.NewContinueAsNewError(ctx, wfn, buildArgs)` to invoke the rollover. The helper drains waiting subscribers, waits for in-flight handlers to finish, then returns a Continue-As-New error built from the args produced by `buildArgs(postDrainState)`:
+
+```go
+type WorkflowInput struct {
+	ItemsProcessed int
+	StreamState    *workflowstreams.WorkflowStreamState
+}
+
+func LongRunningWorkflow(ctx workflow.Context, input WorkflowInput) error {
+	stream, err := workflowstreams.NewWorkflowStream(ctx, input.StreamState)
+	if err != nil {
+		return err
+	}
+	itemsProcessed := input.ItemsProcessed
+
+	for {
+		if err := doOneIteration(ctx, stream); err != nil {
+			return err
+		}
+		itemsProcessed++
+
+		if workflow.GetInfo(ctx).GetContinueAsNewSuggested() {
+			return stream.NewContinueAsNewError(ctx, LongRunningWorkflow, func(state *workflowstreams.WorkflowStreamState) []any {
+				return []any{WorkflowInput{
+					ItemsProcessed: itemsProcessed,
+					StreamState:    state,
+				}}
+			})
+		}
+	}
+}
+```
+
+The `*WorkflowStreamState` field is `nil` on a fresh start and a populated snapshot after a rollover. The `buildArgs` callback receives the post-detach `*WorkflowStreamState` as its only argument, so the snapshot is guaranteed to happen *after* pollers detach.
+
+To pass other Continue-As-New parameters such as a different task queue, or to use a custom publisher TTL, use the explicit recipe instead. Drain the pollers, wait for handlers to finish, snapshot the state with your chosen TTL, then build the Continue-As-New error yourself (set options such as the task queue on the context first):
+
+```go
+stream.DetachPollers()
+_ = workflow.Await(ctx, func() bool { return workflow.AllHandlersFinished(ctx) })
+state, err := stream.GetState(30 * time.Minute) // custom publisher TTL
+if err != nil {
+	return err
+}
+ctx = workflow.WithWorkflowTaskQueue(ctx, "other-tq")
+return workflow.NewContinueAsNewError(ctx, LongRunningWorkflow, WorkflowInput{
+	ItemsProcessed: itemsProcessed,
+	StreamState:    state,
+})
+```
+
+The carried `WorkflowStreamState` includes the entire in-memory log of the previous run, so streams that carry large items can hit Temporal's per-payload size limit at the rollover. Offload the bytes via [External Storage](/external-storage) so each item is a small reference rather than the full payload, and combine that with `stream.Truncate(upToOffset)` to keep the carried log itself small.
+
+## Deduplication window
+
+See [Delivery Semantics](/workflow-streams#delivery-semantics) for more details on subscriber and publisher behavior. See [Tuning](/workflow-streams#tuning) for more details on how to change your settings to meet the requirements for your Workflow Streams.
+
+There are two limits on the [deduplication window](/workflow-streams#deduplication-window) worth highlighting:
+
+- **Publisher TTL.** At each Continue-As-New, deduplicate entries whose last-seen time is older than this are dropped. The last-seen time is updated on each *successful* publish (not on each retry attempt), so a publisher that retries through a long partition without success can still age out. A publisher that returns after a longer pause may produce a duplicate. `stream.NewContinueAsNewError(...)` snapshots with a 15-minute default; to tune it, use the explicit recipe above and pass your value to `GetState(publisherTTL)`.
+- **`MaxRetryDuration`.** A `Client` retries a failed batch for up to this long (default 10 minutes). If the duration elapses with the batch still pending, the client gives up, the pending batch is dropped, and a `FlushTimeoutError` is raised.
+
+  ```go
+  workflowstreams.NewClient(temporalClient, workflowID, workflowstreams.Options{
+  	MaxRetryDuration: 10 * time.Minute,
+  })
+  ```
+
+  On timeout, the dropped batch is at-most-once: it may or may not have reached the Workflow. One operational caveat: the `FlushTimeoutError` is raised from inside the background flusher and terminates it. Until you call `client.Flush(ctx)` or `client.Close(ctx)`, subsequent publishes accumulate in the buffer with no flusher to ship them. `MaxRetryDuration` must be less than the workflow's publisher TTL to preserve exactly-once delivery.
+
+## Best practices
+
+There are a few details to note if you're writing custom message handlers or testing the library's capabilities:
+
+- **Construct exactly one `WorkflowStream` per Workflow.** The constructor re-registers the publish Signal, poll Update, and offset Query handlers on every call, so a second construction registers duplicate handlers. Construct it once at the top of the Workflow function.
+- **`item.Data` is always the raw payload.** Decode it with a converter built from the same `PayloadConverters` used by the publisher. When publishers and subscribers both rely on the defaults, `converter.GetDefaultDataConverter()` matches on both sides. If you pass `WithPayloadConverters` on the Workflow side, build a matching `converter.NewCompositeDataConverter(...)` on the subscriber side.
+- **The codec chain runs once on the envelope.** Payload codecs (encryption, compression) configured on the Temporal client run on the Signal or Update envelope that carries each batch, never per item, so items are never double-encoded. `PayloadConverters` handle only per-item serialization.
+- **The client publish path isn't goroutine-safe.** The client buffer is mutated on the publish path and read from the background flusher. Don't call `Publish()` on the same `Client` from multiple goroutines without coordinating; route events to a single owner.
+
+## Example: Stream LLM output {/* #stream-llm-output */}
+
+The headline use case fits the publish/subscribe shapes documented above. An Activity calls the model and publishes deltas as they arrive. The Workflow starts the Activity and waits for the consumer to acknowledge end-of-stream. The consumer subscribes, accumulates the deltas, and clears its accumulated state on `RETRY` before continuing. The shape works for a terminal client, a desktop UI, or a Server-Sent Events (SSE) endpoint forwarding to a browser. Anything that holds the displayed state calls `render()` to display it.
+
+If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [Delivery semantics](/workflow-streams#delivery-semantics) for the precise guarantees.
+
+```go
+// activity.go
+package main
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/contrib/workflowstreams"
+)
+
+type TextDelta struct {
+	Text string
+}
+
+type RetryEvent struct {
+	Attempt int32
+}
+
+func StreamCompletion(ctx context.Context, prompt string) (string, error) {
+	attempt := activity.GetInfo(ctx).Attempt
+	streamClient, err := workflowstreams.NewClientFromActivity(ctx, workflowstreams.Options{
+		BatchInterval: 200 * time.Millisecond,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer streamClient.Close(ctx)
+
+	deltas := streamClient.Topic("delta")
+	retry := streamClient.Topic("retry")
+	closeTopic := streamClient.Topic("close")
+
+	// Tell consumers an earlier attempt's deltas are stale.
+	if attempt > 1 {
+		retry.Publish(RetryEvent{Attempt: attempt}, true)
+	}
+
+	var full []string
+	first := true
+	// generateDeltas wraps the model call and yields tokens as they arrive.
+	// Disable provider-side retries; let Temporal own retry policy at the Activity layer.
+	for token := range generateDeltas(prompt) {
+		// forceFlush only on the first delta so the user sees something
+		// immediately; subsequent deltas batch at the 200 ms interval.
+		deltas.Publish(TextDelta{Text: token}, first)
+		first = false
+		full = append(full, token)
+	}
+	closeTopic.Publish(struct{}{}, false)
+	return strings.Join(full, ""), nil
+}
+```
+
+```go
+// workflow.go
+package main
+
+import (
+	"time"
+
+	"go.temporal.io/sdk/contrib/workflowstreams"
+	"go.temporal.io/sdk/workflow"
+)
+
+type ChatInput struct {
+	Prompt      string
+	StreamState *workflowstreams.WorkflowStreamState
+}
+
+func ChatWorkflow(ctx workflow.Context, input ChatInput) (string, error) {
+	stream, err := workflowstreams.NewWorkflowStream(ctx, input.StreamState)
+	if err != nil {
+		return "", err
+	}
+	_ = stream
+
+	subscriberDone := false
+	ackCh := workflow.GetSignalChannel(ctx, "subscriber-acknowledged-terminator")
+	workflow.Go(ctx, func(ctx workflow.Context) {
+		ackCh.Receive(ctx, nil)
+		subscriberDone = true
+	})
+
+	ao := workflow.ActivityOptions{StartToCloseTimeout: 5 * time.Minute}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+	var result string
+	if err := workflow.ExecuteActivity(ctx, StreamCompletion, input.Prompt).Get(ctx, &result); err != nil {
+		return "", err
+	}
+
+	// Wait for the subscriber to ack the terminal `close` event. The timeout
+	// is a fallback for when no subscriber is attached; with the ack, the
+	// typical case exits as soon as the subscriber confirms.
+	_, _ = workflow.AwaitWithTimeout(ctx, 30*time.Second, func() bool { return subscriberDone })
+	return result, nil
+}
+```
+
+```go
+// consumer.go: accumulates the model's output and resets on retry
+package main
+
+import (
+	"context"
+	"strings"
+
+	"go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/contrib/workflowstreams"
+	"go.temporal.io/sdk/converter"
+)
+
+func StreamChat(ctx context.Context, temporalClient client.Client, chatID string) (string, error) {
+	// Subscribe-only; no Close needed because the flusher only runs for publishers.
+	stream := workflowstreams.NewClient(temporalClient, chatID, workflowstreams.Options{})
+	dc := converter.GetDefaultDataConverter()
+	var output []string
+
+	render := func() {
+		// ... display the accumulated output (terminal redraw, UI update, etc.)
+	}
+
+	for item, err := range stream.Subscribe(ctx, workflowstreams.SubscribeOptions{Topics: []string{"delta", "retry", "close"}}) {
+		if err != nil {
+			return "", err
+		}
+		switch item.Topic {
+		case "retry":
+			// Earlier attempt's deltas are stale; drop what we've shown.
+			output = output[:0]
+			render()
+		case "delta":
+			var delta TextDelta
+			if err := dc.FromPayload(item.Data, &delta); err != nil {
+				return "", err
+			}
+			output = append(output, delta.Text)
+			render()
+		case "close":
+			// Acknowledge so the Workflow can return without waiting on the fallback timeout.
+			if err := temporalClient.SignalWorkflow(ctx, chatID, "", "subscriber-acknowledged-terminator", nil); err != nil {
+				return "", err
+			}
+			return strings.Join(output, ""), nil
+		}
+	}
+
+	return strings.Join(output, ""), nil
+}
+```
+
+A few choices in this shape are deliberate:
+
+- The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes only the Activity's return value, never reading its own stream — see [Publish from a client](#publish-from-a-client) for why.
+- The Activity publishes a `RETRY` event when `activity.GetInfo(ctx).Attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [Delivery semantics](/workflow-streams#delivery-semantics)).
+- Termination uses an *ack handshake*: the consumer signals the Workflow once it has received the `close` event, so the Workflow can return as soon as the subscriber confirms. The `AwaitWithTimeout` timeout is the fallback when no subscriber is attached (see [Closing the stream](#closing-the-stream) for the simpler fixed-sleep alternative).
+- `forceFlush` is `true` only on the first delta and on the `RETRY` sentinel, where latency matters. Subsequent deltas batch at the 200 ms `BatchInterval`; per-delta `forceFlush` would generate one Signal per token (see [Tuning](/workflow-streams#tuning) for the trade-off).
+
+## See also
+
+- [Workflow Streams samples (samples-go)](https://github.com/temporalio/samples-go/tree/main/workflowstreams): runnable scenarios covering basic publish/subscribe, reconnecting subscribers, external publishers, bounded logs, and LLM streaming.
+- [`workflowstreams` API reference](https://pkg.go.dev/go.temporal.io/sdk/contrib/workflowstreams).
+- [Workflow message passing](/develop/go/workflows/message-passing): Signals, Updates, and Queries that Workflow Streams is built on.
+</content>

--- a/docs/develop/go/workflows/workflow-streams.mdx
+++ b/docs/develop/go/workflows/workflow-streams.mdx
@@ -28,18 +28,7 @@ It batch-publishes events to amortize per-Signal cost, deduplicates batches for 
 
 Use [Workflow Streams](/workflow-streams) when you want outside observers to follow the progress of a Workflow and its Activities: updating a UI as an AI agent works, surfacing status from a payment or order pipeline, or reporting intermediate results from a data job. It is not suited to ultra-low-latency cases like real-time voice, and it targets modest fan-out: tens of publishers and subscribers per Workflow, not thousands.
 
-The Workflow hosts the event log. Publishers append events — the Workflow itself, Activities, or external processes via `Client`. Subscribers attach to the Workflow Id, optionally filter by **topic** (a string label set when publishing; topics are implicit and created on first publish), and consume events by long-polling from an offset they store.
-
-**Looking for...**
-
-- [Enabling streaming on a Workflow](#enable-streaming-on-a-workflow)
-- [Publishing from a Workflow](#publish-from-a-workflow)
-- [Publishing from a client](#publish-from-a-client)
-- [Subscribing to a stream](#subscribe)
-- [Continue-As-New](#continue-as-new)
-- [Deduplication window settings](#deduplication-window)
-- [Best practices](#best-practices)
-- [An example of streaming LLM output](#stream-llm-output)
+The Workflow hosts the event log. Publishers append events: the Workflow itself, Activities, or external processes via `Client`. Subscribers attach to the Workflow Id, optionally filter by **topic** (a string label set when publishing; topics are implicit and created on first publish), and consume events by long-polling from an offset they store.
 
 ## Enable streaming on a Workflow
 
@@ -129,7 +118,7 @@ workflowstreams.NewClient(temporalClient, workflowID, workflowstreams.Options{})
 
 Then use it the same way you would the Workflow-side handle: bind a topic, publish through it, and `defer client.Close(ctx)` to flush on scope exit.
 
-When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state — see [Delivery semantics](/workflow-streams#delivery-semantics).
+When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [Delivery semantics](/workflow-streams#delivery-semantics).
 
 ```go
 import (
@@ -333,7 +322,7 @@ There are two ways to provide that overlap.
 
   	// ... do work and publish events ...
 
-  	// Returns true if the ack arrived, false on timeout — either way, fall through.
+  	// Returns true if the ack arrived, false on timeout. Either way, fall through.
   	_, _ = workflow.AwaitWithTimeout(ctx, 30*time.Second, func() bool { return subscriberDone })
   	return result, nil
   }
@@ -586,7 +575,7 @@ func StreamChat(ctx context.Context, temporalClient client.Client, chatID string
 
 A few choices in this shape are deliberate:
 
-- The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes only the Activity's return value, never reading its own stream — see [Publish from a client](#publish-from-a-client) for why.
+- The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes only the Activity's return value, never reading its own stream. See [Publish from a client](#publish-from-a-client) for why.
 - The Activity publishes a `RETRY` event when `activity.GetInfo(ctx).Attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [Delivery semantics](/workflow-streams#delivery-semantics)).
 - Termination uses an *ack handshake*: the consumer signals the Workflow once it has received the `close` event, so the Workflow can return as soon as the subscriber confirms. The `AwaitWithTimeout` timeout is the fallback when no subscriber is attached (see [Closing the stream](#closing-the-stream) for the simpler fixed-sleep alternative).
 - `forceFlush` is `true` only on the first delta and on the `RETRY` sentinel, where latency matters. Subsequent deltas batch at the 200 ms `BatchInterval`; per-delta `forceFlush` would generate one Signal per token (see [Tuning](/workflow-streams#tuning) for the trade-off).

--- a/docs/develop/go/workflows/workflow-streams.mdx
+++ b/docs/develop/go/workflows/workflow-streams.mdx
@@ -23,12 +23,7 @@ import { ReleaseNoteHeader } from '@site/src/components';
 
 <ReleaseNoteHeader featureName="workflowStreams" />
 
-**Workflow Streams** is a Temporal Go SDK `contrib` library that gives a Workflow a durable, offset-addressed event channel built on Temporal's basic message primitives: Signals, Updates, and Queries.
-It batch-publishes events to amortize per-Signal cost, deduplicates batches for exactly-once delivery to the log, supports topic filtering, and carries state across Continue-As-New for long-running streams.
-
-Use [Workflow Streams](/workflow-streams) when you want outside observers to follow the progress of a Workflow and its Activities: updating a UI as an AI agent works, surfacing status from a payment or order pipeline, or reporting intermediate results from a data job. It is not suited to ultra-low-latency cases like real-time voice, and it targets modest fan-out: tens of publishers and subscribers per Workflow, not thousands.
-
-The Workflow hosts the event log. Publishers append events: the Workflow itself, Activities, or external processes via `Client`. Subscribers attach to the Workflow Id, optionally filter by **topic** (a string label set when publishing; topics are implicit and created on first publish), and consume events by long-polling from an offset they store.
+[Workflow Streams](/workflow-streams) adds a durable event channel to a Workflow, letting outside observers follow its progress in real time. This page walks through enabling a stream, publishing events from Workflows and Activities, subscribing to a stream, and keeping a stream running across long-lived Workflows.
 
 ## Enable streaming on a Workflow
 
@@ -55,7 +50,7 @@ func OrderWorkflow(ctx workflow.Context, input OrderInput) error {
 }
 ```
 
-`NewWorkflowStream` creates the in-memory event log and registers the publish Signal, subscribe Update, and offset Query handlers on the current Workflow. The `priorState` argument is `nil` on a fresh start and a `*WorkflowStreamState` after a Continue-As-New rollover (see [Continue-As-New](#continue-as-new)).
+`NewWorkflowStream` creates the in-memory event log and registers the publish Signal, subscribe Update, and offset Query handlers on the current Workflow. The `priorState` argument is `nil` on a fresh start and a `*WorkflowStreamState` after a Continue-As-New rollover (see [Stream from long-running Workflows](#continue-as-new)).
 
 Construct exactly one `WorkflowStream` per Workflow. The constructor re-registers the handlers unconditionally on every call, so constructing more than one on the same Workflow registers duplicate handlers. The Go SDK doesn't expose an inspection API for existing handlers, so the library can't raise an exception on a duplicate the way the Python SDK does.
 
@@ -118,7 +113,7 @@ workflowstreams.NewClient(temporalClient, workflowID, workflowstreams.Options{})
 
 Then use it the same way you would the Workflow-side handle: bind a topic, publish through it, and `defer client.Close(ctx)` to flush on scope exit.
 
-When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [Delivery semantics](/workflow-streams#delivery-semantics).
+When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [How events are delivered](/workflow-streams#how-events-are-delivered).
 
 ```go
 import (
@@ -332,11 +327,9 @@ The full pattern is wired into the [Stream LLM output](#stream-llm-output) examp
 
 You can [inspect the terminal status](/workflow-streams#inspecting-terminal-status). `Subscribe()` ends cleanly when the Workflow reaches `COMPLETED`, `FAILED`, `CANCELED`, `TERMINATED`, or `TIMED_OUT`, but doesn't distinguish among them. If your application needs to know which (to display success or failure to the user, log the outcome, or decide whether to retry), call `temporalClient.DescribeWorkflowExecution(ctx, workflowID, "")` after the loop returns to inspect the Workflow's status.
 
-## Continue-As-New {/* #continue-as-new */}
+## Stream from long-running Workflows {/* #continue-as-new */}
 
-[Continue-As-New](/workflow-streams#continue-as-new) following requires the client retained from `NewClient()` or `NewClientFromActivity()`, which re-target the Workflow Id across runs.
-
-To roll a long-running streaming Workflow over without subscribers seeing a gap, carry both your application state and the stream state across the boundary. Add a `*WorkflowStreamState` field to your Workflow input, pass it to `NewWorkflowStream`, and return `stream.NewContinueAsNewError(ctx, wfn, buildArgs)` to invoke the rollover. The helper drains waiting subscribers, waits for in-flight handlers to finish, then returns a Continue-As-New error built from the args produced by `buildArgs(postDrainState)`:
+Workflows that run for hours or accumulate thousands of events need to periodically roll over via [Continue-As-New](/workflow-streams#stream-from-long-running-workflows) to keep history bounded. Subscribers automatically follow these rollovers. To keep a stream running across them without subscribers seeing a gap, carry both your application state and the stream state across the boundary. Add a `*WorkflowStreamState` field to your Workflow input, pass it to `NewWorkflowStream`, and return `stream.NewContinueAsNewError(ctx, wfn, buildArgs)` to invoke the rollover. The helper drains waiting subscribers, waits for in-flight handlers to finish, then returns a Continue-As-New error built from the args produced by `buildArgs(postDrainState)`:
 
 ```go
 type WorkflowInput struct {
@@ -391,7 +384,7 @@ The carried `WorkflowStreamState` includes the entire in-memory log of the previ
 
 ## Deduplication window
 
-See [Delivery Semantics](/workflow-streams#delivery-semantics) for more details on subscriber and publisher behavior. See [Tuning](/workflow-streams#tuning) for more details on how to change your settings to meet the requirements for your Workflow Streams.
+See [How events are delivered](/workflow-streams#how-events-are-delivered) for more details on subscriber and publisher behavior. See [Tuning](/workflow-streams#tuning) for more details on how to change your settings to meet the requirements for your Workflow Streams.
 
 There are two limits on the [deduplication window](/workflow-streams#deduplication-window) worth highlighting:
 
@@ -419,7 +412,7 @@ There are a few details to note if you're writing custom message handlers or tes
 
 The headline use case fits the publish/subscribe shapes documented above. An Activity calls the model and publishes deltas as they arrive. The Workflow starts the Activity and waits for the consumer to acknowledge end-of-stream. The consumer subscribes, accumulates the deltas, and clears its accumulated state on `RETRY` before continuing. The shape works for a terminal client, a desktop UI, or a Server-Sent Events (SSE) endpoint forwarding to a browser. Anything that holds the displayed state calls `render()` to display it.
 
-If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [Delivery semantics](/workflow-streams#delivery-semantics) for the precise guarantees.
+If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [How events are delivered](/workflow-streams#how-events-are-delivered) for the precise guarantees.
 
 ```go
 // activity.go
@@ -576,7 +569,7 @@ func StreamChat(ctx context.Context, temporalClient client.Client, chatID string
 A few choices in this shape are deliberate:
 
 - The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes only the Activity's return value, never reading its own stream. See [Publish from a client](#publish-from-a-client) for why.
-- The Activity publishes a `RETRY` event when `activity.GetInfo(ctx).Attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [Delivery semantics](/workflow-streams#delivery-semantics)).
+- The Activity publishes a `RETRY` event when `activity.GetInfo(ctx).Attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [How events are delivered](/workflow-streams#how-events-are-delivered)).
 - Termination uses an *ack handshake*: the consumer signals the Workflow once it has received the `close` event, so the Workflow can return as soon as the subscriber confirms. The `AwaitWithTimeout` timeout is the fallback when no subscriber is attached (see [Closing the stream](#closing-the-stream) for the simpler fixed-sleep alternative).
 - `forceFlush` is `true` only on the first delta and on the `RETRY` sentinel, where latency matters. Subsequent deltas batch at the 200 ms `BatchInterval`; per-delta `forceFlush` would generate one Signal per token (see [Tuning](/workflow-streams#tuning) for the trade-off).
 

--- a/docs/develop/go/workflows/workflow-streams.mdx
+++ b/docs/develop/go/workflows/workflow-streams.mdx
@@ -414,8 +414,10 @@ The headline use case fits the publish/subscribe shapes documented above. An Act
 
 If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [How events are delivered](/workflow-streams#how-events-are-delivered) for the precise guarantees.
 
+<Tabs>
+<TabItem value="activity" label="activity.go">
+
 ```go
-// activity.go
 package main
 
 import (
@@ -470,8 +472,10 @@ func StreamCompletion(ctx context.Context, prompt string) (string, error) {
 }
 ```
 
+</TabItem>
+<TabItem value="workflow" label="workflow.go">
+
 ```go
-// workflow.go
 package main
 
 import (
@@ -514,8 +518,10 @@ func ChatWorkflow(ctx workflow.Context, input ChatInput) (string, error) {
 }
 ```
 
+</TabItem>
+<TabItem value="consumer" label="consumer.go">
+
 ```go
-// consumer.go: accumulates the model's output and resets on retry
 package main
 
 import (
@@ -565,6 +571,9 @@ func StreamChat(ctx context.Context, temporalClient client.Client, chatID string
 	return strings.Join(output, ""), nil
 }
 ```
+
+</TabItem>
+</Tabs>
 
 A few choices in this shape are deliberate:
 

--- a/docs/develop/python/workflows/workflow-streams.mdx
+++ b/docs/develop/python/workflows/workflow-streams.mdx
@@ -363,8 +363,10 @@ The headline use case fits the publish/subscribe shapes documented above. An Act
 
 If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [How events are delivered](/workflow-streams#how-events-are-delivered) for the precise guarantees.
 
+<Tabs>
+<TabItem value="activity" label="activity.py">
+
 ```python
-# activity.py
 from openai import AsyncOpenAI
 
 
@@ -412,8 +414,10 @@ async def stream_completion(prompt: str) -> str:
     return "".join(full)
 ```
 
+</TabItem>
+<TabItem value="workflow" label="workflow.py">
+
 ```python
-# workflow.py
 @workflow.defn
 class ChatWorkflow:
     @workflow.init
@@ -445,8 +449,10 @@ class ChatWorkflow:
         return result
 ```
 
+</TabItem>
+<TabItem value="consumer" label="consumer.py">
+
 ```python
-# consumer.py: accumulates the model's output and resets on retry
 async def stream_chat(chat_id: str) -> str:
     # Subscribe-only; no `async with` needed because the flusher only runs for publishers.
     stream = WorkflowStreamClient.create(temporal_client, workflow_id=chat_id)
@@ -476,6 +482,9 @@ async def stream_chat(chat_id: str) -> str:
 
     return "".join(output)
 ```
+
+</TabItem>
+</Tabs>
 
 A few choices in this shape are deliberate:
 

--- a/docs/develop/python/workflows/workflow-streams.mdx
+++ b/docs/develop/python/workflows/workflow-streams.mdx
@@ -25,12 +25,7 @@ import { ReleaseNoteHeader } from '@site/src/components';
   featureName="workflowStreams"
 />
 
-**Workflow Streams** is a Temporal Python SDK `contrib` library that gives a Workflow a durable, offset-addressed event channel built on Temporal's basic message primitives: Signals, Updates, and Queries.
-It batch-publishes events to amortize per-Signal cost, deduplicates batches for exactly-once delivery to the log, supports topic filtering, and carries state across Continue-As-New for long-running streams.
-
-Use Workflow Streams when you want outside observers to follow the progress of a Workflow and its Activities: updating a UI as an AI agent works, surfacing status from a payment or order pipeline, or reporting intermediate results from a data job. It is not suited to ultra-low-latency cases like real-time voice, and it targets modest fan-out: tens of publishers and subscribers per Workflow, not thousands.
-
-The Workflow hosts the event log. Publishers append events: the Workflow itself, Activities, or external processes via `WorkflowStreamClient`. Subscribers attach to the Workflow ID, optionally filter by **topic** (a string label set when publishing; topics are implicit and created on first publish), and consume events by long-polling from an offset they store.
+[Workflow Streams](/workflow-streams) adds a durable event channel to a Workflow, letting outside observers follow its progress in real time. This page walks through enabling a stream, publishing events from Workflows and Activities, subscribing to a stream, and keeping a stream running across long-lived Workflows.
 
 ## Enable streaming on a Workflow
 
@@ -57,7 +52,7 @@ class OrderWorkflow:
 
 Constructing `WorkflowStream` creates the in-memory event log and dynamically registers the publish Signal, subscribe Update, and offset Query handlers on the current Workflow. Constructing more than one stream on the same Workflow also raises a `RuntimeError`.
 
-If your Workflow uses Continue-As-New, see [Continue-As-New](#continue-as-new) below for how to carry stream state across runs so [subscribers](/workflow-streams#subscribing) see no gap.
+If your Workflow is long-running, see [Stream from long-running Workflows](#continue-as-new) for how to carry stream state across rollovers so subscribers don't see gaps.
 
 ## Publish from a Workflow
 
@@ -111,7 +106,7 @@ WorkflowStreamClient.create(client, workflow_id)
 
 Then use it the same way you would the Workflow-side handle: bind a topic, publish through it, and let the async context manager flush on exit.
 
-When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [Delivery semantics](/workflow-streams#delivery-semantics).
+When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [How events are delivered](/workflow-streams#how-events-are-delivered).
 
 ```python
 from datetime import timedelta
@@ -276,11 +271,9 @@ The full pattern is wired into the [Stream LLM output](#stream-llm-output) examp
 
 You can [inspect the terminal status](/workflow-streams#inspecting-terminal-status). `subscribe()` exits cleanly when the Workflow reaches `COMPLETED`, `FAILED`, `CANCELED`, `TERMINATED`, or `TIMED_OUT`, but does not distinguish among them. If your application needs to know which (to display success or failure to the user, log the outcome, or decide whether to retry), call `await temporal_client.get_workflow_handle(workflow_id).describe()` after the loop returns to inspect the Workflow's status.
 
-## Continue-As-New {/* #continue-as-new */}
+## Stream from long-running Workflows {/* #continue-as-new */}
 
-[Continue-As-New](/workflow-streams#continue-as-new) following requires the client retained from `WorkflowStreamClient.create()` or `from_within_activity()`. Clients constructed directly with a single handle cannot re-target the new run.
-
-To roll a long-running streaming Workflow over without subscribers seeing a gap, carry both your application state and the stream state across the boundary. Add a `WorkflowStreamState | None` field to your Workflow input, pass it to the constructor, and call `WorkflowStream.continue_as_new(build_args)` to invoke the rollover. The helper drains waiting subscribers, waits for in-flight handlers to finish, then calls `workflow.continue_as_new` with the args produced by `build_args(post_drain_state)`:
+Workflows that run for hours or accumulate thousands of events need to periodically roll over via [Continue-As-New](/workflow-streams#stream-from-long-running-workflows) to keep history bounded. Subscribers automatically follow these rollovers, but the client retained from `WorkflowStreamClient.create()` or `from_within_activity()` is required (clients constructed directly with a single handle cannot re-target the new run). To keep a stream running across rollovers without subscribers seeing a gap, carry both your application state and the stream state across the boundary. Add a `WorkflowStreamState | None` field to your Workflow input, pass it to the constructor, and call `WorkflowStream.continue_as_new(build_args)` to invoke the rollover. The helper drains waiting subscribers, waits for in-flight handlers to finish, then calls `workflow.continue_as_new` with the args produced by `build_args(post_drain_state)`:
 
 ```python
 from dataclasses import dataclass, field
@@ -341,7 +334,7 @@ The carried `WorkflowStreamState` includes the entire in-memory log of the previ
 
 ## Deduplication window
 
-See [Delivery Semantics](/workflow-streams#delivery-semantics) for more details on subscriber and publisher behavior. See [Tuning](/workflow-streams#tuning) for more details on how to change your settings to meet the requirements for your Workflow Streams.
+See [How events are delivered](/workflow-streams#how-events-are-delivered) for more details on subscriber and publisher behavior. See [Tuning](/workflow-streams#tuning) for more details on how to change your settings to meet the requirements for your Workflow Streams.
 
 There are two limits on the [deduplication window](/workflow-streams#deduplication-window) worth highlighting:
 
@@ -368,7 +361,7 @@ There are a few details to note if you're writing custom message handlers or tes
 
 The headline use case fits the publish/subscribe shapes documented above. An Activity calls the model and publishes deltas as they arrive. The Workflow starts the Activity and waits for the consumer to acknowledge end-of-stream. The consumer subscribes, accumulates the deltas, and clears its accumulated state on `RETRY` before continuing. The shape works for a terminal client, a desktop UI, or a Server-Sent Events (SSE) endpoint forwarding to a browser. Anything that holds the displayed state calls `render()` to display it.
 
-If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [Delivery semantics](/workflow-streams#delivery-semantics) for the precise guarantees.
+If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [How events are delivered](/workflow-streams#how-events-are-delivered) for the precise guarantees.
 
 ```python
 # activity.py
@@ -487,7 +480,7 @@ async def stream_chat(chat_id: str) -> str:
 A few choices in this shape are deliberate:
 
 - The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes the Activity's return value, never reading its own stream. See [Publish from a client](#publish-from-a-client) for why.
-- The Activity publishes a `RETRY` event when `activity.info().attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [Delivery semantics](/workflow-streams#delivery-semantics)).
+- The Activity publishes a `RETRY` event when `activity.info().attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [How events are delivered](/workflow-streams#how-events-are-delivered)).
 - Termination uses an *ack handshake*: the consumer signals the Workflow once it has received the `close` event, so the Workflow can return as soon as the subscriber confirms. The `wait_condition` timeout is the fallback when no subscriber is attached (see [Closing the stream](#closing-the-stream) for the simpler fixed-sleep alternative).
 - `force_flush=True` is used on the first delta and on the `RETRY` sentinel, where latency matters. Subsequent deltas batch at the 200 ms `batch_interval`; per-delta `force_flush=True` would generate one Signal per token (see [Tuning](/workflow-streams#tuning) for the trade-off).
 

--- a/docs/develop/python/workflows/workflow-streams.mdx
+++ b/docs/develop/python/workflows/workflow-streams.mdx
@@ -30,18 +30,7 @@ It batch-publishes events to amortize per-Signal cost, deduplicates batches for 
 
 Use Workflow Streams when you want outside observers to follow the progress of a Workflow and its Activities: updating a UI as an AI agent works, surfacing status from a payment or order pipeline, or reporting intermediate results from a data job. It is not suited to ultra-low-latency cases like real-time voice, and it targets modest fan-out: tens of publishers and subscribers per Workflow, not thousands.
 
-The Workflow hosts the event log. Publishers append events — the Workflow itself, Activities, or external processes via `WorkflowStreamClient`. Subscribers attach to the Workflow ID, optionally filter by **topic** (a string label set when publishing; topics are implicit and created on first publish), and consume events by long-polling from an offset they store.
-
-**Looking for...**
-
-- [Enabling streaming on a Workflow](#enable-streaming-on-a-workflow)
-- [Publishing from a Workflow](#publish-from-a-workflow)
-- [Publishing from a client](#publish-from-a-client)
-- [Subscribing to a stream](#subscribe)
-- [Continue-As-New](#continue-as-new)
-- [Deduplication window settings](#deduplication-window)
-- [Best practices](#best-practices)
-- [An example of streaming LLM output](#stream-llm-output) 
+The Workflow hosts the event log. Publishers append events: the Workflow itself, Activities, or external processes via `WorkflowStreamClient`. Subscribers attach to the Workflow ID, optionally filter by **topic** (a string label set when publishing; topics are implicit and created on first publish), and consume events by long-polling from an offset they store.
 
 ## Enable streaming on a Workflow
 
@@ -122,7 +111,7 @@ WorkflowStreamClient.create(client, workflow_id)
 
 Then use it the same way you would the Workflow-side handle: bind a topic, publish through it, and let the async context manager flush on exit.
 
-When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state — see [Delivery semantics](/workflow-streams#delivery-semantics).
+When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [Delivery semantics](/workflow-streams#delivery-semantics).
 
 ```python
 from datetime import timedelta
@@ -497,7 +486,7 @@ async def stream_chat(chat_id: str) -> str:
 
 A few choices in this shape are deliberate:
 
-- The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes the Activity's return value, never reading its own stream — see [Publish from a client](#publish-from-a-client) for why.
+- The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes the Activity's return value, never reading its own stream. See [Publish from a client](#publish-from-a-client) for why.
 - The Activity publishes a `RETRY` event when `activity.info().attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [Delivery semantics](/workflow-streams#delivery-semantics)).
 - Termination uses an *ack handshake*: the consumer signals the Workflow once it has received the `close` event, so the Workflow can return as soon as the subscriber confirms. The `wait_condition` timeout is the fallback when no subscriber is attached (see [Closing the stream](#closing-the-stream) for the simpler fixed-sleep alternative).
 - `force_flush=True` is used on the first delta and on the `RETRY` sentinel, where latency matters. Subsequent deltas batch at the 200 ms `batch_interval`; per-delta `force_flush=True` would generate one Signal per token (see [Tuning](/workflow-streams#tuning) for the trade-off).

--- a/docs/develop/typescript/workflows/workflow-streams.mdx
+++ b/docs/develop/typescript/workflows/workflow-streams.mdx
@@ -359,8 +359,10 @@ The headline use case fits the publish/subscribe shapes documented above. An Act
 
 If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [How events are delivered](/workflow-streams#how-events-are-delivered) for the precise guarantees.
 
+<Tabs>
+<TabItem value="activity" label="activities.ts">
+
 ```typescript
-// activities.ts
 import { Context } from '@temporalio/activity';
 import { WorkflowStreamClient } from '@temporalio/workflow-streams/client';
 import OpenAI from 'openai';
@@ -412,8 +414,10 @@ export async function streamCompletion(prompt: string): Promise<string> {
 }
 ```
 
+</TabItem>
+<TabItem value="workflow" label="workflows.ts">
+
 ```typescript
-// workflows.ts
 import { condition, defineSignal, executeActivity, setHandler } from '@temporalio/workflow';
 import { WorkflowStream } from '@temporalio/workflow-streams/workflow';
 import type * as activities from './activities';
@@ -443,8 +447,10 @@ export async function chatWorkflow(input: ChatInput): Promise<string> {
 }
 ```
 
+</TabItem>
+<TabItem value="consumer" label="consumer.ts">
+
 ```typescript
-// consumer.ts: accumulates the model's output and resets on retry
 import { Client } from '@temporalio/client';
 import { defaultPayloadConverter } from '@temporalio/common';
 import { WorkflowStreamClient } from '@temporalio/workflow-streams/client';
@@ -479,6 +485,9 @@ export async function streamChat(chatId: string): Promise<string> {
   return output.join('');
 }
 ```
+
+</TabItem>
+</Tabs>
 
 A few choices in this shape are deliberate:
 

--- a/docs/develop/typescript/workflows/workflow-streams.mdx
+++ b/docs/develop/typescript/workflows/workflow-streams.mdx
@@ -19,7 +19,7 @@ tags:
 description: Stream events from a Workflow to subscribers using the Temporal TypeScript SDK Workflow Streams contrib module.
 ---
 
-Use [Workflow Streams](/workflow-streams) when you want outside observers to follow the progress of a Workflow and its Activities: updating a UI as an AI agent works, surfacing status from a payment or order pipeline, or reporting intermediate results from a data job.
+[Workflow Streams](/workflow-streams) adds a durable event channel to a Workflow, letting outside observers follow its progress in real time. This page walks through enabling a stream, publishing events from Workflows and Activities, subscribing to a stream, and keeping a stream running across long-lived Workflows.
 
 :::tip SUPPORT, STABILITY, and DEPENDENCY INFO
 
@@ -50,7 +50,7 @@ export async function orderWorkflow(input: OrderInput): Promise<void> {
 
 Construct exactly one `WorkflowStream` at the top of the Workflow function. Constructing `WorkflowStream` creates the in-memory event log and registers the publish Signal, subscribe Update, and offset Query handlers on the current Workflow. If you have more than one `WorkflowStream` on the same Workflow silently replaces the handlers. The TypeScript Workflow runtime doesn't expose an inspection API for existing handlers, so the library can't raise an exception on a duplicate the way the Python SDK does.
 
-If your Workflow uses Continue-As-New, see [Continue-As-New](#continue-as-new) below for how to carry stream state across runs so subscribers don't have gaps.
+If your Workflow is long-running, see [Stream from long-running Workflows](#continue-as-new) for how to carry stream state across rollovers so subscribers don't see gaps.
 
 ## Publish from a Workflow
 
@@ -102,7 +102,7 @@ WorkflowStreamClient.create(client, workflowId)
 
 Then use it the same way you would the Workflow-side handle: bind a topic, publish through it, and let `await using` flush on scope exit.
 
-When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [Delivery semantics](/workflow-streams#delivery-semantics).
+When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [How events are delivered](/workflow-streams#how-events-are-delivered).
 
 ```typescript
 import { Client } from '@temporalio/client';
@@ -278,11 +278,9 @@ The full pattern is wired into the [Stream LLM output](#stream-llm-output) examp
 
 You can [inspect the terminal status](/workflow-streams#inspecting-terminal-status). `subscribe()` exits cleanly when the Workflow reaches `COMPLETED`, `FAILED`, `CANCELLED`, `TERMINATED`, or `TIMED_OUT`, but doesn't distinguish among them. If your application needs to know which (to display success or failure to the user, log the outcome, or decide whether to retry), call `await temporalClient.workflow.getHandle(workflowId).describe()` after the loop returns to inspect the Workflow's status.
 
-## Continue-As-New
+## Stream from long-running Workflows {/* #continue-as-new */}
 
-[Continue-As-New](/workflow-streams#continue-as-new) following requires the client retained from `WorkflowStreamClient.create()` or `fromWithinActivity()`. Clients constructed directly from a single `WorkflowHandle` can't re-target the new run.
-
-To roll a long-running streaming Workflow over without subscribers seeing a gap, carry both your application state and the stream state across the boundary. Add an optional `streamState?: WorkflowStreamState` field to your Workflow input, pass it to the constructor, and call `stream.continueAsNew(buildArgs)` to invoke the rollover. The helper drains waiting subscribers, waits for in-flight handlers to finish, then calls `continueAsNew` with the args produced by `buildArgs(postDrainState)`:
+Workflows that run for hours or accumulate thousands of events need to periodically roll over via [Continue-As-New](/workflow-streams#stream-from-long-running-workflows) to keep history bounded. Subscribers automatically follow these rollovers, but the client retained from `WorkflowStreamClient.create()` or `fromWithinActivity()` is required (clients constructed directly from a single `WorkflowHandle` can't re-target the new run). To keep a stream running across rollovers without subscribers seeing a gap, carry both your application state and the stream state across the boundary. Add an optional `streamState?: WorkflowStreamState` field to your Workflow input, pass it to the constructor, and call `stream.continueAsNew(buildArgs)` to invoke the rollover. The helper drains waiting subscribers, waits for in-flight handlers to finish, then calls `continueAsNew` with the args produced by `buildArgs(postDrainState)`:
 
 ```typescript
 import { workflowInfo } from '@temporalio/workflow';
@@ -335,7 +333,7 @@ The carried `WorkflowStreamState` includes the entire in-memory log of the previ
 
 ## Deduplication window
 
-See [Delivery Semantics](/workflow-streams#delivery-semantics) for more details on subscriber and publisher behavior. See [Tuning](/workflow-streams#tuning) for more details on how to change your settings to meet the requirements for your Workflow Streams.
+See [How events are delivered](/workflow-streams#how-events-are-delivered) for more details on subscriber and publisher behavior. See [Tuning](/workflow-streams#tuning) for more details on how to change your settings to meet the requirements for your Workflow Streams.
 
 There are two limits on the [deduplication window](/workflow-streams#deduplication-window) worth highlighting:
 
@@ -365,7 +363,7 @@ There are a few details to note if you're writing custom message handlers or tes
 
 The headline use case fits the publish/subscribe shapes documented above. An Activity calls the model and publishes deltas as they arrive. The Workflow kicks off the Activity and waits for the consumer to acknowledge end-of-stream. The consumer subscribes, accumulates the deltas, and clears its accumulated state on `RETRY` before continuing. The shape works for a terminal client, a desktop UI, or a Server-Sent Events (SSE) endpoint forwarding to a browser. Anything that holds the displayed state calls `render()` to display it.
 
-If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [Delivery semantics](/workflow-streams#delivery-semantics) for the precise guarantees.
+If your Activity can retry, the consumer side has to account for it. A retried attempt is a fresh publisher, so its output appears in the stream alongside the output from the previous attempt. In the LLM streaming pattern below, that means the failed attempt's partial deltas and the retried attempt's full output both reach a subscribed UI unless the UI resets on a `RETRY` event. The example wires up that pattern. See [How events are delivered](/workflow-streams#how-events-are-delivered) for the precise guarantees.
 
 ```typescript
 // activities.ts
@@ -491,7 +489,7 @@ export async function streamChat(chatId: string): Promise<string> {
 A few choices in this shape are deliberate:
 
 - The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes only the Activity's return value, never reading its own stream. See [Publish from a client](#publish-from-a-client) for why.
-- The Activity publishes a `RETRY` event when `Context.current().info.attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [Delivery semantics](/workflow-streams#delivery-semantics)).
+- The Activity publishes a `RETRY` event when `Context.current().info.attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [How events are delivered](/workflow-streams#how-events-are-delivered)).
 - Termination uses an *ack handshake*: the consumer signals the Workflow once it has received the `close` event, so the Workflow can return as soon as the subscriber confirms. The `condition` timeout is the fallback when no subscriber is attached (see [Closing the stream](#closing-the-stream) for the simpler fixed-sleep alternative).
 - `{ forceFlush: true }` is used only on the first delta and on the `RETRY` sentinel, where latency matters. Subsequent deltas batch at the 200 ms `batchInterval`; per-delta `forceFlush: true` would generate one Signal per token (see [Tuning](/workflow-streams#tuning) for the trade-off).
 

--- a/docs/develop/typescript/workflows/workflow-streams.mdx
+++ b/docs/develop/typescript/workflows/workflow-streams.mdx
@@ -102,7 +102,7 @@ WorkflowStreamClient.create(client, workflowId)
 
 Then use it the same way you would the Workflow-side handle: bind a topic, publish through it, and let `await using` flush on scope exit.
 
-When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state — see [Delivery semantics](/workflow-streams#delivery-semantics).
+When events originate in an Activity, publish from the Activity directly rather than returning them for the Workflow to forward. The Workflow hosts the stream but doesn't read its own stream; it processes the Activity's return value and emits its own lifecycle events. Keeping Workflow state independent of streamed output is what lets retried Activity attempts surface to subscribers without polluting the Workflow's durable state. See [Delivery semantics](/workflow-streams#delivery-semantics).
 
 ```typescript
 import { Client } from '@temporalio/client';
@@ -269,7 +269,7 @@ There are two ways to provide that overlap.
     // ... do work and publish events ...
 
     await condition(() => subscriberDone, '30 seconds');
-    // Returns true if the ack arrived, false on timeout — either way, fall through.
+    // Returns true if the ack arrived, false on timeout. Either way, fall through.
     return result;
   }
   ```
@@ -490,7 +490,7 @@ export async function streamChat(chatId: string): Promise<string> {
 
 A few choices in this shape are deliberate:
 
-- The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes only the Activity's return value, never reading its own stream — see [Publish from a client](#publish-from-a-client) for why.
+- The Activity is the publisher because it owns the non-deterministic LLM call. The Workflow processes only the Activity's return value, never reading its own stream. See [Publish from a client](#publish-from-a-client) for why.
 - The Activity publishes a `RETRY` event when `Context.current().info.attempt > 1`. This lets the UI respond appropriately to the failure, typically by clearing accumulated deltas before the next attempt's deltas arrive (see [Delivery semantics](/workflow-streams#delivery-semantics)).
 - Termination uses an *ack handshake*: the consumer signals the Workflow once it has received the `close` event, so the Workflow can return as soon as the subscriber confirms. The `condition` timeout is the fallback when no subscriber is attached (see [Closing the stream](#closing-the-stream) for the simpler fixed-sleep alternative).
 - `{ forceFlush: true }` is used only on the first delta and on the `RETRY` sentinel, where latency matters. Subsequent deltas batch at the 200 ms `batchInterval`; per-delta `forceFlush: true` would generate one Signal per token (see [Tuning](/workflow-streams#tuning) for the trade-off).

--- a/docs/develop/typescript/workflows/workflow-streams.mdx
+++ b/docs/develop/typescript/workflows/workflow-streams.mdx
@@ -19,17 +19,11 @@ tags:
 description: Stream events from a Workflow to subscribers using the Temporal TypeScript SDK Workflow Streams contrib module.
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
+<ReleaseNoteHeader featureName="workflowStreams" />
+
 [Workflow Streams](/workflow-streams) adds a durable event channel to a Workflow, letting outside observers follow its progress in real time. This page walks through enabling a stream, publishing events from Workflows and Activities, subscribing to a stream, and keeping a stream running across long-lived Workflows.
-
-:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
-
-The `@temporalio/workflow-streams` module is currently in
-[Public Preview](/evaluate/development-production-features/release-stages#public-preview). Refer to the
-[Temporal product release stages guide](/evaluate/development-production-features/release-stages) for more information.
-
-The API may change before general availability.
-
-:::
 
 ## Enable streaming on a Workflow
 

--- a/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
+++ b/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
@@ -46,9 +46,9 @@ This page covers the following:
 - [How Workflow Streams works](#how-workflow-streams-works)
 - [Choose where to host the stream](#choose-where-to-host-the-stream)
 - [Closing the stream](#closing-the-stream)
-- [Delivery semantics](#delivery-semantics)
+- [How events are delivered](#how-events-are-delivered)
 - [Tuning](#tuning)
-- [Continue-As-New](#continue-as-new)
+- [Stream from long-running Workflows](#stream-from-long-running-workflows)
 
 ## What are Workflow Streams? {/* #what-are-workflow-streams */}
 
@@ -113,7 +113,7 @@ the flusher; it doesn't wait for delivery.
 
 Each client has a unique publisher Id and a monotonic sequence number. Every batch is tagged with this pair so that a
 Signal retried by the SDK or the network deduplicates to a single landing in the log. See
-[Delivery semantics](#delivery-semantics) for the full guarantee.
+[How events are delivered](#how-events-are-delivered) for the full guarantee.
 
 <RelatedReadContainer>
   <RelatedReadItem
@@ -204,7 +204,7 @@ Two mechanisms bound the growth of the in-memory log:
   doesn't remove publish Signals already recorded in Workflow history. A subscriber whose offset falls below the new
   base after truncation is silently advanced to the current base.
 - **Continue-As-New** starts a fresh Workflow history. This is the only way to shrink history. See
-  [Continue-As-New](#continue-as-new).
+  [Stream from long-running Workflows](#stream-from-long-running-workflows).
 
 ### Architecture
 
@@ -290,7 +290,9 @@ The subscribe iterator exits cleanly when the Workflow reaches `COMPLETED`, `FAI
 `TIMED_OUT`, but doesn't distinguish among them. If your application needs to know which, describe the Workflow handle
 after the loop returns to inspect the status.
 
-## Delivery semantics
+## How events are delivered
+
+Workflow Streams provides exactly-once publishing, total ordering within a publisher, and transparent handling of Activity retries. This section covers each guarantee and the failure modes to be aware of.
 
 ### Exactly-once publishing
 
@@ -345,8 +347,7 @@ The most important question when tuning is: how often do you want to update your
 between user-perceived latency and the number of history events your Workflow accumulates.
 
 Each batched publish is one Signal and each subscriber poll is one Update. Each Signal and each Update counts against
-the Workflow's history. A more responsive UI means more messages and more history per second. For long-running streams,
-plan a [Continue-As-New](#continue-as-new) policy from the start.
+the Workflow's history. A more responsive UI means more messages and more history per second. To plan for long-running streams, refer to [Stream from long-running Workflows](#stream-from-long-running-workflows) for details on how to use [Continue-As-New](/encyclopedia/workflow/workflow-execution/continue-as-new) to avoid performance degradation from large event histories.
 
 ### Batch interval
 
@@ -366,11 +367,11 @@ completion produces 500 publish Signals, which is meaningful but tractable. Per-
 | **max batch size** | unbounded | Caps the number of items per batch. Without this, only batch interval bounds batch size. A hot publisher can accumulate enough items that the resulting Signal exceeds Temporal's per-message gRPC payload limit. For large items, offload via [External Storage](/external-storage) so each item is a small reference. |
 | **poll cooldown**  | 100 ms    | Minimum interval between subscriber polls. Skipped only when a poll response was capped at the 1 MB limit and more items remain.                                                                                  |
 
-## Continue-As-New
+## Stream from long-running Workflows
 
 If your Workflow runs for minutes and finishes (a single chat completion, an order pipeline, a one-shot agent), you can
-skip this section. Continue-As-New becomes relevant for streams that run for hours or accumulate thousands of events,
-where you need to roll the Workflow over to keep history bounded.
+skip this section. Long-running streams that run for hours or accumulate thousands of events need to periodically roll
+over via Continue-As-New to keep history bounded.
 
 Subscribers automatically follow Continue-As-New chains. Workflow Ids are stable across Continue-As-New, so the
 subscriber fetches a fresh handle for the same Workflow Id and continues polling from its carried offset.
@@ -390,17 +391,17 @@ storage so each item is a small reference, and use truncation to drop entries th
 <RelatedReadContainer>
   <RelatedReadItem
     path="/develop/python/workflows/workflow-streams#continue-as-new"
-    text="Continue-As-New with the Python SDK"
+    text="Long-running streams with the Python SDK"
     archetype="feature-guide"
   />
   <RelatedReadItem
     path="/develop/typescript/workflows/workflow-streams#continue-as-new"
-    text="Continue-As-New with the TypeScript SDK"
+    text="Long-running streams with the TypeScript SDK"
     archetype="feature-guide"
   />
   <RelatedReadItem
     path="/develop/go/workflows/workflow-streams#continue-as-new"
-    text="Continue-As-New with the Go SDK"
+    text="Long-running streams with the Go SDK"
     archetype="feature-guide"
   />
 </RelatedReadContainer>

--- a/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
+++ b/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
@@ -347,7 +347,7 @@ The most important question when tuning is: how often do you want to update your
 between user-perceived latency and the number of history events your Workflow accumulates.
 
 Each batched publish is one Signal and each subscriber poll is one Update. Each Signal and each Update counts against
-the Workflow's history. A more responsive UI means more messages and more history per second. To plan for long-running streams, refer to [Stream from long-running Workflows](#stream-from-long-running-workflows) for details on how to use [Continue-As-New](/encyclopedia/workflow/workflow-execution/continue-as-new) to avoid performance degradation from large event histories.
+the Workflow's history. A more responsive UI means more messages and more history per second. To plan for long-running streams, refer to [Stream from long-running Workflows](#stream-from-long-running-workflows) for details on how to use [Continue-As-New](/workflow-execution/continue-as-new) to avoid performance degradation from large event histories.
 
 ### Batch interval
 

--- a/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
+++ b/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
@@ -32,8 +32,6 @@ import { RelatedReadContainer, RelatedReadItem, ReleaseNoteHeader } from '@site/
 
 <ReleaseNoteHeader featureName="workflowStreams" />
 
-Cross-language client support is on the roadmap. The Go, TypeScript, and Python clients are available today.
-
 This page covers the following:
 
 - [What are Workflow Streams?](#what-are-workflow-streams)

--- a/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
+++ b/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
@@ -36,7 +36,7 @@ Workflow Streams is currently in
 [Public Preview](/evaluate/development-production-features/release-stages#public-preview). The API may change before
 general availability.
 
-Cross-language client support is on the roadmap. The TypeScript and Python clients are available today.
+Cross-language client support is on the roadmap. The Go, TypeScript, and Python clients are available today.
 
 :::
 
@@ -72,6 +72,11 @@ publishers and subscribers per Workflow, not thousands.
   <RelatedReadItem
     path="/develop/typescript/workflows/workflow-streams"
     text="Workflow Streams with the TypeScript SDK"
+    archetype="feature-guide"
+  />
+  <RelatedReadItem
+    path="/develop/go/workflows/workflow-streams"
+    text="Workflow Streams with the Go SDK"
     archetype="feature-guide"
   />
 </RelatedReadContainer>
@@ -131,6 +136,16 @@ Signal retried by the SDK or the network deduplicates to a single landing in the
     text="Publish from a client with the TypeScript SDK"
     archetype="feature-guide"
   />
+  <RelatedReadItem
+    path="/develop/go/workflows/workflow-streams#publish-from-a-workflow"
+    text="Publish from a Workflow with the Go SDK"
+    archetype="feature-guide"
+  />
+  <RelatedReadItem
+    path="/develop/go/workflows/workflow-streams#publish-from-a-client"
+    text="Publish from a client with the Go SDK"
+    archetype="feature-guide"
+  />
 </RelatedReadContainer>
 
 ### Topics
@@ -172,6 +187,11 @@ The Workflow is the single source of truth for stream state, so any process brid
   <RelatedReadItem
     path="/develop/typescript/workflows/workflow-streams#subscribe"
     text="Subscribe with the TypeScript SDK"
+    archetype="feature-guide"
+  />
+  <RelatedReadItem
+    path="/develop/go/workflows/workflow-streams#subscribe"
+    text="Subscribe with the Go SDK"
     archetype="feature-guide"
   />
 </RelatedReadContainer>
@@ -376,6 +396,11 @@ storage so each item is a small reference, and use truncation to drop entries th
   <RelatedReadItem
     path="/develop/typescript/workflows/workflow-streams#continue-as-new"
     text="Continue-As-New with the TypeScript SDK"
+    archetype="feature-guide"
+  />
+  <RelatedReadItem
+    path="/develop/go/workflows/workflow-streams#continue-as-new"
+    text="Continue-As-New with the Go SDK"
     archetype="feature-guide"
   />
 </RelatedReadContainer>

--- a/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
+++ b/docs/encyclopedia/workflow-message-passing/workflow-streams.mdx
@@ -28,17 +28,11 @@ tags:
   - Streaming
 ---
 
-import { RelatedReadContainer, RelatedReadItem } from '@site/src/components';
+import { RelatedReadContainer, RelatedReadItem, ReleaseNoteHeader } from '@site/src/components';
 
-:::tip SUPPORT, STABILITY, and DEPENDENCY INFO
-
-Workflow Streams is currently in
-[Public Preview](/evaluate/development-production-features/release-stages#public-preview). The API may change before
-general availability.
+<ReleaseNoteHeader featureName="workflowStreams" />
 
 Cross-language client support is on the roadmap. The Go, TypeScript, and Python clients are available today.
-
-:::
 
 This page covers the following:
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -124,6 +124,7 @@ module.exports = {
                 'develop/go/workflows/side-effects',
                 'develop/go/workflows/dynamic-workflow',
                 'develop/go/workflows/versioning',
+                'develop/go/workflows/workflow-streams',
               ],
             },
             {


### PR DESCRIPTION
Mirrors the existing Python and TypeScript SDK Workflow Streams pages, adapted for the Go implementation in `go.temporal.io/sdk/contrib/workflowstreams`. Defers all conceptual material to the shared `/workflow-streams` encyclopedia page, same as the other two SDK guides.

## What's here

- **New page** `docs/develop/go/workflows/workflow-streams.mdx` — same section structure as the Python/TS guides (enable → publish from Workflow → publish from client → subscribe → Continue-As-New → dedup window → best practices → LLM example → see also).
- **Wiring** — added to the Go Workflows sidebar (`sidebars.js`) and the Go index pages (`docs/develop/go/index.mdx`, `docs/develop/go/workflows/index.mdx`), plus Go `RelatedReadItem` entries on the encyclopedia concept page.

## Go-specific API differences reflected in the doc

- `NewWorkflowStream(ctx, priorState, opts...)` at the top of the workflow function; no double-construction guard (re-registers handlers), so the doc says "construct exactly one."
- **Untyped topics** — `Topic(name)` carries no per-topic type binding; subscribers always decode the raw `*commonpb.Payload` via `converter...FromPayload`.
- Two distinct handle types: workflow-side `Publish(value) error` vs client-side `Publish(value, forceFlush bool)` (no error return, positional bool).
- `defer client.Close(ctx)` replaces Python `async with` / TS `await using`.
- `Subscribe` returns `iter.Seq2[WorkflowStreamItem, error]` (range-over-func).
- Ack handshake via `workflow.GetSignalChannel` + `workflow.AwaitWithTimeout`; Continue-As-New via `stream.NewContinueAsNewError(ctx, wfn, buildArgs)` with the explicit `DetachPollers`/`GetState` recipe for custom task queue or publisher TTL.

## Notes

- The samples link (`https://github.com/temporalio/samples-go/tree/main/workflowstreams`) tracks samples-go PR #490 and will 404 until that merges — same situation as the Python/TS sample links when those pages landed.
- API verified against the source in `sdk-go/contrib/workflowstreams/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215815556696235">EDU-6562 Add Workflow Streams documentation for the Go SDK</a>
