### PR TITLE
fix(encyclopedia): added clarifications to Activity Task Executions and Activity Executions

### DIFF
--- a/docs/encyclopedia/detecting-activity-failures.mdx
+++ b/docs/encyclopedia/detecting-activity-failures.mdx
@@ -55,6 +55,10 @@ The Schedule-To-Start Timeout is enforced for each Activity Task, whereas the Sc
 Thus, "Schedule" in Schedule-To-Start refers to the scheduling moment of _every_ Activity Task in the sequence of Activity Tasks that make up the Activity Execution, while
 "Schedule" in Schedule-To-Close refers to the _first_ Activity Task in that sequence.
 
+An Activity Execution can be composed of multiple Activity Task Executions, with each Task representing a single attempt or retry. When you define an Activity in a Workflow, that definition represents a single logical Activity Execution.
+
+If that Activity fails (for example, due to a timeout or error) and a Retry Policy is in place, Temporal will schedule another attempt to execute the same Activity. Each attempt is called an Activity Task Execution.
+
 A [Retry Policy](/encyclopedia/retry-policies) attached to an Activity Execution retries an Activity Task.
 
 <CaptionedImage

--- a/docs/encyclopedia/workers/tasks.mdx
+++ b/docs/encyclopedia/workers/tasks.mdx
@@ -131,8 +131,7 @@ An Activity Task runs one attempt of an [Activity](/activities).
 ### What is an Activity Task Execution? {/* #activity-task-execution */}
 
 An Activity Task Execution occurs when a [Worker](/workers#worker-entity) uses the context provided from the
-[Activity Task](#activity-task) and executes the [Activity Definition](/activity-definition) (also known as the Activity
-Function).
+[Activity Task](#activity-task) and executes the [Activity Definition](/activity-definition) (also known as the Activity Function).
 
 The [ActivityTaskScheduled Event](/references/events#activitytaskscheduled) corresponds to when the Temporal Service
 puts the Activity Task into the Task Queue.


### PR DESCRIPTION
## What does this PR do?

A [discussion](https://temporalio.slack.com/archives/C05JRT1GKEE/p1754501791.000600) came up in the community Slack a while ago that asked for clarification on Activity Executions and Activity Task Executions.

This adds more detail around both and how they're related.

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216359980207325">EDU-6667 fix(encyclopedia): added clarifications to Activity Task Executions and Activity Executions</a>
