### PR TITLE
Clarify Priority and Fairness apply within a Task Queue partition

### DIFF
--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -32,7 +32,7 @@ You can use Priority and Fairness individually or combine them to express Fairne
   alt="Flowchart of how Priority dispatches Tasks from highest to lowest priority queue"
 />
 
-Priority is enforced within a single Task Queue [partition](/task-queue#task-ordering). A Task Queue uses multiple partitions by default and spreads Tasks across them, so priority ordering is exact within a partition but only approximate across the Task Queue as a whole. When one partition carries a larger backlog than another, lower-priority Tasks on a lighter partition can dispatch ahead of higher-priority Tasks waiting on a heavier one.
+Priority is enforced within a single Task Queue [partition](/task-queue#task-ordering). A Task Queue by default uses multiple partitions and randomly distributes Tasks across them, so partitions are usually balanced and priority ordering closely approximates the Task Queue as a whole. When partitions become imbalanced, lower-priority Tasks on a lighter partition can dispatch ahead of higher-priority Tasks waiting on a heavier one.
 
 ### When to use Priority
 

--- a/docs/develop/task-queue-priority-fairness.mdx
+++ b/docs/develop/task-queue-priority-fairness.mdx
@@ -32,6 +32,8 @@ You can use Priority and Fairness individually or combine them to express Fairne
   alt="Flowchart of how Priority dispatches Tasks from highest to lowest priority queue"
 />
 
+Priority is enforced within a single Task Queue [partition](/task-queue#task-ordering). A Task Queue uses multiple partitions by default and spreads Tasks across them, so priority ordering is exact within a partition but only approximate across the Task Queue as a whole. When one partition carries a larger backlog than another, lower-priority Tasks on a lighter partition can dispatch ahead of higher-priority Tasks waiting on a heavier one.
+
 ### When to use Priority
 
 If you need a way to specify the order your Tasks execute in, you can use Priority to manage that. Priority lets you differentiate between your Tasks, like batch and real-time Tasks, so that you can use a single pool of Workers for efficient resource allocation, while ensuring real-time Tasks are processed ahead of batch Tasks.
@@ -527,7 +529,7 @@ When you use Priority and Fairness together, the next Task to dispatch is chosen
 2. **Fairness key within a tier (weighted).** Within a priority tier, each fairness key is a virtual queue. Keys are dispatched proportional to their weights - a key with weight 2.0 is dispatched twice as often as one with weight 1.0.
 3. **FIFO within a key.** Tasks that share a priority tier _and_ fairness key dispatch in the order they were enqueued.
 
-These rules apply within a Task Queue partition. See [Limitations of Fairness](#limitations-of-fairness) for how partitioning can affect ordering.
+These rules apply within a Task Queue partition.
 
 <EnlargeImage
   src="/img/develop/task-queue-priority-fairness/priority-fairness.png"
@@ -613,7 +615,7 @@ To unset a single key's override, pass `key=default`. To clear all overrides on 
 ### Limitations of Fairness
 
 - There isn't a limit on the number of fairness keys you can use, but their accuracy can degrade as you add more.
-- Task Queues are internally [partitioned](/task-queue#task-ordering) and Tasks are distributed to partitions randomly. This could interfere with fairness. Depending on your use case, you can reach out to Temporal Support to get your Task Queues set to a single partition.
+- Fairness is enforced within a single Task Queue [partition](/task-queue#task-ordering). When a Task Queue's partitions are imbalanced, Fairness may not appear to hold, since it applies only within individual partitions. Depending on your use case, you can reach out to Temporal Support to get your Task Queues set to a single partition.
 - The fairness weight applies at schedule time, not at dispatch time. So it only affects newly-scheduled Tasks, not currently backlogged ones. This means if you need to throttle a single fairness key in the existing backlog of Tasks, you won't be able to.
 - When you use Worker Versioning and you're moving Workflows from one version to another, Priority will still apply between versions. Fairness isn't guaranteed between versions. For example, you may have Tasks that were originally queued on Worker version _alpha_, Tasks that were queued on Worker version _beta_, and some Tasks were moved from _alpha_ to _beta_. Fairness is only guaranteed when Tasks are originally queued on the same Worker version. So there might be some discrepancies on the Tasks moved from _alpha_ to _beta_.
 - Backlogged tasks are durable and unaffected by server restarts. Fairness ordering is preserved across restarts for the most active keys; less active keys may briefly dispatch new tasks ahead of their existing backlog until ordering normalizes.


### PR DESCRIPTION
Make it explicit that Priority and Fairness are enforced per Task Queue partition, not across the whole Task Queue.

- Priority section: state that priority applies within a single partition.
- Limitations of Fairness: rewrite the partition bullet; drop the inaccurate "distributed to partitions randomly".
- Combined section: remove the now-redundant cross-reference.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216179565010355">EDU-6625 Clarify Priority and Fairness apply within a Task Queue partition</a>
