### PR TITLE
Fixing how index pages are handled in terms of markdown generation

### DIFF
--- a/plugins/markdown-pages/index.js
+++ b/plugins/markdown-pages/index.js
@@ -26,7 +26,11 @@ module.exports = function markdownPagesPlugin(context, options = {}) {
     const id = frontmatter.id || path.basename(withoutExt);
     const dir = path.dirname(withoutExt);
     if (dir === '.') return id === 'index' ? 'index' : id;
-    if (id === 'index') return dir;
+    // Docusaurus treats a doc named the same as its parent folder (e.g.
+    // `event-history/event-history.mdx`) as that folder's index page, the
+    // same way it treats `index.mdx`/`README.mdx`. Mirror that convention
+    // here so the generated .md file lands at the same route as the real page.
+    if (id === 'index' || id === path.basename(dir)) return dir;
     return `${dir}/${id}`;
   }
 


### PR DESCRIPTION
In two cases, MDX files at a path like `docs/encyclopedia/event-history/event-history.mdx` were generating a markdown file like /encyclopedia/event-history/event-history.md instead of /encyclopedia/event-history.md ... this fixes that by following the same logic as docusaurus where foo/foo.mdx is treated like foo/index.mdx

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216249583343319">EDU-6641 Fixing how index pages are handled in terms of markdown generation</a>
