### PR TITLE
Add analytics tracking to IntegrationsGrid

### DIFF
--- a/src/components/IntegrationsGrid/index.tsx
+++ b/src/components/IntegrationsGrid/index.tsx
@@ -82,6 +82,8 @@ function IntegrationCard({ item }: { item: Integration }) {
       to={item.href}
       className={styles.card}
       {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+      data-analytics-id={`integrations-card-${item.name}`}
+      data-analytics-action="click"
     >
       <div className={styles.cardHeader}>
         <h3 className={styles.cardName}>
@@ -146,7 +148,7 @@ export default function IntegrationsGrid({
   }, [query, filters]);
 
   return (
-    <div className={styles.container}>
+    <div className={styles.container} data-analytics-component="integrations-grid">
       <div className={styles.searchWrapper}>
         <span className={styles.searchIcon}>
           <SearchIcon />
@@ -158,6 +160,8 @@ export default function IntegrationsGrid({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           aria-label="Search integrations"
+          data-analytics-id="integrations-search"
+          data-analytics-action="input"
         />
       </div>
 
@@ -177,6 +181,8 @@ export default function IntegrationsGrid({
                   setFilters((f) => ({ ...f, [key]: toggleIn(f[key], value) }))
                 }
                 aria-pressed={filters[key].includes(value)}
+                data-analytics-id={`integrations-filter-${key}-${value}`}
+                data-analytics-action="click"
               >
                 {value}
               </button>


### PR DESCRIPTION
## Summary
- Add `data-analytics-*` attributes to the IntegrationsGrid component to track user interactions via Amplitude.
- Follows the same declarative pattern used by the LLM Actions component.

### Events tracked

| Element | `data-analytics-id` | `data-analytics-action` |
|---|---|---|
| Grid container | `integrations-grid` (component) | — |
| Search input | `integrations-search` | `input` |
| Filter pills | `integrations-filter-{sdks\|tags}-{value}` | `click` |
| Integration cards | `integrations-card-{name}` | `click` |

## Test plan
- [x] Verify `data-analytics-*` attributes render in DOM via browser dev tools
- [x] Confirm Amplitude picks up events (check Amplitude dashboard after interacting with the page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215940719444566">EDU-6576 Add analytics tracking to IntegrationsGrid</a>
