### PR TITLE
docs: Add Datadog Cost Management integration

### DIFF
--- a/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
@@ -42,7 +42,9 @@ Datadog provides a serverless integration with the OpenMetrics endpoint. It scra
 
 For Datadog-side details, see the [Datadog integration page](https://docs.datadoghq.com/integrations/temporal-cloud-openmetrics/).
 
-For Datadog users, treat this integration as the Cloud-side half of your observability setup:
+Datadog also offers a separate [Cost Management integration](https://docs.datadoghq.com/integrations/temporal-cloud-costs/) that sends Temporal Cloud billing data to Datadog Cloud Cost Management for spend attribution by namespace and service type.
+
+For Datadog users, treat the OpenMetrics integration as the Cloud-side half of your observability setup:
 
 - Use OpenMetrics in Datadog to monitor Temporal Cloud behavior such as Task Queue backlog, poll success, and rate limiting.
 - Collect [SDK metrics](/cloud/metrics/sdk-metrics-setup) from your Workers separately to monitor saturation, Schedule-To-Start latency, slot availability, and sticky cache behavior.

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -36,13 +36,22 @@
     "href": "https://clickhouse.com/docs/use-cases/observability/clickstack/integrations/temporal-metrics"
   },
   {
-    "name": "Datadog",
+    "name": "Datadog (Metrics)",
     "description": "Export Temporal Cloud metrics to Datadog with a serverless integration and pre-built dashboard.",
     "tags": [
       "Observability",
       "Temporal Cloud"
     ],
     "href": "https://docs.datadoghq.com/integrations/temporal-cloud-openmetrics/"
+  },
+  {
+    "name": "Datadog (Cost Management)",
+    "description": "Send Temporal Cloud billing data to Datadog Cloud Cost Management for spend attribution by namespace and service type.",
+    "tags": [
+      "Observability",
+      "Temporal Cloud"
+    ],
+    "href": "https://docs.datadoghq.com/integrations/temporal-cloud-costs/"
   },
   {
     "name": "Google ADK",


### PR DESCRIPTION
## Summary
- Split the single "Datadog" integrations grid entry into "Datadog (Metrics)" and "Datadog (Cost Management)" to distinguish the two Datadog integrations.
- Added a cross-reference in the metrics integrations page pointing to the new [Datadog Cost Management integration](https://docs.datadoghq.com/integrations/temporal-cloud-costs/).

## Test plan
- [x] Verify the integrations grid renders both Datadog entries correctly
- [x] Verify the metrics integrations page cross-reference link works

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216133111890952">EDU-6623 Add Datadog Cost Management integration</a>
