### PR TITLE
Move Java Standalone Activities to Public Preview

### DIFF
--- a/docs/develop/java/activities/standalone-activities.mdx
+++ b/docs/develop/java/activities/standalone-activities.mdx
@@ -22,7 +22,7 @@ description: Execute Activities independently without a Workflow using the Tempo
 import { ReleaseNoteHeader } from '@site/src/components';
 
 <ReleaseNoteHeader
-  type="prerelease"
+  featureName="standaloneActivity"
 />
 
 [Standalone Activities](/standalone-activity) are Activities that run independently, without being orchestrated by a

--- a/docs/develop/python/activities/standalone-activities.mdx
+++ b/docs/develop/python/activities/standalone-activities.mdx
@@ -23,7 +23,6 @@ import { ReleaseNoteHeader } from '@site/src/components';
 
 <ReleaseNoteHeader
   featureName="standaloneActivity"
-  languages={["Go", "TypeScript", "Java", ".NET", "Python"]}
 />
 
 Standalone Activities are Activities that run independently, without being orchestrated by a

--- a/docs/encyclopedia/activities/standalone-activity.mdx
+++ b/docs/encyclopedia/activities/standalone-activity.mdx
@@ -23,7 +23,7 @@ import { ReleaseNoteHeader } from '@site/src/components';
   featureName="standaloneActivity"
   languages={["Go", "Python", "Java", ".NET", "TypeScript", "Ruby"]}
 >
-  Available in [Temporal Cloud](#temporal-cloud-support) and in the [Temporal CLI](#temporal-cli-support) v1.7.0 or higher with Temporal Server v1.31.0 or higher. Java SDK support is in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
+  Available in [Temporal Cloud](#temporal-cloud-support) and in Temporal Server v1.31.0 or higher (included in [Temporal CLI](#temporal-cli-support) v1.7.0 or higher).
 </ReleaseNoteHeader>
 
 See [limitations](#public-preview-limitations) below.


### PR DESCRIPTION
## What does this PR do?

- Java SDK v1.36.0 moves Standalone Activities from Pre-release to Public Preview. The updated docs replace the local `type` override with `featureName`.
- Removed Java-specific sentence and made the wording in the infobox clearer on SAA Encyclopedia page.
- Removed language badges from Python page infobox.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216012515546111">EDU-6585 Move Java Standalone Activities to Public Preview</a>
