### PR TITLE
hotfix: revert trailingSlash:false (caused sitewide server-side 404s)

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -9,7 +9,6 @@ module.exports = async function createConfigAsync() {
     tagline: 'Build invincible applications',
     url: 'https://docs.temporal.io',
     baseUrl: '/',
-    trailingSlash: false,
     onBrokenLinks: 'throw',
     onBrokenAnchors: 'throw',
     favicon: 'img/favicon.ico',


### PR DESCRIPTION
## Urgent: restores production

PR #4742 set `trailingSlash: false` in `docusaurus.config.js`. This regressed production: **every extensionless doc URL (e.g. `/develop`) now returns a server-side HTTP 404**, rescued client-side by the SPA — users see a "page not found" flash before the real page loads, and crawlers/curl see a 404.

### Root cause
- `trailingSlash: false` makes Docusaurus emit `develop.html` instead of `develop/index.html`.
- `vercel.json` has **no `cleanUrls`**, so Vercel serves the file only at `/develop.html` — `/develop` 404s.
- Confirmed live: `/develop.html` → 200, `/develop` → 404 (server), SPA then renders the page.

### This change
Reverts **only** the `trailingSlash: false` line, returning to Docusaurus's default output (`develop/index.html`), which Vercel serves correctly at `/develop`. 

**Retained from #4742:** the dead-link fix and the sitemap `ignorePatterns`. The sitemap's trailing-slash 308s return temporarily — acceptable (pre-existing, low severity) vs. a sitewide 404.

### Follow-up
Re-do the sitemap fix properly with `trailingSlash: false` **+** `cleanUrls: true` in `vercel.json`, validated on a Vercel **preview deploy** (deep pages = 200) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215837252519168">EDU-6566 hotfix: revert trailingSlash:false (caused sitewide server-side 404s)</a>
