### PR TITLE
Adds TEMPORAL_DISABLE_NEWS_FETCH, used to control the news feed feature

### DIFF
--- a/docs/references/web-ui-environment-variables.mdx
+++ b/docs/references/web-ui-environment-variables.mdx
@@ -227,3 +227,8 @@ list of the HTTP headers to be forwarded.
 ## `TEMPORAL_HIDE_LOGS`
 
 If enabled, does not print logs from the Temporal Service.
+
+## `TEMPORAL_DISABLE_NEWS_FETCH`
+
+Disables the news feed feature in the Web UI. If set to `true`, the Web UI will not request the news feed, and the button used to open the news feed panel will be hidden.
+


### PR DESCRIPTION
## What does this PR do?

It documents the `TEMPORAL_DISABLE_NEWS_FETCH` environment variable, which an operator can use if they wish to disable the news feed feature in a self-hosted deployment of the Temporal Web UI.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216243488590175">EDU-6639 Adds TEMPORAL_DISABLE_NEWS_FETCH, used to control the news feed feature</a>
