### PR TITLE
Replaced split button in LLM Actions with a row layout for better discovery

### DIFF
--- a/src/components/LLMActions/LLMActions.module.css
+++ b/src/components/LLMActions/LLMActions.module.css
@@ -1,22 +1,22 @@
 .container {
-  position: relative;
   display: inline-flex;
   margin-bottom: 2rem;
 }
 
-.splitButton {
-  display: inline-flex;
-  align-items: stretch;
-  height: 30px;
+.row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.copyButton {
+.button {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
+  height: 30px;
   padding: 0 0.7rem;
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-right: none;
   background: transparent;
   color: var(--ifm-color-emphasis-700);
   font-family: inherit;
@@ -30,106 +30,71 @@
   transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
 }
 
-.copyButton:hover {
+.button:hover {
   background: var(--ifm-color-emphasis-100);
   border-color: var(--ifm-color-emphasis-400);
   color: var(--ifm-color-emphasis-800);
+  text-decoration: none;
 }
 
-.copyButton:focus-visible {
+.button:focus-visible {
   outline: 2px solid var(--ifm-color-primary);
   outline-offset: 2px;
 }
 
-.copyButton:disabled {
+.button:disabled {
   opacity: 0.6;
   cursor: not-allowed;
 }
 
-.chevronButton {
+.openIn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.openInLabel {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--ifm-color-emphasis-600);
+}
+
+.iconLink {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0 0.5rem;
+  width: 30px;
+  height: 30px;
   border: 1px solid var(--ifm-color-emphasis-300);
-  border-left: 1px solid var(--ifm-color-emphasis-200);
   background: transparent;
   color: var(--ifm-color-emphasis-700);
-  font-family: inherit;
   box-sizing: border-box;
   cursor: pointer;
+  text-decoration: none;
   border-radius: 0;
   transition: background-color 150ms ease, border-color 150ms ease, color 150ms ease;
 }
 
-.chevronButton:hover {
+.iconLink:hover {
   background: var(--ifm-color-emphasis-100);
   border-color: var(--ifm-color-emphasis-400);
-  border-left-color: var(--ifm-color-emphasis-300);
   color: var(--ifm-color-emphasis-800);
+  text-decoration: none;
 }
 
-.chevronButton:focus-visible {
+.iconLink[data-analytics-id='open-in-chatgpt']:hover {
+  color: #10a37f;
+  border-color: #10a37f;
+}
+
+.iconLink[data-analytics-id='open-in-claude']:hover {
+  color: #d97757;
+  border-color: #d97757;
+}
+
+.iconLink:focus-visible {
   outline: 2px solid var(--ifm-color-primary);
   outline-offset: 2px;
-}
-
-.dropdown {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  z-index: 100;
-  /* Pull up 1px so the menu's top border merges with the split button's
-     bottom border into a single continuous line instead of doubling up. */
-  margin-top: -1px;
-  background: var(--ifm-background-color);
-  border: 1px solid var(--ifm-color-emphasis-300);
-  min-width: 190px;
-}
-
-.dropdownItem {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  width: 100%;
-  padding: 0.45rem 0.75rem;
-  border: none;
-  border-bottom: 1px solid var(--ifm-color-emphasis-200);
-  background: transparent;
-  color: var(--ifm-color-emphasis-700);
-  font-family: inherit;
-  font-size: 0.8rem;
-  font-weight: 500;
-  line-height: 1.5;
-  box-sizing: border-box;
-  cursor: pointer;
-  text-decoration: none;
-  text-align: left;
-  transition: background-color 150ms ease, color 150ms ease;
-}
-
-.dropdownItem:last-child {
-  border-bottom: none;
-}
-
-.dropdownItem:hover {
-  background: var(--ifm-color-emphasis-100);
-  color: var(--ifm-color-emphasis-800);
-  text-decoration: none;
-}
-
-.dropdownItem:focus-visible {
-  outline: 2px solid var(--ifm-color-primary);
-  outline-offset: -2px;
-}
-
-.dropdownItem:disabled {
-  opacity: 0.6;
-  cursor: not-allowed;
-}
-
-.dropdownItem span {
-  flex: 1;
 }
 
 .icon {
@@ -138,70 +103,46 @@
   flex-shrink: 0;
 }
 
-.chevronIcon {
-  width: 0.75em;
-  height: 0.75em;
-  flex-shrink: 0;
-}
-
-.externalIcon {
-  width: 0.7em;
-  height: 0.7em;
-  flex-shrink: 0;
-  opacity: 0.6;
-  margin-left: auto;
-}
-
 /* Dark mode adjustments */
-:global([data-theme='dark']) .copyButton,
-:global([data-theme='dark']) .chevronButton {
+:global([data-theme='dark']) .button,
+:global([data-theme='dark']) .iconLink {
   border-color: var(--ifm-color-emphasis-400);
   color: var(--ifm-color-emphasis-600);
 }
 
-:global([data-theme='dark']) .chevronButton {
-  border-left-color: var(--ifm-color-emphasis-300);
-}
-
-:global([data-theme='dark']) .copyButton:hover,
-:global([data-theme='dark']) .chevronButton:hover {
+:global([data-theme='dark']) .button:hover,
+:global([data-theme='dark']) .iconLink:hover {
   background: var(--ifm-color-emphasis-200);
   border-color: var(--ifm-color-emphasis-500);
   color: var(--ifm-color-emphasis-800);
 }
 
-:global([data-theme='dark']) .dropdown {
-  border-color: var(--ifm-color-emphasis-400);
+:global([data-theme='dark']) .iconLink[data-analytics-id='open-in-chatgpt']:hover {
+  color: #10a37f;
+  border-color: #10a37f;
 }
 
-:global([data-theme='dark']) .dropdownItem {
-  border-bottom-color: var(--ifm-color-emphasis-300);
-  color: var(--ifm-color-emphasis-600);
-}
-
-:global([data-theme='dark']) .dropdownItem:hover {
-  background: var(--ifm-color-emphasis-200);
-  color: var(--ifm-color-emphasis-800);
+:global([data-theme='dark']) .iconLink[data-analytics-id='open-in-claude']:hover {
+  color: #d97757;
+  border-color: #d97757;
 }
 
 @media (max-width: 600px) {
   .container {
     display: flex;
-    flex-direction: column;
-    align-items: stretch;
+    width: 100%;
   }
 
-  .splitButton {
+  .row {
+    width: 100%;
+  }
+
+  .button {
     height: 38px;
   }
 
-  .copyButton {
-    flex: 1;
-    justify-content: center;
-    padding: 0 1rem;
-  }
-
-  .dropdown {
-    min-width: 100%;
+  .iconLink {
+    width: 38px;
+    height: 38px;
   }
 }

--- a/src/components/LLMActions/LLMActions.tsx
+++ b/src/components/LLMActions/LLMActions.tsx
@@ -1,15 +1,13 @@
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback } from 'react';
 import { useDoc } from '@docusaurus/plugin-content-docs/client';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
-import { FaRegCopy, FaCheck, FaMarkdown, FaExternalLinkAlt, FaChevronDown, FaChevronUp } from 'react-icons/fa';
+import { FaRegCopy, FaCheck, FaMarkdown } from 'react-icons/fa';
 import { SiOpenai, SiClaude } from 'react-icons/si';
 import styles from './LLMActions.module.css';
 
 export default function LLMActions() {
   const [copied, setCopied] = useState(false);
   const [loading, setLoading] = useState(false);
-  const [open, setOpen] = useState(false);
-  const containerRef = useRef<HTMLDivElement>(null);
 
   const { metadata, frontMatter } = useDoc();
   const { permalink } = metadata;
@@ -31,7 +29,6 @@ export default function LLMActions() {
 
   const handleCopyForLLM = useCallback(async () => {
     setLoading(true);
-    setOpen(false);
     try {
       const response = await fetch(mdPath);
       if (!response.ok) {
@@ -50,32 +47,15 @@ export default function LLMActions() {
     }
   }, [mdPath, pageUrl]);
 
-  const handleViewMarkdown = useCallback(() => {
-    window.open(mdPath, '_blank', 'noopener,noreferrer');
-    setOpen(false);
-  }, [mdPath]);
-
-  // Close dropdown when clicking outside
-  useEffect(() => {
-    if (!open) return;
-    function handleClick(e: MouseEvent) {
-      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener('mousedown', handleClick);
-    return () => document.removeEventListener('mousedown', handleClick);
-  }, [open]);
-
   if (!permalink || frontMatter.llm_exclude) {
     return null;
   }
 
   return (
-    <div className={styles.container} ref={containerRef} data-analytics-component="llm-actions">
-      <div className={styles.splitButton}>
+    <div className={styles.container} data-analytics-component="llm-actions">
+      <div className={styles.row}>
         <button
-          className={styles.copyButton}
+          className={styles.button}
           onClick={handleCopyForLLM}
           disabled={loading}
           title="Copy page markdown for use with LLMs"
@@ -87,65 +67,49 @@ export default function LLMActions() {
           ) : (
             <FaRegCopy className={styles.icon} />
           )}
-          {loading ? 'Loading...' : copied ? 'Copied!' : 'Copy'}
+          {loading ? 'Loading...' : copied ? 'Copied!' : 'Copy Markdown'}
         </button>
-        <button
-          className={styles.chevronButton}
-          onClick={() => setOpen((v) => !v)}
-          aria-haspopup="true"
-          aria-expanded={open}
-          title="More options"
-          data-analytics-id="llm-actions-toggle"
+
+        <a
+          className={styles.button}
+          href={mdPath}
+          target="_blank"
+          rel="noopener noreferrer"
+          title="View this page as Markdown"
+          data-analytics-id="view-as-markdown"
           data-analytics-action="click"
         >
-          {open ? (
-            <FaChevronUp className={styles.chevronIcon} />
-          ) : (
-            <FaChevronDown className={styles.chevronIcon} />
-          )}
-        </button>
-      </div>
+          <FaMarkdown className={styles.icon} />
+          <span>View Markdown</span>
+        </a>
 
-      {open && (
-        <div className={styles.dropdown}>
-          <button
-            className={styles.dropdownItem}
-            onClick={handleViewMarkdown}
-            data-analytics-id="view-as-markdown"
-            data-analytics-action="click"
-          >
-            <FaMarkdown className={styles.icon} />
-            <span>View as Markdown</span>
-            <FaExternalLinkAlt className={styles.externalIcon} />
-          </button>
+        <div className={styles.openIn}>
           <a
-            className={styles.dropdownItem}
+            className={styles.iconLink}
             href={chatGptUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => setOpen(false)}
+            title="Open in ChatGPT"
+            aria-label="Open in ChatGPT"
             data-analytics-id="open-in-chatgpt"
             data-analytics-action="click"
           >
             <SiOpenai className={styles.icon} />
-            <span>Open in ChatGPT</span>
-            <FaExternalLinkAlt className={styles.externalIcon} />
           </a>
           <a
-            className={styles.dropdownItem}
+            className={styles.iconLink}
             href={claudeUrl}
             target="_blank"
             rel="noopener noreferrer"
-            onClick={() => setOpen(false)}
+            title="Open in Claude"
+            aria-label="Open in Claude"
             data-analytics-id="open-in-claude"
             data-analytics-action="click"
           >
             <SiClaude className={styles.icon} />
-            <span>Open in Claude</span>
-            <FaExternalLinkAlt className={styles.externalIcon} />
           </a>
         </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Revamps the LLM actions buttons to remove the drop down and bring back more meaning to the Copy command

Currently production experience:
<img width="857" height="274" alt="Production UX showing dropdown" src="https://github.com/user-attachments/assets/d432eae9-55c9-4e07-99da-a50619ab0966" />


New proposal:
<img width="700" height="174" alt="New proposed UX" src="https://github.com/user-attachments/assets/b0d662f0-0ac3-4611-a21e-ad9515a6aa0d" />



This is in response to the significant drop in engagement on these actions after the new UX was rolled out, but still keeps the ChatGPT & Claude functionality
<img width="1581" height="544" alt="Screenshot 2026-06-22 at 10 06 17 AM" src="https://github.com/user-attachments/assets/3dd1d3e9-9755-4a69-bd91-9fe6bc135866" />

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215935557905920">EDU-6575 Replaced split button in LLM Actions with a row layout for better discovery</a>
