### PR TITLE
Update to include timeline view in the 'enriching ui' section of docs

### DIFF
--- a/docs/develop/dotnet/platform/enriching-ui.mdx
+++ b/docs/develop/dotnet/platform/enriching-ui.mdx
@@ -162,7 +162,7 @@ The **Timeline** tab on the Workflow details page renders each Activity and Time
   
 Labels longer than 120 characters are truncated with an ellipsis.
   
-Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+Setting a distinct `Summary` per Activity is especially useful for **fan-out Workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
      
 Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
 

--- a/docs/develop/dotnet/platform/enriching-ui.mdx
+++ b/docs/develop/dotnet/platform/enriching-ui.mdx
@@ -156,6 +156,17 @@ At the top of the Workflow details page, you'll find the Workflow-level metadata
 
 All Workflow details support standard Markdown formatting (excluding images, HTML, and scripts), allowing you to create rich, structured information displays.
 
+### Timeline
+ 
+The **Timeline** tab on the Workflow details page renders each Activity and Timer as a horizontal bar. When you set a `Summary` on an Activity or Timer, the summary text is shown directly on the bar label, making it possible to distinguish individual instances of the same Activity Type at a glance.
+  
+Labels longer than 120 characters are truncated with an ellipsis.
+  
+Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+     
+Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
+
+
 ### Event History
 
 Individual events in the Workflow's Event History display their associated summaries when available.

--- a/docs/develop/dotnet/platform/enriching-ui.mdx
+++ b/docs/develop/dotnet/platform/enriching-ui.mdx
@@ -145,7 +145,7 @@ The input format for `Summary` is a string, and limited to 200 bytes.
 ## Viewing Summary and Details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and timers, you can view this enriched information in the Temporal Web UI. 
-Navigate to your Workflow's details page to see the metadata displayed in two key locations:
+Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
 ### Workflow Overview Section
 

--- a/docs/develop/go/platform/enriching-ui.mdx
+++ b/docs/develop/go/platform/enriching-ui.mdx
@@ -142,7 +142,7 @@ The input format for `Summary` is a string, and limited to 200 bytes.
 ## Viewing Summary and Details in the UI
 
 Once you've added summaries and details to your workflows, activities, and timers, you can view this enriched information in the Temporal Web UI. 
-Navigate to your Workflow's details page to see the metadata displayed in two key locations:
+Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
 ### Workflow Overview Section
 
@@ -153,9 +153,19 @@ At the top of the workflow details page, you'll find the workflow-level metadata
 
 All Workflow details support standard Markdown formatting (excluding images, HTML, and scripts), allowing you to create rich, structured information displays.
 
+### Timeline
+ 
+The **Timeline** tab on the Workflow details page renders each Activity and Timer as a horizontal bar. When you set a `Summary` on an Activity or Timer, the summary text is shown directly on the bar label, making it possible to distinguish individual instances of the same Activity Type at a glance.
+  
+Labels longer than 120 characters are truncated with an ellipsis.
+  
+Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+     
+Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
+
 ### Event History
 
-Individual events in the Workflow's Event History display their associated summaries when available.
+Individual events in the Workflow's **Event History** display their associated summaries when available, both in the timeline graph at the top of the tab and in the events table below it.
 
 Workflow, Activity and Timer summaries appear in purple text next to their corresponding events, providing immediate context without requiring you to expand the event details. 
 When you do expand an event, the summary is also prominently displayed in the detailed view. 

--- a/docs/develop/go/platform/enriching-ui.mdx
+++ b/docs/develop/go/platform/enriching-ui.mdx
@@ -159,7 +159,7 @@ The **Timeline** tab on the Workflow details page renders each Activity and Time
   
 Labels longer than 120 characters are truncated with an ellipsis.
   
-Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+Setting a distinct `Summary` per Activity is especially useful for **fan-out Workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
      
 Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
 

--- a/docs/develop/go/platform/enriching-ui.mdx
+++ b/docs/develop/go/platform/enriching-ui.mdx
@@ -165,7 +165,7 @@ Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** an
 
 ### Event History
 
-Individual events in the Workflow's **Event History** display their associated summaries when available, both in the timeline graph at the top of the tab and in the events table below it.
+Individual events in the Workflow's Event History display their associated summaries when available, both in the timeline graph at the top of the tab and in the events table below it.
 
 Workflow, Activity and Timer summaries appear in purple text next to their corresponding events, providing immediate context without requiring you to expand the event details. 
 When you do expand an event, the summary is also prominently displayed in the detailed view. 

