### PR TITLE
docs: add Parseable Java integration and fill gaps in integration lists

### DIFF
--- a/docs/develop/java/index.mdx
+++ b/docs/develop/java/index.mdx
@@ -78,9 +78,11 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 - [Debugging](/develop/java/best-practices/debugging)
 - [Converters and encryption](/develop/java/best-practices/converters-and-encryption)
 
-## Spring Boot Integration
+## [Integrations](/develop/java/integrations)
 
-- [Spring Boot Integration](/develop/java/integrations/spring-boot-integration)
+- [Parseable integration](https://github.com/parseablehq/temporal-plugin-java/blob/main/INTEGRATION.md)
+- [Spring AI integration](/develop/java/integrations/spring-ai)
+- [Spring Boot integration](/develop/java/integrations/spring-boot-integration)
 
 ## Temporal Java Technical Resources
 

--- a/docs/develop/java/index.mdx
+++ b/docs/develop/java/index.mdx
@@ -84,7 +84,7 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 - [Spring AI integration](/develop/java/integrations/spring-ai)
 - [Spring Boot integration](/develop/java/integrations/spring-boot-integration)
 
-## Temporal Java Technical Resources
+## Temporal Java technical resources
 
 - [Java SDK Quickstart - Setup Guide](https://docs.temporal.io/develop/java/set-up-your-local-java)
 - [Java API Documentation](https://javadoc.io/doc/io.temporal/temporal-sdk)

--- a/docs/develop/typescript/index.mdx
+++ b/docs/develop/typescript/index.mdx
@@ -87,7 +87,7 @@ Once your local Temporal Service is set up, continue building with the following
 - [Parseable integration](https://github.com/parseablehq/temporal-plugin/blob/main/INTEGRATION.md)
 - [Vercel AI SDK integration](/develop/typescript/integrations/ai-sdk)
 
-## Temporal TypeScript Technical Resources
+## Temporal TypeScript technical resources
 
 - [TypeScript SDK Quickstart - Setup Guide](/develop/typescript/set-up-your-local-typescript)
 - [TypeScript API Documentation](https://typescript.temporal.io)

--- a/docs/develop/typescript/index.mdx
+++ b/docs/develop/typescript/index.mdx
@@ -81,8 +81,11 @@ Once your local Temporal Service is set up, continue building with the following
 
 ## [Integrations](/develop/typescript/integrations)
 
-- [Vercel AI SDK Integration](/develop/typescript/integrations/ai-sdk)
-- [OpenAI Agents SDK Integration](/develop/typescript/integrations/openai-agents)
+- [Braintrust integration](https://www.braintrust.dev/docs/integrations/sdk-integrations/temporal#typescript)
+- [Mastra integration](https://mastra.ai/guides/deployment/temporal)
+- [OpenAI Agents SDK integration](/develop/typescript/integrations/openai-agents)
+- [Parseable integration](https://github.com/parseablehq/temporal-plugin/blob/main/INTEGRATION.md)
+- [Vercel AI SDK integration](/develop/typescript/integrations/ai-sdk)
 
 ## Temporal TypeScript Technical Resources
 

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -141,6 +141,15 @@
     "tags": [
       "Agent observability"
     ],
+    "sdk": "Java",
+    "href": "https://github.com/parseablehq/temporal-plugin-java/blob/main/INTEGRATION.md"
+  },
+  {
+    "name": "Parseable",
+    "description": "Stream Temporal Workflow and Activity execution events to Parseable for observability and analysis.",
+    "tags": [
+      "Agent observability"
+    ],
     "sdk": "Python",
     "href": "https://github.com/parseablehq/temporal-plugin-python/blob/main/INTEGRATION.MD"
   },


### PR DESCRIPTION
## What

- Add a **Parseable Java** entry to the integrations grid data (`integrations-data.json`).
- Add an **Integrations** section to the Java develop index listing Parseable, Spring AI, and Spring Boot.
- Fill gaps in the **TypeScript** index Integrations list — added the missing Braintrust, Mastra, and Parseable entries (they existed in the grid data but weren't listed).
- Lowercase "integration" in link labels across the language index lists for consistency.

## Why

Parseable now has a Java plugin (verified `temporal-plugin-java` repo + `INTEGRATION.md` exist), and an audit of `integrations-data.json` against each language's index list surfaced integrations that were present in the grid but missing from the corresponding per-language list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216371145082200">EDU-6671 docs: add Parseable Java integration and fill gaps in integration lists</a>
