### PR TITLE
Note the Temporal Cloud 40 KB Memo size limit

### DIFF
--- a/docs/encyclopedia/workflow/workflow-execution/workflow-execution.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/workflow-execution.mdx
@@ -182,6 +182,8 @@ Memos shouldn't store data that's critical to the execution of a Workflow, for s
 
 :::
 
+On Temporal Cloud, a Memo is limited to 40 KB.
+
 ## What is a State Transition? {/* #state-transition */}
 
 A State Transition is a unit of progress made by a [Workflow Execution](#workflow-execution).


### PR DESCRIPTION
## Summary

Adds a one-line note in the Memo concept section of the Workflow Execution overview stating that a Memo is limited to **40 KB** on Temporal Cloud.

## Why

Memo previously had no documented size limit of its own — it silently inherited the general 2 MB payload limit. This adds the 40 KB ceiling where Memo is defined so users have a reference.

## Note on merge timing

The 40 KB limit is rolling out gradually across Cloud cells; this should merge to coincide with enforcement.

## Checklist
- [x] Follows STYLE.md guidelines
- [x] Edits an existing page (no new pages, no sidebar change)
- [x] No new broken links