### PR TITLE
Add guide links to ReleaseNoteHeader language icons

### DIFF
--- a/docs/develop/standalone-activities-interactive-demo.mdx
+++ b/docs/develop/standalone-activities-interactive-demo.mdx
@@ -17,6 +17,7 @@ import { StandaloneActivityDemo, ReleaseNoteHeader, SdkGuideLinks } from '@site/
 <ReleaseNoteHeader
   featureName="standaloneActivity"
   languages={["Go", "Python", "Java", ".NET", "TypeScript", "Ruby"]}
+  guidePath="activities/standalone-activities"
 >
   Available in [Temporal Cloud](/standalone-activity#temporal-cloud-support) and in the [Temporal CLI](/standalone-activity#temporal-cli-support) v1.7.0 or higher with Temporal Server v1.31.0 or higher. Java SDK support is in [Pre-release](/evaluate/development-production-features/release-stages#pre-release).
 </ReleaseNoteHeader>

--- a/docs/encyclopedia/activities/standalone-activity.mdx
+++ b/docs/encyclopedia/activities/standalone-activity.mdx
@@ -22,6 +22,7 @@ import { ReleaseNoteHeader } from '@site/src/components';
 <ReleaseNoteHeader
   featureName="standaloneActivity"
   languages={["Go", "Python", "Java", ".NET", "TypeScript", "Ruby"]}
+  guidePath="activities/standalone-activities"
 >
   Available in [Temporal Cloud](#temporal-cloud-support) and in Temporal Server v1.31.0 or higher (included in [Temporal CLI](#temporal-cli-support) v1.7.0 or higher).
 </ReleaseNoteHeader>

--- a/docs/encyclopedia/nexus/standalone-nexus-operation.mdx
+++ b/docs/encyclopedia/nexus/standalone-nexus-operation.mdx
@@ -23,6 +23,7 @@ import { ReleaseNoteHeader, SdkGuideLinks } from '@site/src/components';
 <ReleaseNoteHeader
   featureName="standaloneNexusOperation"
   languages={["Go", "Java", "Python", "TypeScript", ".NET"]}
+  guidePath="nexus/standalone-operations"
 >
   APIs are experimental and may be subject to backwards-incompatible changes.
 </ReleaseNoteHeader>

--- a/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.js
+++ b/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.js
@@ -1,8 +1,7 @@
 // src/components/info/ReleaseNoteHeader/index.js
 
 import React from "react";
-import clsx from "clsx";
-import { LANGUAGE_ICONS } from "../constants";
+import Link from "@docusaurus/Link";
 import SdkSvg from '../../elements/SdkSvgs/SdkSvg';
 import styles from "./ReleaseNoteHeader.module.css";
 import { FEATURE_RELEASE_TYPES } from "../../../constants/featureReleaseTypes";
@@ -35,6 +34,17 @@ const LANGUAGE_TO_SDK_SVG = {
   "TypeScript": "typeScriptBlock",
 }
 
+const LANGUAGE_TO_SDK_SLUG = {
+  ".NET": "dotnet",
+  "Go": "go",
+  "Java": "java",
+  "PHP": "php",
+  "Python": "python",
+  "Ruby": "ruby",
+  "Rust": "rust",
+  "TypeScript": "typescript",
+}
+
 function getResolvedType({ featureName, type }) {
   return FEATURE_RELEASE_TYPES[featureName] || type || "publicPreview";
 }
@@ -59,6 +69,8 @@ export default function ReleaseNoteHeader({
   href,
   // These are the supported languages for the release. If provided, icons for these languages will be shown.
   languages = [],
+  // Path segment after /develop/<sdk>/ for linked language icons).
+  guidePath,
   // If you want to override the default label for the release type, you can pass it here. This is useful for cases like "generalAvailability" where you might want to just say "Stable".
   label,
 }) {
@@ -94,12 +106,27 @@ export default function ReleaseNoteHeader({
           <div className={styles.supportedLanguages}>
             <p className={styles.text}>Supported languages:</p>
                 <ul className={styles.languages} aria-label="Supported languages">
-                  {languages.map((language) => (
+                  {languages.map((language) => {
+                    const icon = (
+                      <SdkSvg name={LANGUAGE_TO_SDK_SVG[language]} />
+                    );
+                    const sdkSlug = LANGUAGE_TO_SDK_SLUG[language];
+                    return (
                       <li key={language} className={styles.language}>
-                        <SdkSvg name={LANGUAGE_TO_SDK_SVG[language]} />
+                        {guidePath && sdkSlug ? (
+                          <Link
+                            to={`/develop/${sdkSlug}/${guidePath}`}
+                            className={styles.languageLink}
+                            aria-label={`${language} getting started guide`}
+                          >
+                            {icon}
+                          </Link>
+                        ) : (
+                          icon
+                        )}
                       </li>
-                    )
-                  )}
+                    );
+                  })}
                 </ul>
           </div>
         )}

--- a/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.js
+++ b/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.js
@@ -69,7 +69,7 @@ export default function ReleaseNoteHeader({
   href,
   // These are the supported languages for the release. If provided, icons for these languages will be shown.
   languages = [],
-  // Path segment after /develop/<sdk>/ for linked language icons).
+  // Path segment after /develop/<sdk>/ for linked language icons.
   guidePath,
   // If you want to override the default label for the release type, you can pass it here. This is useful for cases like "generalAvailability" where you might want to just say "Stable".
   label,

--- a/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.js
+++ b/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.js
@@ -122,7 +122,7 @@ export default function ReleaseNoteHeader({
                             {icon}
                           </Link>
                         ) : (
-                          icon
+                          <span className={styles.languageStatic}>{icon}</span>
                         )}
                       </li>
                     );

--- a/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.module.css
+++ b/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.module.css
@@ -105,6 +105,13 @@
   outline-offset: 2px;
 }
 
+.languageStatic {
+  display: flex;
+  line-height: 0;
+  pointer-events: none;
+  cursor: default;
+}
+
 .supportedLanguages {
   display: flex;
   align-items: center;

--- a/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.module.css
+++ b/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.module.css
@@ -89,6 +89,22 @@
   margin-top: 10px;
 }
 
+.languageLink {
+  display: flex;
+  line-height: 0;
+  border-radius: 4px;
+  transition: opacity 0.15s ease;
+}
+
+.languageLink:hover {
+  opacity: 0.85;
+}
+
+.languageLink:focus-visible {
+  outline: 2px solid var(--release-note-border);
+  outline-offset: 2px;
+}
+
 .supportedLanguages {
   display: flex;
   align-items: center;


### PR DESCRIPTION
For the SDK icons: 
- Makes SDK icons clickable to the dev guides in release note header component (e.g - standalone nexus operations page) 
- When there's no links, remove the hover feature (e.g eager workflow start on worker performance page)

## What does this PR do?

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216460471569185">EDU-6681 Add guide links to ReleaseNoteHeader language icons</a>