--- a/docs/develop/java/platform/enriching-ui.mdx
+++ b/docs/develop/java/platform/enriching-ui.mdx
@@ -143,7 +143,7 @@ The input format for `setSummary()` is a string, and limited to 200 bytes.
 ## Viewing Summary and Details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI. 
-Navigate to your Workflow's details page to see the metadata displayed in two key locations:
+Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
 ### Workflow Overview Section
 

--- a/docs/develop/java/platform/enriching-ui.mdx
+++ b/docs/develop/java/platform/enriching-ui.mdx
@@ -160,7 +160,7 @@ The **Timeline** tab on the Workflow details page renders each Activity and Time
   
 Labels longer than 120 characters are truncated with an ellipsis.
   
-Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+Setting a distinct `Summary` per Activity is especially useful for **fan-out Workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
      
 Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
 

--- a/docs/develop/java/platform/enriching-ui.mdx
+++ b/docs/develop/java/platform/enriching-ui.mdx
@@ -154,6 +154,17 @@ At the top of the workflow details page, you'll find the workflow-level metadata
 
 All Workflow details support standard Markdown formatting (excluding images, HTML, and scripts), allowing you to create rich, structured information displays.
 
+### Timeline
+ 
+The **Timeline** tab on the Workflow details page renders each Activity and Timer as a horizontal bar. When you set a `Summary` on an Activity or Timer, the summary text is shown directly on the bar label, making it possible to distinguish individual instances of the same Activity Type at a glance.
+  
+Labels longer than 120 characters are truncated with an ellipsis.
+  
+Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+     
+Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
+
+
 ### Event History
 
 Individual events in the Workflow's Event History display their associated summaries when available.

--- a/docs/develop/php/platform/enriching-ui.mdx
+++ b/docs/develop/php/platform/enriching-ui.mdx
@@ -140,7 +140,7 @@ The **Timeline** tab on the Workflow details page renders each Activity and Time
   
 Labels longer than 120 characters are truncated with an ellipsis.
   
-Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+Setting a distinct `Summary` per Activity is especially useful for **fan-out Workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
      
 Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
 

--- a/docs/develop/php/platform/enriching-ui.mdx
+++ b/docs/develop/php/platform/enriching-ui.mdx
@@ -123,7 +123,7 @@ The input format for `summary` is a string, and limited to 200 bytes.
 ## Viewing Summary and Details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI. 
-Navigate to your Workflow's details page to see the metadata displayed in two key locations:
+Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
 ### Workflow Overview Section
 

--- a/docs/develop/php/platform/enriching-ui.mdx
+++ b/docs/develop/php/platform/enriching-ui.mdx
@@ -134,6 +134,16 @@ At the top of the Workflow details page, you'll find the Workflow-level metadata
 
 All Workflow details support standard Markdown formatting (excluding images, HTML, and scripts), allowing you to create rich, structured information displays.
 
+### Timeline
+ 
+The **Timeline** tab on the Workflow details page renders each Activity and Timer as a horizontal bar. When you set a `Summary` on an Activity or Timer, the summary text is shown directly on the bar label, making it possible to distinguish individual instances of the same Activity Type at a glance.
+  
+Labels longer than 120 characters are truncated with an ellipsis.
+  
+Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+     
+Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
+
 ### Event History
 
 Individual events in the Workflow's Event History display their associated summaries when available.

--- a/docs/develop/python/platform/enriching-ui.mdx
+++ b/docs/develop/python/platform/enriching-ui.mdx
@@ -130,7 +130,7 @@ The **Timeline** tab on the Workflow details page renders each Activity and Time
   
 Labels longer than 120 characters are truncated with an ellipsis.
   
-Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+Setting a distinct `Summary` per Activity is especially useful for **fan-out Workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
      
 Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
 

--- a/docs/develop/python/platform/enriching-ui.mdx
+++ b/docs/develop/python/platform/enriching-ui.mdx
@@ -113,7 +113,7 @@ The input format for `summary` is a string, and limited to 200 bytes.
 ## Viewing Summary and Details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI. 
-Navigate to your Workflow's details page to see the metadata displayed in two key locations:
+Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
 ### Workflow Overview Section
 

--- a/docs/develop/python/platform/enriching-ui.mdx
+++ b/docs/develop/python/platform/enriching-ui.mdx
@@ -124,6 +124,16 @@ At the top of the Workflow details page, you'll find the Workflow-level metadata
 
 All Workflow details support standard Markdown formatting (excluding images, HTML, and scripts), allowing you to create rich, structured information displays.
 
