### PR TITLE
Centralize Cloud throughput default limit; point to UI, CLI, and metrics for the current value

### DIFF
--- a/docs/cloud/capacity-modes.mdx
+++ b/docs/cloud/capacity-modes.mdx
@@ -99,15 +99,12 @@ Actions that are external to the core Temporal service do not contribute to your
 
 ## On-Demand Capacity {/* #on-demand-capacity */}
 
-Using On-Demand Capacity, your rate limit grows automatically along with your usage. 
-
-
-|               | Actions Per Second | Requests Per Second | Operations Per Second|
-|---------------|--------------------|---------------------|----------------------|
-| Default Limit | 500                | 2000                | 4000                 |
-
+Using On-Demand Capacity, your rate limit grows automatically along with your usage.
+Each Namespace has an Actions per second (APS), Requests per second (RPS), and Operations per second (OPS) limit that scales automatically with usage. Your APS limit never falls below its [default limit](/cloud/limits#actions-per-second).
 
 Scaling automatically adjusts based on the lesser of 4 * APS Average or 2 * APS P90 over the past 7 days.
+
+To see your Namespace's current APS, RPS, and OPS limits, track the `temporal_cloud_v1_action_limit`, `temporal_cloud_v1_service_request_limit`, and `temporal_cloud_v1_operations_limit` metrics. See [Monitoring Trends Against Limits](/cloud/service-health#rps-aps-rate-limits).
 
 If you experience usage spikes, you may hit a throughput limit. 
 In that case, consider switching to [Provisioned Capacity](#provisioned-capacity). 
@@ -116,18 +113,18 @@ You can also optimize your workload to remain under the On-Demand limits. See [B
 ### What kind of throughput can I get on Temporal Cloud with On-Demand Capacity?
 
 Each Namespace has a rate limit, which is measured in Actions per second (APS). 
-A Namespace's default limit is set at 500 APS and automatically adjusts based on a formula that compares your average usage over the last 7 days and your usage at the 90th percentile, or P90. 
-Your throughput limit will never fall below the default value. 
+Your APS limit automatically adjusts based on a formula that compares your average usage over the last 7 days and your usage at the 90th percentile, or P90. 
+Your throughput limit will never fall below the [default limit](/cloud/limits#actions-per-second) for your Namespace. 
 Under On-Demand capacity you are only charged for the Actions you use.
+To see your current limit, view it in the Temporal Cloud UI under the Namespace overview, retrieve it with the [Temporal CLI](/cli/command-reference/cloud/namespace#capacity) (`temporal cloud namespace capacity get`), or track the `temporal_cloud_v1_action_limit` metric described in [Monitoring Trends Against Limits](/cloud/service-health#rps-aps-rate-limits).
 
-For example: If your average APS in the last 7 days was 200 APS, and your P90 was 500 APS, then your limit would be calculated as follows:
-Greater of:
-* Default limit of 500 APS
+For example, if your average APS over the last 7 days was 200 and your P90 was 500, your limit would be the greater of:
+* The [default limit](/cloud/limits#actions-per-second)
 * The lesser of:
   * 4 * 200 APS Mean = 800 APS
   * 2 * 500 APS P90 = 1000 APS
 
-This means that your default limit would be 800 APS.
+Because 800 APS exceeds the default limit, your limit in this example would be 800 APS.
 
 ![Usage graph showing increasing APS usage for one month, with occasional spikes, and a rising APS limit](/img/cloud/provisioned-capacity/usage_graph.png)
 

--- a/docs/evaluate/temporal-cloud/limits.mdx
+++ b/docs/evaluate/temporal-cloud/limits.mdx
@@ -57,11 +57,9 @@ The following limits apply at the Namespace level.
 ### Actions per second
 
 - Scope: Namespace
-- Default limit: 500 actions per second (APS)
-- How to increase:
-  - Automatically increases (and decreases) based on the last 7 days of APS usage. Will never go below the default limit.
-  - See [Capacity Modes](/cloud/capacity-modes).
-  - [Contact support](/cloud/support#support-ticket).
+- Default limit: 500 actions per second (APS). With On-Demand Capacity, the default limit is the floor your APS limit automatically scales above based on the last 7 days of usage; your limit never falls below the default limit. With Provisioned Capacity, your limit is set by the Temporal Resource Units you provision.
+- See your current limit: View it in the Temporal Cloud UI under the Namespace overview, retrieve it with the [Temporal CLI](/cli/command-reference/cloud/namespace#capacity) (`temporal cloud namespace capacity get`), or track the `temporal_cloud_v1_action_limit` metric. See [Monitoring Trends Against Limits](/cloud/service-health#rps-aps-rate-limits).
+- How to increase: See [Capacity Modes](/cloud/capacity-modes) or [contact support](/cloud/support#support-ticket).
 - What happens when you exceed the limit: See [Throttling behavior](#throttling-behavior) below.
 
 See the [Actions page](/cloud/actions) for the list of actions. 
@@ -69,22 +67,18 @@ See the [Actions page](/cloud/actions) for the list of actions.
 ### Requests per second
 
 - Scope: Namespace
-- Default limit: 2000 requests per second (RPS)
-- How to increase:
-  - Automatically increases (and decreases) based on the last 7 days of RPS usage. Will never go below the default limit.
-  - See [Capacity Modes](/cloud/capacity-modes).
-  - [Contact support](/cloud/support#support-ticket).
+- Limit: Your requests per second (RPS) limit is dynamic and depends on your [capacity mode](/cloud/capacity-modes). With On-Demand Capacity it automatically increases (and decreases) based on the last 7 days of RPS usage and never falls below the On-Demand floor; with Provisioned Capacity it is set by the Temporal Resource Units you provision.
+- See your current limit: Track the `temporal_cloud_v1_service_request_limit` metric. See [Monitoring Trends Against Limits](/cloud/service-health#rps-aps-rate-limits).
+- How to increase: See [Capacity Modes](/cloud/capacity-modes) or [contact support](/cloud/support#support-ticket).
 
 See the [glossary](/glossary#requests-per-second-rps) for more about RPS.
 
 ### Operations per second
 
 - Scope: Namespace
-- Default limit: 4000 operations per second (OPS)
-- How to increase:
-  - Automatically increases (and decreases) based on the last 7 days of OPS usage. Will never go below the default limit.
-  - See [Capacity Modes](/cloud/capacity-modes).
-  - [Contact support](/cloud/support#support-ticket).
+- Limit: Your operations per second (OPS) limit is dynamic and depends on your [capacity mode](/cloud/capacity-modes). With On-Demand Capacity it automatically increases (and decreases) based on the last 7 days of OPS usage and never falls below the On-Demand floor; with Provisioned Capacity it is set by the Temporal Resource Units you provision.
+- See your current limit: Track the `temporal_cloud_v1_operations_limit` metric. See [Monitoring Trends Against Limits](/cloud/service-health#rps-aps-rate-limits).
+- How to increase: See [Capacity Modes](/cloud/capacity-modes) or [contact support](/cloud/support#support-ticket).
 
 See the [operations list](/references/operation-list) for the list of operations.
 


### PR DESCRIPTION
## Summary

Give the namespace **default APS limit a single source of truth**, and point users to the **current** (dynamically scaled) limit instead of hardcoded numbers that go stale.

Before, the On-Demand default APS/RPS/OPS values (500/2000/4000) were duplicated across the System Limits and Capacity Modes pages, so each limit change meant editing several places.

**Default limit:** `500 actions per second (APS)` is now defined once, on the System Limits page (`/cloud/limits#actions-per-second`). Capacity Modes links to it as "the default limit" instead of restating the number, including in the worked scaling example.

**Current limit:** Three ways to see a namespace's current limit, now in the docs:
- Cloud UI — Namespace overview
- Temporal CLI — `temporal cloud namespace capacity get`
- Limit metrics — `temporal_cloud_v1_action_limit` / `_service_request_limit` / `_operations_limit`, under [Monitoring Trends Against Limits](https://docs.temporal.io/cloud/service-health#rps-aps-rate-limits)

## Changes

`docs/evaluate/temporal-cloud/limits.mdx`
- Actions per second: keeps `Default limit: 500 actions per second (APS)` as the canonical definition; adds how to see the current scaled value (UI / CLI / metric).
- Requests / Operations per second: described as dynamic; point to their metric + Monitoring Trends Against Limits (no restated default value).

`docs/cloud/capacity-modes.mdx` (On-Demand section only)
- Removed the duplicated `Default Limit | 500 | 2000 | 4000` table and every literal 500 APS reference.
- Refers to "the [default limit](/cloud/limits#actions-per-second)" in the prose and worked example.
- Added the UI / CLI / metric pointers for the current limit.

## Unchanged (by design)
- Provisioned Capacity / TRUs (TRU table, 500 APS/TRU spec, 1500 RPS, 4000 OPS).
- Other fixed limits: users, namespaces, schedules RPS, Visibility API/sec.
- `operation-api.mdx`, the `service-health.mdx` worked example, `pricing.mdx` math, self-hosted `dynamic-configuration.mdx`.

## RPS/OPS note
Only the APS default (500) is published as a single source, since APS is the headline throughput/billing limit and the one used in the worked example. RPS/OPS point to their metrics for the current value. Can add RPS/OPS defaults to the limits page if reviewers want full parity.

## Checklist
- [x] Follows STYLE.md
- [x] Frontmatter unchanged (edits in place)
- [x] Link targets verified to exist: `#actions-per-second`, `#rps-aps-rate-limits`, `#capacity`, the limit metric names
- [x] No new pages; `sidebars.js` not affected
- [ ] Local `yarn build` not run — blocked by an upstream registry quarantine on `dompurify@3.4.11` (from dependency bumps on main), unrelated to these edits. Relying on CI build; link targets verified manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)