### PR TITLE
fix(ReleaseNoteHeader): avoid invalid nested <p> in release note banner

### DIFF
--- a/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.js
+++ b/src/components/info/ReleaseNoteHeader/ReleaseNoteHeader.js
@@ -130,7 +130,7 @@ export default function ReleaseNoteHeader({
                 </ul>
           </div>
         )}
-        <p className={styles.text}>
+        <div className={styles.text}>
           {href ? (
             <a href={href} className={styles.link}>
               {children}
@@ -138,7 +138,7 @@ export default function ReleaseNoteHeader({
           ) : (
             children
           )}
-        </p>
+        </div>
       </div>
     </aside>
   );


### PR DESCRIPTION
## Summary

`ReleaseNoteHeader` wraps its `children` in a `<p className={styles.text}>`. When the component is used in MDX with block-position children (the common pattern across the docs), MDX/remark independently wraps that text in its own `<p>`, producing invalid nested markup: `<p><p>...</p></p>`. A `<p>` cannot contain another `<p>`, so the outer tag gets auto-closed by the parser as soon as the inner one opens, leaving a dangling `</p>` later with no matching open `<p>` in scope.

This surfaced during `yarn build` as 23 instances of:

```
[HTML minifier diagnostic - error] No "p" element in scope but a "p" end tag seen
```

(one on `/cloud/migrate/automated` and 22 other pages that use `<ReleaseNoteHeader>` the same way, e.g. `/schedule`, `/standalone-activity`, `/serverless-workers`, etc.)

The fix renders the wrapper as a `<div>` instead of a `<p>`. Styling is unaffected since it's driven entirely by the CSS class (`styles.text`), and the CSS already had a `.text > p { margin: unset; }` rule anticipating the inner `<p>` from MDX.

## Evidence

Captured the SSR HTML for `/cloud/migrate/automated` before and after the fix, isolating the `ReleaseNoteHeader` output:

**Before** (invalid nested `<p>`):
```html
<div class="meta_wnSQ">...</div><p class="text_TSE4"><p>Please contact your Temporal account executive prior to planning your migration project.</p></p>
```

**After** (valid nesting):
```html
<div class="meta_wnSQ">...</div><div class="text_TSE4"><p>Please contact your Temporal account executive prior to planning your migration project.</p></div>
```

Rebuilding the full site after the fix shows the "No p element in scope" diagnostic no longer occurs anywhere (down from 23 pages to 0).

## Test plan

- [x] `yarn build` completes with 0 "No p element in scope but a p end tag seen" diagnostics (previously 23)
- [ ] Visually spot-check a page using `<ReleaseNoteHeader>` (e.g. `/cloud/migrate/automated`, `/schedule`) to confirm the banner still renders/styles identically (try this one! https://temporal-documentation-git-fix-release-note-header-nested-p.preview.thundergun.io/schedule#workflow-pause)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216464655313140">EDU-6692 fix(ReleaseNoteHeader): avoid invalid nested &lt;p&gt; in release note banner</a>