+### Timeline
+ 
+The **Timeline** tab on the Workflow details page renders each Activity and Timer as a horizontal bar. When you set a `Summary` on an Activity or Timer, the summary text is shown directly on the bar label, making it possible to distinguish individual instances of the same Activity Type at a glance.
+  
+Labels longer than 120 characters are truncated with an ellipsis.
+  
+Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+     
+Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
+
 ### Event History
 
 Individual events in the Workflow's Event History display their associated summaries when available.

--- a/docs/develop/ruby/platform/enriching-ui.mdx
+++ b/docs/develop/ruby/platform/enriching-ui.mdx
@@ -138,6 +138,16 @@ At the top of the workflow details page, you'll find the workflow-level metadata
 
 All Workflow details support standard Markdown formatting (excluding images, HTML, and scripts), allowing you to create rich, structured information displays.
 
+### Timeline
+ 
+The **Timeline** tab on the Workflow details page renders each Activity and Timer as a horizontal bar. When you set a `Summary` on an Activity or Timer, the summary text is shown directly on the bar label, making it possible to distinguish individual instances of the same Activity Type at a glance.
+  
+Labels longer than 120 characters are truncated with an ellipsis.
+  
+Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+     
+Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
+
 ### Event History
 
 Individual events in the Workflow's Event History display their associated summaries when available:

--- a/docs/develop/ruby/platform/enriching-ui.mdx
+++ b/docs/develop/ruby/platform/enriching-ui.mdx
@@ -144,7 +144,7 @@ The **Timeline** tab on the Workflow details page renders each Activity and Time
   
 Labels longer than 120 characters are truncated with an ellipsis.
   
-Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+Setting a distinct `Summary` per Activity is especially useful for **fan-out Workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
      
 Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
 

--- a/docs/develop/ruby/platform/enriching-ui.mdx
+++ b/docs/develop/ruby/platform/enriching-ui.mdx
@@ -127,7 +127,7 @@ The input format for `summary:` is a string, and limited to 200 bytes.
 ## Viewing Summary and Details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI. 
-Navigate to your Workflow's details page to see the metadata displayed in two key locations:
+Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
 ### Workflow Overview Section
 

--- a/docs/develop/typescript/platform/enriching-ui.mdx
+++ b/docs/develop/typescript/platform/enriching-ui.mdx
@@ -133,6 +133,16 @@ At the top of the workflow details page, you'll find the workflow-level metadata
 
 All Workflow details support standard Markdown formatting (excluding images, HTML, and scripts), allowing you to create rich, structured information displays.
 
+### Timeline
+ 
+The **Timeline** tab on the Workflow details page renders each Activity and Timer as a horizontal bar. When you set a `Summary` on an Activity or Timer, the summary text is shown directly on the bar label, making it possible to distinguish individual instances of the same Activity Type at a glance.
+  
+Labels longer than 120 characters are truncated with an ellipsis.
+  
+Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+     
+Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
+
 ### Event History
 
 Individual events in the Workflow's Event History display their associated summaries when available. 

--- a/docs/develop/typescript/platform/enriching-ui.mdx
+++ b/docs/develop/typescript/platform/enriching-ui.mdx
@@ -122,7 +122,7 @@ The input format for `summary` is a string, and limited to 200 bytes.
 ## Viewing Summary and Details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI.
-Navigate to your Workflow's details page to see the metadata displayed in two key locations:
+Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
 ### Workflow Overview Section
 

--- a/docs/develop/typescript/platform/enriching-ui.mdx
+++ b/docs/develop/typescript/platform/enriching-ui.mdx
@@ -139,7 +139,7 @@ The **Timeline** tab on the Workflow details page renders each Activity and Time
   
 Labels longer than 120 characters are truncated with an ellipsis.
   
-Setting a distinct `Summary` per Activity is especially useful for **fan-out workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
+Setting a distinct `Summary` per Activity is especially useful for **fan-out Workflows** that schedule many instances of the same Activity Type, where the Activity Type alone is not enough to tell each bar apart on the Timeline. 
      
 Activity `Summary` support on the Timeline shipped in Temporal UI **v2.34.6** and is available on Temporal Cloud and on self-hosted UI builds at that version or later.
 


### PR DESCRIPTION
## What does this PR do?

Adds details around the timeline view to the enriching-ui doc pages.

## Notes to reviewers


<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216078378828042">EDU-6603 Update to include timeline view in the &#39;enriching ui&#39; section of docs</a>
