### PR TITLE
Remove Public Preview notice from temporal_cloud_v1_billable_action_c…

### DIFF
--- a/docs/cloud/metrics/openmetrics/metrics-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-reference.mdx
@@ -625,12 +625,6 @@ The number of billable actions per second, broken down by action type and Workfl
 | `action_type` | The [action](/cloud/actions) type |
 | `temporal_workflow_type` | The workflow type |
 
-:::note Public Preview
-
-This metric is currently in [Public Preview](/evaluate/development-production-features/release-stages#public-preview).
-
-:::
-
 :::caution High Cardinality
 
 This metric could have high cardinality depending on number of action types and workflow types.


### PR DESCRIPTION


The metric temporal_cloud_v1_billable_action_count is now in General Availability, so this box is removed. 

See Slack discussion: https://temporaltechnologies.slack.com/archives/C01H1G7J98F/p1783552313892169



<!-- delete if n/a -->