### PR TITLE
doc(integrations): add SigNoz to Temporal Cloud metrics integrations

### DIFF
--- a/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
@@ -14,6 +14,7 @@ keywords:
   - observability tools integration
   - openmetrics api
   - datadog temporal integration
+  - signoz temporal integration
 tags:
   - Metrics
   - OpenMetrics
@@ -108,6 +109,14 @@ The integration runs on a host (Linux, Windows, or Kubernetes) with the New Reli
 4. In **one.newrelic.com**, go to **Integrations & Agents → Dashboards**, search for **Temporal Cloud**, and install the pre-built dashboard. Data appears within a few minutes.
 
 For New Relic-side details, see the [New Relic integration page](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/temporal-cloud-integration/).
+
+### SigNoz
+
+SigNoz provides an integration with the OpenMetrics endpoint using a self-hosted OpenTelemetry collector. The collector scrapes the endpoint, forwards metrics to SigNoz Cloud or self-hosted SigNoz over OTLP, and a pre-built dashboard visualizes the data. See the [SigNoz integration page](https://signoz.io/docs/integrations/temporal-cloud-metrics/) for more details.
+
+1. Create an OpenTelemetry collector config that uses a Prometheus receiver against `metrics.temporal.io` with Bearer token auth (your Temporal Cloud API key), a 60-second scrape interval, and an OTLP exporter pointed at your SigNoz ingestion endpoint with your SigNoz ingestion key. Copy the full template (VM and Kubernetes variants) from the [SigNoz integration page](https://signoz.io/docs/integrations/temporal-cloud-metrics/).
+2. Run the collector and confirm metrics with the `temporal_cloud_v1_` prefix are arriving in the SigNoz metrics explorer.
+3. Import the pre-built dashboard: in SigNoz, go to **Dashboards → New Dashboard → Import JSON** and load [`temporal-cloud-metrics.json`](https://raw.githubusercontent.com/SigNoz/dashboards/main/temporal.io/temporal-cloud-metrics.json).
 
 ### Prometheus \+ Grafana {/* #prometheus-grafana */}
 

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -181,6 +181,15 @@
     "href": "/develop/ruby/integrations/rails-integration"
   },
   {
+    "name": "SigNoz",
+    "description": "Ingest Temporal Cloud metrics into SigNoz via an OpenTelemetry collector with a pre-built dashboard.",
+    "tags": [
+      "Observability",
+      "Temporal Cloud"
+    ],
+    "href": "https://signoz.io/docs/integrations/temporal-cloud-metrics/"
+  },
+  {
     "name": "Spring AI",
     "description": "Build AI-powered Java applications with durable Spring AI tool calls.",
     "tags": [


### PR DESCRIPTION
## What does this PR do?

Adds SigNoz to the Observability & Temporal Cloud integrations:

- Catalog entry in `integrations-data.json`
- A SigNoz section on the metrics integrations page, following the shape of the ClickStack and New Relic entries

SigNoz consumes the OpenMetrics endpoint with a customer-run OpenTelemetry collector: Prometheus receiver with Bearer token auth, OTLP export to SigNoz Cloud or self-hosted SigNoz. Setup templates (VM and Kubernetes) and a pre-built dashboard live on the SigNoz side: https://signoz.io/docs/integrations/temporal-cloud-metrics/

## Notes to reviewers

I am from the SigNoz team. If listings on these pages go through a partner process rather than PRs, happy to route this accordingly.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216255867010270">EDU-6647 doc(integrations): add SigNoz to Temporal Cloud metrics integrations</a>
