### PR TITLE
Fix payload size limit docs with SDK versions and behaviors

### DIFF
--- a/docs/troubleshooting/blob-size-limit-error.mdx
+++ b/docs/troubleshooting/blob-size-limit-error.mdx
@@ -45,8 +45,9 @@ include:
 
 The behavior when a payload exceeds the size limit depends on the SDK version.
 
-**Python SDK 1.23.0+:** The SDK fails the Workflow Task with cause `WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE`. The
-Workflow is not terminated and remains open, so you can deploy a fix and allow the Workflow to continue.
+**Python SDK 1.23.0+ and Go SDK 1.43.0+:** The SDK fails the Workflow Task with cause `WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE`. The
+Workflow is not terminated and remains open, so you can deploy a fix and allow the Workflow to continue. For Activities,
+the Activity Task fails with an explicit error instead of timing out silently.
 
 **All other SDK versions:** The behavior depends on whether the oversized payload is an input or a result:
 
@@ -100,13 +101,7 @@ The error message depends on which operation carried the oversized gRPC message 
 
 ### Error behavior {/* #grpc-error-behavior */}
 
-The behavior when a gRPC message exceeds the size limit depends on the SDK version.
-
-**Python SDK 1.23.0+:** The SDK fails the Workflow Task with cause `WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE`. The
-Workflow is not terminated and remains open, so you can deploy a fix and allow the Workflow to continue. For Activities,
-the Activity fails with an explicit error instead of timing out silently.
-
-**All other SDK versions:** The behavior depends on where the oversized message originates:
+The behavior depends on where the oversized message originates:
 
 - **Workflow Tasks:** The Workflow gets stuck in a retry loop that isn't visible in the Event History. This happens
   because when the Worker completes a Workflow Task, it sends all the commands the Workflow produced (such as Activity


### PR DESCRIPTION
## What does this PR do?

Updates to the blob size limit error documentation:
- Add Go SDK 1.43.0 to SDK list that proactively fails WFT and AT when payload sizes are too large.
- Move AT proactive failure behavior from gRPC message size to payload size section.
- Remove `WORKFLOW_TASK_FAILED_CAUSE_PAYLOADS_TOO_LARGE` and related description from gRPC message size section since they are not related.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1215972912805434">EDU-6580 Fix payload size limit docs with SDK versions and behaviors</a>
