### PR TITLE
docs: note IAM role name length limit for CloudFormation stack

### DIFF
--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -393,7 +393,7 @@ Deploy the following CloudFormation template to create the invocation role and i
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `AssumeRoleExternalId` | A string you choose to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks. Can be any value. Use the same value when creating the Worker Deployment Version. |
 | `LambdaFunctionARNs`   | Comma-separated list of Lambda function ARNs that Temporal may invoke. To allow invocation of any published version of a function, use a wildcard suffix (for example, `arn:aws:lambda:...:function:my-temporal-worker:*`). One role can authorize multiple Worker Lambdas. |
-| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Cloud-Serverless-Worker`.                                                                                                                                |
+| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Cloud-Serverless-Worker`. The template appends the stack name to this value (`<RoleName>-<StackName>`), and IAM role names cannot exceed 64 characters. If the combined name is too long, stack creation fails; use a shorter `RoleName` or stack name. |
 
 <details>
 <summary>CloudFormation template</summary>

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda.mdx
@@ -393,7 +393,14 @@ Deploy the following CloudFormation template to create the invocation role and i
 | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `AssumeRoleExternalId` | A string you choose to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks. Can be any value. Use the same value when creating the Worker Deployment Version. |
 | `LambdaFunctionARNs`   | Comma-separated list of Lambda function ARNs that Temporal may invoke. To allow invocation of any published version of a function, use a wildcard suffix (for example, `arn:aws:lambda:...:function:my-temporal-worker:*`). One role can authorize multiple Worker Lambdas. |
-| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Cloud-Serverless-Worker`. The template appends the stack name to this value (`<RoleName>-<StackName>`), and IAM role names cannot exceed 64 characters. If the combined name is too long, stack creation fails; use a shorter `RoleName` or stack name. |
+| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Cloud-Serverless-Worker`.                                                                                                                                |
+
+:::caution
+
+The template appends the stack name to `RoleName` to form the final IAM role name (`<RoleName>-<StackName>`). IAM role
+names cannot exceed 64 characters, so a long `RoleName` or stack name can cause stack creation to fail.
+
+:::
 
 <details>
 <summary>CloudFormation template</summary>

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -127,7 +127,14 @@ aws cloudformation create-stack \
 | `TemporalIamRoleArn`   | The ARN of the IAM role or user that the Temporal Service runs as. This is the identity the server uses to call `sts:AssumeRole`. To find the ARN, run `aws sts get-caller-identity` in the server's environment.  |
 | `AssumeRoleExternalId` | A unique string to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks. Choose any value and pass the same value when creating the Worker Deployment Version. |
 | `LambdaFunctionARNs`   | Comma-separated list of Lambda function ARNs that Temporal may invoke. To allow invocation of any published version of a function, use a wildcard suffix (for example, `arn:aws:lambda:...:function:my-temporal-worker:*`). |
-| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Serverless-Worker`. The template appends the stack name to this value (`<RoleName>-<StackName>`), and IAM role names cannot exceed 64 characters. If the combined name is too long, stack creation fails; use a shorter `RoleName` or stack name. |
+| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Serverless-Worker`.                                                                                                                                      |
+
+:::caution
+
+The template appends the stack name to `RoleName` to form the final IAM role name (`<RoleName>-<StackName>`). IAM role
+names cannot exceed 64 characters, so a long `RoleName` or stack name can cause stack creation to fail.
+
+:::
 
 <details>
 <summary>CloudFormation template</summary>

--- a/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/self-hosted-setup.mdx
@@ -127,7 +127,7 @@ aws cloudformation create-stack \
 | `TemporalIamRoleArn`   | The ARN of the IAM role or user that the Temporal Service runs as. This is the identity the server uses to call `sts:AssumeRole`. To find the ARN, run `aws sts get-caller-identity` in the server's environment.  |
 | `AssumeRoleExternalId` | A unique string to prevent [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks. Choose any value and pass the same value when creating the Worker Deployment Version. |
 | `LambdaFunctionARNs`   | Comma-separated list of Lambda function ARNs that Temporal may invoke. To allow invocation of any published version of a function, use a wildcard suffix (for example, `arn:aws:lambda:...:function:my-temporal-worker:*`). |
-| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Serverless-Worker`.                                                                                                                                      |
+| `RoleName`             | Base name for the created IAM role. Defaults to `Temporal-Serverless-Worker`. The template appends the stack name to this value (`<RoleName>-<StackName>`), and IAM role names cannot exceed 64 characters. If the combined name is too long, stack creation fails; use a shorter `RoleName` or stack name. |
 
 <details>
 <summary>CloudFormation template</summary>


### PR DESCRIPTION
## Summary
- The Serverless Worker CloudFormation templates (Lambda invocation role, both Cloud and self-hosted) build the final IAM role name by concatenating `RoleName` and the stack name (`<RoleName>-<StackName>`).
- IAM role names cannot exceed 64 characters, so a long `RoleName` or stack name can cause stack creation to fail.
- Added a note to the `RoleName` parameter description in both deploy guides.

## Test plan
- [x] `yarn build` passes with no new broken links or MDX errors

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216371555812455">EDU-6672 Note IAM role name length limit for CloudFormation stack</a>
