### PR TITLE
fix(timeouts): added clarification about non-retryable nature of schedule to start timeouts

### DIFF
--- a/docs/cloud/worker-health.mdx
+++ b/docs/cloud/worker-health.mdx
@@ -210,7 +210,7 @@ Consider
 
 #### High Schedule To Start latency and low sync match rate
 
-Verify that you have not set a value for `ScheduleToStartTimeout` in your Activity Options. This may skew your observations.
+Verify that you have not set a value for `ScheduleToStartTimeout` in your Activity Options. This may skew your observations and note that this timeout is non-retryable.
 
 It may be acceptable for your use case to have low sync match rate.
 For example, if you have known workloads or you intentionally throttle tasks.

--- a/docs/develop/dotnet/activities/timeouts.mdx
+++ b/docs/develop/dotnet/activities/timeouts.mdx
@@ -25,7 +25,7 @@ The following Timeouts are available in the Activity Options.
 
 - **[Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout):** is the maximum amount of time allowed for the overall [Activity Execution](/activity-execution).
 - **[Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout):** is the maximum time allowed for a single [Activity Task Execution](/tasks#activity-task-execution).
-- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task.
+- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task. This timeout is non-retryable by design.
 
 An Activity Execution must have either the Start-To-Close or the Schedule-To-Close Timeout set.
 
@@ -34,8 +34,8 @@ These values can be set in the `ActivityOptions` when calling `ExecuteActivityAs
 Available timeouts are:
 
 - ScheduleToCloseTimeout
-- ScheduleToStartTimeout
 - StartToCloseTimeout
+- ScheduleToStartTimeout
 
 ```csharp
 return await Workflow.ExecuteActivityAsync(

--- a/docs/develop/go/activities/timeouts.mdx
+++ b/docs/develop/go/activities/timeouts.mdx
@@ -26,7 +26,7 @@ The following timeouts are available in the Activity Options.
 
 - **[Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout):** is the maximum amount of time allowed for the overall [Activity Execution](/activity-execution).
 - **[Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout):** is the maximum time allowed for a single [Activity Task Execution](/tasks#activity-task-execution).
-- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task.
+- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task. This timeout is non-retryable by design.
 
 An Activity Execution must have either the Start-To-Close or the Schedule-To-Close Timeout set.
 

--- a/docs/develop/java/activities/timeouts.mdx
+++ b/docs/develop/java/activities/timeouts.mdx
@@ -28,9 +28,9 @@ Set your Activity Timeout from the [`ActivityOptions.Builder`](https://www.javad
 
 Available timeouts are:
 
-- ScheduleToCloseTimeout()
-- StartToCloseTimeout()
-- ScheduleToStartTimeout()
+- ScheduleToCloseTimeout
+- StartToCloseTimeout
+- ScheduleToStartTimeout
 
 You can set Activity Options using an `ActivityStub` within a Workflow implementation, or per-Activity using `WorkflowImplementationOptions` within a Worker.
 

--- a/docs/develop/java/activities/timeouts.mdx
+++ b/docs/develop/java/activities/timeouts.mdx
@@ -20,7 +20,7 @@ The following timeouts are available in the Activity Options.
 
 - **[Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout):** is the maximum amount of time allowed for the overall [Activity Execution](/activity-execution).
 - **[Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout):** is the maximum time allowed for a single [Activity Task Execution](/tasks#activity-task-execution).
-- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task.
+- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task. This timeout is non-retryable by design.
 
 An Activity Execution must have either the Start-To-Close or the Schedule-To-Close Timeout set.
 
@@ -29,8 +29,8 @@ Set your Activity Timeout from the [`ActivityOptions.Builder`](https://www.javad
 Available timeouts are:
 
 - ScheduleToCloseTimeout()
-- ScheduleToStartTimeout()
 - StartToCloseTimeout()
+- ScheduleToStartTimeout()
 
 You can set Activity Options using an `ActivityStub` within a Workflow implementation, or per-Activity using `WorkflowImplementationOptions` within a Worker.
 

--- a/docs/develop/php/activities/timeouts.mdx
+++ b/docs/develop/php/activities/timeouts.mdx
@@ -25,7 +25,7 @@ The following timeouts are available in the Activity Options.
 
 - **[Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout):** is the maximum amount of time allowed for the overall [Activity Execution](/activity-execution).
 - **[Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout):** is the maximum time allowed for a single [Activity Task Execution](/tasks#activity-task-execution).
-- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task.
+- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task.  This timeout is non-retryable by design.
 
 An Activity Execution must have either the Start-To-Close or the Schedule-To-Close Timeout set.
 

--- a/docs/develop/python/activities/timeouts.mdx
+++ b/docs/develop/python/activities/timeouts.mdx
@@ -27,7 +27,7 @@ The following timeouts are available in the Activity Options.
 
 - **[Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout):** is the maximum amount of time allowed for the overall [Activity Execution](/activity-execution).
 - **[Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout):** is the maximum time allowed for a single [Activity Task Execution](/tasks#activity-task-execution).
-- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task.
+- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task. This timeout is non-retryable by design.
 
 An Activity Execution must have either the Start-To-Close or the Schedule-To-Close Timeout set.
 

--- a/docs/develop/rust/activities/timeouts.mdx
+++ b/docs/develop/rust/activities/timeouts.mdx
@@ -25,7 +25,7 @@ The following timeouts are available in Activity options:
 
 - [Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout): the maximum amount of time allowed for the overall [Activity Execution](/activity-execution).
 - [Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout): the maximum time allowed for a single [Activity Task Execution](/tasks#activity-task-execution).
-- [Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout): the maximum amount of time allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task.
+- [Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout): the maximum amount of time allowed from when an [Activity Task](/tasks#activity-task) is scheduled to when a [Worker](/workers#worker) starts that Activity Task. This timeout is non-retryable by design.
 
 An Activity Execution must have either the Start-To-Close Timeout or the Schedule-To-Close Timeout set. Temporal strongly recommends setting a Start-To-Close Timeout because the service relies on it to detect lost Activity Tasks and trigger retries when appropriate.
 

--- a/docs/develop/typescript/activities/timeouts.mdx
+++ b/docs/develop/typescript/activities/timeouts.mdx
@@ -33,9 +33,9 @@ Each Activity Timeout controls the maximum duration of a different aspect of an 
 
 The following Timeouts are available in the Activity Options:
 
-- **[Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout):** is the maximum amount of time allowed for the entire [Activity Execution](/activity-execution), from when the [Activity Task](/tasks#activity-task) is initially scheduled by the Workflow to when the server receives a successful completion for that Activity Task
-- **[Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout):** is the maximum time allowed for a single [Activity Task Execution](/tasks#activity-task-execution), from when the Activity Task Execution gets polled by a [Worker](/workers#worker) to when the server receives a successful completion for that Activity Task
-- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is initially scheduled by the Workflow to when a [Worker](/workers#worker) polls the Activity Task Execution
+- **[Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout):** is the maximum amount of time allowed for the entire [Activity Execution](/activity-execution), from when the [Activity Task](/tasks#activity-task) is initially scheduled by the Workflow to when the server receives a successful completion for that Activity Task.
+- **[Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout):** is the maximum time allowed for a single [Activity Task Execution](/tasks#activity-task-execution), from when the Activity Task Execution gets polled by a [Worker](/workers#worker) to when the server receives a successful completion for that Activity Task.
+- **[Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout):** is the maximum amount of time that is allowed from when an [Activity Task](/tasks#activity-task) is initially scheduled by the Workflow to when a [Worker](/workers#worker) polls the Activity Task Execution. This timeout is non-retryable by design.
 
 An Activity Execution must have either the Start-To-Close or the Schedule-To-Close Timeout set.
 

--- a/docs/encyclopedia/detecting-activity-failures.mdx
+++ b/docs/encyclopedia/detecting-activity-failures.mdx
@@ -73,8 +73,7 @@ This timeout has two primary use cases:
 **The default Schedule-To-Start Timeout is ∞ (infinity).**
 
 If this timeout is used, we recommend setting this timeout to the maximum time a Workflow Execution is willing to wait for an Activity Execution in the presence of all possible Worker outages, and have a concrete plan in place to reroute Activity Tasks to a different Task Queue.
-This timeout **does not** trigger any retries regardless of the Retry Policy, as a retry would place the Activity Task back into the same Task Queue.
-We do not recommend using this timeout unless you know what you are doing.
+This timeout is non-retryable by design. It **does not** trigger any retries regardless of the Retry Policy, as a retry would place the Activity Task back into the same Task Queue.
 
 In most cases, we recommend monitoring the `temporal_activity_schedule_to_start_latency` metric to know when Workers slow down picking up Activity Tasks, instead of setting this timeout.
 

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -564,7 +564,7 @@ Activity Execution, reaches a Closed status.
 #### [Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#schedule-to-start-timeout)
 
 A Schedule-To-Start Timeout is the maximum amount of time that is allowed from when an Activity Task is placed in a Task
-Queue to when a Worker picks it up from the Task Queue.
+Queue to when a Worker picks it up from the Task Queue. This timeout is non-retryable by design.
 
 <!-- _Tags: [term](/tags/term), [explanation](/tags/explanation), [timeouts](/tags/timeouts)_ -->
 


### PR DESCRIPTION
## What does this PR do?

This adds the caveat that `Schedule-To-Start` timeouts are non-retryable by design. The info came from a [community conversation](https://temporalio.slack.com/archives/C04S80QKB2Q/p1733205250777109) with Maxim about it.

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216394150007656">EDU-6676 fix(timeouts): added clarification about non-retryable nature of schedule to start timeouts</a>
