### PR TITLE
Add ReleaseNoteHeader to cloud CLI documentation files

### DIFF
--- a/docs/cli/command-reference/cloud/account.mdx
+++ b/docs/cli/command-reference/cloud/account.mdx
@@ -11,8 +11,12 @@ tags:
   - account
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Manage the Temporal Cloud account.
 

--- a/docs/cli/command-reference/cloud/apikey.mdx
+++ b/docs/cli/command-reference/cloud/apikey.mdx
@@ -12,8 +12,12 @@ tags:
   - apikeys
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for creating, listing, and managing Temporal Cloud API keys.
 

--- a/docs/cli/command-reference/cloud/async-operation.mdx
+++ b/docs/cli/command-reference/cloud/async-operation.mdx
@@ -12,8 +12,12 @@ tags:
   - async-operations
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for working with Temporal Cloud async operations.
 

--- a/docs/cli/command-reference/cloud/connectivity.mdx
+++ b/docs/cli/command-reference/cloud/connectivity.mdx
@@ -11,8 +11,12 @@ tags:
   - connectivity
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for managing connectivity rules for Temporal Cloud.
 

--- a/docs/cli/command-reference/cloud/custom-role.mdx
+++ b/docs/cli/command-reference/cloud/custom-role.mdx
@@ -12,8 +12,12 @@ tags:
   - custom-roles
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for managing Temporal Cloud custom roles.
 

--- a/docs/cli/command-reference/cloud/login.mdx
+++ b/docs/cli/command-reference/cloud/login.mdx
@@ -12,8 +12,12 @@ tags:
   - login
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Authenticate with Temporal Cloud using browser-based OAuth login.
 

--- a/docs/cli/command-reference/cloud/logout.mdx
+++ b/docs/cli/command-reference/cloud/logout.mdx
@@ -12,8 +12,12 @@ tags:
   - login
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Log out from Temporal Cloud by clearing stored authentication tokens
 and credentials from the local configuration.

--- a/docs/cli/command-reference/cloud/namespace.mdx
+++ b/docs/cli/command-reference/cloud/namespace.mdx
@@ -11,8 +11,12 @@ tags:
   - namespaces
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for creating, updating, and managing Temporal Cloud namespaces.
 

--- a/docs/cli/command-reference/cloud/nexus.mdx
+++ b/docs/cli/command-reference/cloud/nexus.mdx
@@ -10,8 +10,12 @@ tags:
   - nexus
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for managing Nexus Operations in Temporal Cloud.
 

--- a/docs/cli/command-reference/cloud/region.mdx
+++ b/docs/cli/command-reference/cloud/region.mdx
@@ -11,8 +11,12 @@ tags:
   - region
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for listing Temporal Cloud regions.
 

--- a/docs/cli/command-reference/cloud/service-account.mdx
+++ b/docs/cli/command-reference/cloud/service-account.mdx
@@ -11,8 +11,12 @@ tags:
   - service-accounts
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for managing Temporal Cloud service accounts.
 

--- a/docs/cli/command-reference/cloud/user-group.mdx
+++ b/docs/cli/command-reference/cloud/user-group.mdx
@@ -11,8 +11,12 @@ tags:
   - user-groups
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for managing Temporal Cloud user groups.
 

--- a/docs/cli/command-reference/cloud/user.mdx
+++ b/docs/cli/command-reference/cloud/user.mdx
@@ -11,8 +11,12 @@ tags:
   - users
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Commands for managing Temporal Cloud users.
 

--- a/docs/cli/command-reference/cloud/whoami.mdx
+++ b/docs/cli/command-reference/cloud/whoami.mdx
@@ -12,8 +12,12 @@ tags:
   - authentication
 ---
 
+import { ReleaseNoteHeader } from '@site/src/components';
+
 {/* NOTE: This is an auto-generated file. Any edit to this file will be overwritten.
 This file is generated from the CLI command definitions via cmd/gen-docs. */}
+
+<ReleaseNoteHeader featureName="cloudCli" />
 
 Display information about the currently authenticated identity.
 


### PR DESCRIPTION
This update reintroduces the ReleaseNoteHeader component to various cloud CLI documentation files.

## What does this PR do?

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216531372315582">EDU-6706 Add ReleaseNoteHeader to cloud CLI documentation files</a>
