### PR TITLE
Major Vale related update

### DIFF
--- a/.vale-ci.ini
+++ b/.vale-ci.ini
@@ -14,8 +14,56 @@ Temporal.programming = NO
 Temporal.WordList = NO
 Temporal.terms = NO
 
+; Temporal.Headings and Temporal.RelativeLinks are intentionally left enabled
+; (not listed above) — they're the two high-confidence checks this CI gate runs.
+
 ; ignore MDX custom heading-ID comments, e.g. {/* #ha-worker-patterns */}
 TokenIgnores = (\{/\*[^\n]*?\*/\})
+
+; These are reference docs whose headings are literal command/metric names
+; (e.g. "## audit-log", "### --workflow_id"), not prose — sentence-case
+; capitalization doesn't apply, so skip Temporal.Headings for them.
+[docs/references/sdk-metrics.mdx]
+Temporal.Headings = NO
+
+[docs/tctl-v1/**]
+Temporal.Headings = NO
+
+[docs/cli/command-reference/**]
+Temporal.Headings = NO
+
+[docs/cloud/tcld/**]
+Temporal.Headings = NO
+
+[docs/cloud/references/regions/**]
+Temporal.Headings = NO
+
+[docs/cloud/metrics/reference.mdx]
+Temporal.Headings = NO
+
+[docs/cloud/metrics/openmetrics/metrics-reference.mdx]
+Temporal.Headings = NO
+
+[docs/references/cluster-metrics.mdx]
+Temporal.Headings = NO
+
+[docs/references/configuration.mdx]
+Temporal.Headings = NO
+
+[docs/references/web-ui-configuration.mdx]
+Temporal.Headings = NO
+
+[docs/references/server-options.mdx]
+Temporal.Headings = NO
+
+[docs/references/errors.mdx]
+Temporal.Headings = NO
+
+[docs/references/commands.mdx]
+Temporal.Headings = NO
+
+[docs/references/events.mdx]
+Temporal.Headings = NO
 
 [formats]
 mdx = md

--- a/.vale.ini
+++ b/.vale.ini
@@ -27,6 +27,51 @@ Google.Will = NO
 Microsoft.ComplexWords = NO
 Google.WordList = NO
 
+; These are reference docs whose headings are literal command/metric names
+; (e.g. "## audit-log", "### --workflow_id"), not prose — sentence-case
+; capitalization doesn't apply, so skip Temporal.Headings for them.
+[docs/references/sdk-metrics.mdx]
+Temporal.Headings = NO
+
+[docs/tctl-v1/**]
+Temporal.Headings = NO
+
+[docs/cli/command-reference/**]
+Temporal.Headings = NO
+
+[docs/cloud/tcld/**]
+Temporal.Headings = NO
+
+[docs/cloud/references/regions/**]
+Temporal.Headings = NO
+
+[docs/cloud/metrics/reference.mdx]
+Temporal.Headings = NO
+
+[docs/cloud/metrics/openmetrics/metrics-reference.mdx]
+Temporal.Headings = NO
+
+[docs/references/cluster-metrics.mdx]
+Temporal.Headings = NO
+
+[docs/references/configuration.mdx]
+Temporal.Headings = NO
+
+[docs/references/web-ui-configuration.mdx]
+Temporal.Headings = NO
+
+[docs/references/server-options.mdx]
+Temporal.Headings = NO
+
+[docs/references/errors.mdx]
+Temporal.Headings = NO
+
+[docs/references/commands.mdx]
+Temporal.Headings = NO
+
+[docs/references/events.mdx]
+Temporal.Headings = NO
+
 [formats]
 mdx = md
 

--- a/docs/best-practices/cloud-access-control.mdx
+++ b/docs/best-practices/cloud-access-control.mdx
@@ -38,8 +38,8 @@ The high-level end-to-end rotation process is:
 5. **Remove old credentials**: Remove old certificates and API keys from your secrets provider after confirming successful migration 
 
 This approach ensures near-zero-downtime rotation and prevents authentication failures that could impact running workflows. For specific guidance to rotate mTLS certificates and API keys, see:
-- https://docs.temporal.io/cloud/certificates#manage-certificates 
-- https://docs.temporal.io/cloud/api-keys#rotate-an-api-key 
+- /cloud/certificates#manage-certificates 
+- /cloud/api-keys#rotate-an-api-key 
 - https://github.com/temporal-sa/temporal-Worker-cert-rotation 
 
 For mutual TLS (mTLS) implementations, using Let's Encrypt is not recommended, as it is designed primarily for public-facing services and lacks support for internal certificate requirements. 
@@ -50,16 +50,16 @@ Select the option that aligns best with your infrastructure, security requiremen
 
 In the case that you are using multiple certificates signed by the same CA, and some of these certificates are for production environments, there are some workarounds you can employ. 
 
-One convention is to give certificates a common name that matches the namespace. If you do this when using the same CA for dev and prod, then you can leverage Certificate Filters to prevent access to production environments. This is described in detail under the [authorization section](https://docs.temporal.io/cloud/certificates#control-authorization) of the documentation. 
+One convention is to give certificates a common name that matches the namespace. If you do this when using the same CA for dev and prod, then you can leverage Certificate Filters to prevent access to production environments. This is described in detail under the [authorization section](/cloud/certificates#control-authorization) of the documentation. 
 
 ## Best practices
 
 ### Establish clear guidelines on authentication methods
 
-Teams should standardize on either [mTLS certificates](https://docs.temporal.io/cloud/certificates) or
-[API keys](https://docs.temporal.io/cloud/api-keys) for the following operations:
+Teams should standardize on either [mTLS certificates](/cloud/certificates) or
+[API keys](/cloud/api-keys) for the following operations:
 - Connect Temporal clients to Temporal Cloud (e.g. Worker processes)
-- Automation (e.g. Temporal Cloud [Operations API](https://docs.temporal.io/ops), [Terraform provider](https://docs.temporal.io/cloud/terraform-provider), [Temporal CLI](https://docs.temporal.io/cli/setup-cli))
+- Automation (e.g. Temporal Cloud [Operations API](/ops), [Terraform provider](/cloud/terraform-provider), [Temporal CLI](/cli/setup-cli))
 
 By default, teams should use API keys with [service accounts](/cloud/manage-access/service-accounts) for both operations. API keys
 are generally easier to set up and rotate than mTLS certificates, and service accounts let you assign account-level and

--- a/docs/best-practices/cloud-access-control.mdx
+++ b/docs/best-practices/cloud-access-control.mdx
@@ -38,8 +38,8 @@ The high-level end-to-end rotation process is:
 5. **Remove old credentials**: Remove old certificates and API keys from your secrets provider after confirming successful migration 
 
 This approach ensures near-zero-downtime rotation and prevents authentication failures that could impact running workflows. For specific guidance to rotate mTLS certificates and API keys, see:
-- /cloud/certificates#manage-certificates 
-- /cloud/api-keys#rotate-an-api-key 
+- https://docs.temporal.io/cloud/certificates#manage-certificates 
+- https://docs.temporal.io/cloud/api-keys#rotate-an-api-key 
 - https://github.com/temporal-sa/temporal-Worker-cert-rotation 
 
 For mutual TLS (mTLS) implementations, using Let's Encrypt is not recommended, as it is designed primarily for public-facing services and lacks support for internal certificate requirements. 

--- a/docs/best-practices/cost-optimization.mdx
+++ b/docs/best-practices/cost-optimization.mdx
@@ -114,7 +114,7 @@ Focus optimization efforts on what's driving costs with a specific workload:
 
 ## Measuring
 
-Establish [baseline metrics](https://docs.temporal.io/cloud/metrics/reference) before optimizing and be sure to validate impact after implementation.
+Establish [baseline metrics](/cloud/metrics/reference) before optimizing and be sure to validate impact after implementation.
 Specifically:
 
 - Actions consumption (per Workflow, per day/month, by Namespace)
@@ -124,7 +124,7 @@ Specifically:
 
 ## Actions optimization
 
-[Actions](https://docs.temporal.io/cloud/actions) encompass Workflow operations, Activity Executions, Signals, Queries, and other interactions with Temporal.
+[Actions](/cloud/actions) encompass Workflow operations, Activity Executions, Signals, Queries, and other interactions with Temporal.
 Each represents a unit of consumption.
 
 ### Activity granularity

--- a/docs/best-practices/knowledge-hub.mdx
+++ b/docs/best-practices/knowledge-hub.mdx
@@ -26,7 +26,7 @@ To bootstrap your knowledge hub, use the
 
 ## What belongs in your knowledge hub
 
-Although Temporal itself has [thorough documentation](https://docs.temporal.io/), not all of it applies to your organization or your teams' use cases.
+Although Temporal itself has [thorough documentation](/), not all of it applies to your organization or your teams' use cases.
 The knowledge hub distills the documentation into just the specific information your teams need.
 One way to organize the content is according to where developers are in their journey.
 The following sample outline shows what sections to include.
@@ -97,7 +97,7 @@ These metrics create a feedback loop: measure, identify gaps, improve content, a
 
 ## What doesn't belong in your knowledge hub
 
-A knowledge hub is not a mirror of [Temporal's official documentation](https://docs.temporal.io/).
+A knowledge hub is not a mirror of [Temporal's official documentation](/).
 Avoid duplicating SDK API references, concept explanations, or release notes that Temporal already maintains.
 When that content changes, your copy becomes a source of confusion rather than clarity.
 Instead, link to the official docs and reserve your knowledge hub for organization-specific decisions, conventions,

--- a/docs/best-practices/security-controls.mdx
+++ b/docs/best-practices/security-controls.mdx
@@ -35,21 +35,21 @@ Strong identity management in Temporal Cloud is crucial for ensuring secure acce
 
 ### Best Practices:
 
-#### 1. Enable [SAML Single Sign-on](https://docs.temporal.io/cloud/manage-access/saml) (SSO) for User Access
+#### 1. Enable [SAML Single Sign-on](/cloud/manage-access/saml) (SSO) for User Access
 
 Integrate Temporal Cloud with your organization's identity provider via SAML 2.0 for centralized authentication. SSO allows you to enforce your corporate login policies (MFA, password complexity, etc.). When you configure SAML with Temporal Cloud, you can disable social logins (i.e. Microsoft, Google) by opening a support ticket. 
 
 #### 2. Use Least-Privilege Roles for Temporal Cloud Users
 
-Temporal Cloud provides [preconfigured account-level roles](https://docs.temporal.io/cloud/manage-access/users) (Account Owner, Finance Admin, Global Admin, Developer, Read-Only) and Namespace-level permissions. Assign users the lowest level of access they need. For example, give developers access only to the Namespaces they work on, and use read-only roles for auditors or reviewers. Regularly review user roles and remove or downgrade accounts that are no longer needed
+Temporal Cloud provides [preconfigured account-level roles](/cloud/manage-access/users) (Account Owner, Finance Admin, Global Admin, Developer, Read-Only) and Namespace-level permissions. Assign users the lowest level of access they need. For example, give developers access only to the Namespaces they work on, and use read-only roles for auditors or reviewers. Regularly review user roles and remove or downgrade accounts that are no longer needed
 
 #### 3. Leverage SCIM or Automated User Provisioning
 
-When applicable, use [SCIM](https://docs.temporal.io/cloud/manage-access/scim) or the Temporal Cloud user management API to automate adding and removing user accounts. This ensures timely removal of access when people change roles or leave the organization.
+When applicable, use [SCIM](/cloud/manage-access/scim) or the Temporal Cloud user management API to automate adding and removing user accounts. This ensures timely removal of access when people change roles or leave the organization.
 
 #### Use Service Accounts for Automation
 
-For non-human access (CI/CD pipelines, backend services), use [Temporal Cloud Service Accounts](https://docs.temporal.io/cloud/manage-access/service-accounts) instead of shared user logins. Service Accounts are machine identities that can be granted specific permissions without ties to an individual. Create separate Service Accounts with unique API keys for different applications or microservices, and apply least privilege to each (e.g. a service account that only has access to one Namespace).
+For non-human access (CI/CD pipelines, backend services), use [Temporal Cloud Service Accounts](/cloud/manage-access/service-accounts) instead of shared user logins. Service Accounts are machine identities that can be granted specific permissions without ties to an individual. Create separate Service Accounts with unique API keys for different applications or microservices, and apply least privilege to each (e.g. a service account that only has access to one Namespace).
 
 ## Secure Application Authentication and API Access
 
@@ -67,7 +67,7 @@ We recommend you enable mTLS for strong identity assurance of clients; it ensure
 
 #### 2. Proactively manage and rotate certificates
 
-Track the expiration dates of your client and [Certificate Authority certificates](https://docs.temporal.io/cloud/certificates). Temporal Cloud trusts the uploaded CA; if it expires, all client authorizations will fail. Establish and automate a certificate rotation schedule (e.g. rotate client certificates quarterly and CA certificates annually, well before expiry). Temporal supports uploading a new CA certificate alongside the old one to allow seamless rollover. Always test new certificates in a staging environment if possible.
+Track the expiration dates of your client and [Certificate Authority certificates](/cloud/certificates). Temporal Cloud trusts the uploaded CA; if it expires, all client authorizations will fail. Establish and automate a certificate rotation schedule (e.g. rotate client certificates quarterly and CA certificates annually, well before expiry). Temporal supports uploading a new CA certificate alongside the old one to allow seamless rollover. Always test new certificates in a staging environment if possible.
 
 #### 3. If you’re using API Keys, handle them with strict care
 
@@ -86,11 +86,11 @@ Although Temporal Cloud is a SaaS offering, you retain control over its networki
 
 #### 1. Use Private Connectivity
 
-Temporal Cloud supports private connectivity options such as [AWS PrivateLink](https://docs.temporal.io/cloud/connectivity/aws-connectivity) and [Google Cloud Private Service Connect](https://docs.temporal.io/cloud/connectivity/gcp-connectivity). If your infrastructure is in AWS or GCP, configure a PrivateLink/PSC endpoint for Temporal Cloud. This allows your workers and applications to reach Temporal Cloud over a private network path, avoiding traversal of the public internet. Private connectivity reduces the surface for man-in-the-middle attacks and can meet stringent network security policies.
+Temporal Cloud supports private connectivity options such as [AWS PrivateLink](/cloud/connectivity/aws-connectivity) and [Google Cloud Private Service Connect](/cloud/connectivity/gcp-connectivity). If your infrastructure is in AWS or GCP, configure a PrivateLink/PSC endpoint for Temporal Cloud. This allows your workers and applications to reach Temporal Cloud over a private network path, avoiding traversal of the public internet. Private connectivity reduces the surface for man-in-the-middle attacks and can meet stringent network security policies.
 
 #### 2. Separate environments by Namespace
 
-Use [Temporal Namespaces](https://docs.temporal.io/best-practices/managing-namespace#naming-conventions) to isolate workflows for different environments or teams (e.g. development, staging, production). Each Namespace is logically segregated and cannot interact with others by default, providing a security boundary. 
+Use [Temporal Namespaces](/best-practices/managing-namespace#naming-conventions) to isolate workflows for different environments or teams (e.g. development, staging, production). Each Namespace is logically segregated and cannot interact with others by default, providing a security boundary. 
 
 Ensure that your production Namespace uses stricter network controls (e.g. only accessible from the prod network) and that credentials for it are separate from non-prod Namespaces. This limits the impact of any compromise in a lower environment, and as workflow data is only visible to users with access to that Namespace, separating environments by Namespace also enforces data-visibility boundaries.
 
@@ -102,19 +102,19 @@ Temporal's data encryption capabilities ensure the security and confidentiality 
 
 #### 1. Enable Client-Side Encryption for Workflow Data
 
-Temporal provides an optional [data conversion framework](https://docs.temporal.io/dataconversion) (Data Converter) and payload codec interface; customers must implement, deploy, and operate their own custom codec and manage encryption keys. 
+Temporal provides an optional [data conversion framework](/dataconversion) (Data Converter) and payload codec interface; customers must implement, deploy, and operate their own custom codec and manage encryption keys. 
 
 In practice, this means you can encrypt any sensitive data before it is sent to Temporal Cloud and only decrypt it on the Client/Worker side. Because encryption keys stay under your control, you are responsible for key generation, secure storage, rotation, and versioning. Implementing this involves developing a custom codec plugin in your Temporal SDK and optionally (if you need to inspect decrypted payloads in the Web UI or CLI) deploying a dedicated codec server.
 
-#### 2. Encode Workflow Failure Details with a [Failure Converter](https://docs.temporal.io/failure-converter)
+#### 2. Encode Workflow Failure Details with a [Failure Converter](/failure-converter)
 
 Temporal’s default behavior copies error messages and call stacks as plain text, and this text is directly accessible in the Message field of Workflow Executions.
 
-If your failure messages and stack traces contain sensitive information, it is recommended that you configure the [Failure Converter](https://docs.temporal.io/failure-converter) to encrypt the error information. This would encrypt the `message` and `stack_trace` fields in the payloads.
+If your failure messages and stack traces contain sensitive information, it is recommended that you configure the [Failure Converter](/failure-converter) to encrypt the error information. This would encrypt the `message` and `stack_trace` fields in the payloads.
 
 #### 3. Leverage Namespace Data Retention Policies
 
-Temporal Cloud Namespace has a [Retention Period](https://docs.temporal.io/temporal-service/temporal-server#retention-period) setting for workflow histories (1 to 90 days). Set an appropriate retention period to balance operational needs with security. Shorter retention means completed workflow data (history, payloads) is purged sooner, reducing the amount of sensitive data stored in the cloud at any time. Document your retention choices to align with your company’s data retention policies and regulatory requirements. For retention periods over 90 days, these can be exported to your own GCS or S3 buckets.
+Temporal Cloud Namespace has a [Retention Period](/temporal-service/temporal-server#retention-period) setting for workflow histories (1 to 90 days). Set an appropriate retention period to balance operational needs with security. Shorter retention means completed workflow data (history, payloads) is purged sooner, reducing the amount of sensitive data stored in the cloud at any time. Document your retention choices to align with your company’s data retention policies and regulatory requirements. For retention periods over 90 days, these can be exported to your own GCS or S3 buckets.
 
 ### Availability and Disaster Recovery
 
@@ -137,8 +137,8 @@ Run a business-impact analysis to flag workflows where a regional outage would c
 
 For many organizations, ensuring High Availability (HA) is required because of strict uptime requirements, compliance, and regulatory needs. 
 
-For these critical use cases, enable High Availability features for specific namespaces for a [99.99% contractual SLA](https://docs.temporal.io/cloud/high-availability#high-availability-features). When choosing between [same-region, multi-region, and multi-cloud replication](https://docs.temporal.io/cloud/high-availability), it is recommended to use multi-region/multi-cloud replication to distribute your dependencies across regions. Using physically separated regions improves the fault tolerance of your application.
+For these critical use cases, enable High Availability features for specific namespaces for a [99.99% contractual SLA](/cloud/high-availability#high-availability-features). When choosing between [same-region, multi-region, and multi-cloud replication](/cloud/high-availability), it is recommended to use multi-region/multi-cloud replication to distribute your dependencies across regions. Using physically separated regions improves the fault tolerance of your application.
 
-By default, Temporal Cloud provides a [99.9% contractual SLA guarantee](https://docs.temporal.io/cloud/high-availability) against service errors for all namespaces. 
+By default, Temporal Cloud provides a [99.9% contractual SLA guarantee](/cloud/high-availability) against service errors for all namespaces. 
 
-Note: [enabling HA features for namespaces will 2x the consumption cost.](https://docs.temporal.io/cloud/pricing#high-availability-features)
+Note: [enabling HA features for namespaces will 2x the consumption cost.](/cloud/pricing#high-availability-features)

--- a/docs/cli/command-reference/activity.mdx
+++ b/docs/cli/command-reference/activity.mdx
@@ -88,7 +88,7 @@ temporal activity count \
     --query 'ActivityType="YourActivity"'
 ```
 
-Visit https://docs.temporal.io/visibility to read more about
+Visit /visibility to read more about
 Search Attributes and queries.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -150,7 +150,7 @@ Use the following options to change the behavior of this command. You can also u
 | `--retry-maximum-interval` | No | **duration** Maximum interval between retries. |
 | `--schedule-to-close-timeout` | No | **duration** Maximum time for the Activity Execution, including all retries. Either this or "start-to-close-timeout" is required. |
 | `--schedule-to-start-timeout` | No | **duration** Maximum time an Activity task can stay in a task queue before a Worker picks it up. On expiry it results in a non-retryable failure and no further attempts are scheduled. |
-| `--search-attribute` | No | **string[]** Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. Can be passed multiple times. See https://docs.temporal.io/visibility. |
+| `--search-attribute` | No | **string[]** Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. Can be passed multiple times. See /visibility. |
 | `--start-to-close-timeout` | No | **duration** Maximum time for a single Activity attempt. On expiry a new attempt may be scheduled if permitted by the retry policy and schedule-to-close timeout. Either this or "schedule-to-close-timeout" is required. |
 | `--static-details` | No | **string** Static Activity details for human consumption in UIs. Uses standard Markdown formatting excluding images, HTML, and script tags. _(Experimental)_ |
 | `--static-summary` | No | **string** Static Activity summary for human consumption in UIs. Uses standard Markdown formatting excluding images, HTML, and script tags. _(Experimental)_ |
@@ -186,7 +186,7 @@ temporal activity list \
     --query 'ActivityType="YourActivity"'
 ```
 
-Visit https://docs.temporal.io/visibility to read more about
+Visit /visibility to read more about
 Search Attributes and queries.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -355,7 +355,7 @@ Use the following options to change the behavior of this command. You can also u
 | `--retry-maximum-interval` | No | **duration** Maximum interval between retries. |
 | `--schedule-to-close-timeout` | No | **duration** Maximum time for the Activity Execution, including all retries. Either this or "start-to-close-timeout" is required. |
 | `--schedule-to-start-timeout` | No | **duration** Maximum time an Activity task can stay in a task queue before a Worker picks it up. On expiry it results in a non-retryable failure and no further attempts are scheduled. |
-| `--search-attribute` | No | **string[]** Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. Can be passed multiple times. See https://docs.temporal.io/visibility. |
+| `--search-attribute` | No | **string[]** Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. Can be passed multiple times. See /visibility. |
 | `--start-to-close-timeout` | No | **duration** Maximum time for a single Activity attempt. On expiry a new attempt may be scheduled if permitted by the retry policy and schedule-to-close timeout. Either this or "schedule-to-close-timeout" is required. |
 | `--static-details` | No | **string** Static Activity details for human consumption in UIs. Uses standard Markdown formatting excluding images, HTML, and script tags. _(Experimental)_ |
 | `--static-summary` | No | **string** Static Activity summary for human consumption in UIs. Uses standard Markdown formatting excluding images, HTML, and script tags. _(Experimental)_ |

--- a/docs/cli/command-reference/activity.mdx
+++ b/docs/cli/command-reference/activity.mdx
@@ -88,7 +88,7 @@ temporal activity count \
     --query 'ActivityType="YourActivity"'
 ```
 
-Visit /visibility to read more about
+Visit https://docs.temporal.io/visibility to read more about
 Search Attributes and queries.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -150,7 +150,7 @@ Use the following options to change the behavior of this command. You can also u
 | `--retry-maximum-interval` | No | **duration** Maximum interval between retries. |
 | `--schedule-to-close-timeout` | No | **duration** Maximum time for the Activity Execution, including all retries. Either this or "start-to-close-timeout" is required. |
 | `--schedule-to-start-timeout` | No | **duration** Maximum time an Activity task can stay in a task queue before a Worker picks it up. On expiry it results in a non-retryable failure and no further attempts are scheduled. |
-| `--search-attribute` | No | **string[]** Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. Can be passed multiple times. See /visibility. |
+| `--search-attribute` | No | **string[]** Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. Can be passed multiple times. See https://docs.temporal.io/visibility. |
 | `--start-to-close-timeout` | No | **duration** Maximum time for a single Activity attempt. On expiry a new attempt may be scheduled if permitted by the retry policy and schedule-to-close timeout. Either this or "schedule-to-close-timeout" is required. |
 | `--static-details` | No | **string** Static Activity details for human consumption in UIs. Uses standard Markdown formatting excluding images, HTML, and script tags. _(Experimental)_ |
 | `--static-summary` | No | **string** Static Activity summary for human consumption in UIs. Uses standard Markdown formatting excluding images, HTML, and script tags. _(Experimental)_ |
@@ -186,7 +186,7 @@ temporal activity list \
     --query 'ActivityType="YourActivity"'
 ```
 
-Visit /visibility to read more about
+Visit https://docs.temporal.io/visibility to read more about
 Search Attributes and queries.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -355,7 +355,7 @@ Use the following options to change the behavior of this command. You can also u
 | `--retry-maximum-interval` | No | **duration** Maximum interval between retries. |
 | `--schedule-to-close-timeout` | No | **duration** Maximum time for the Activity Execution, including all retries. Either this or "start-to-close-timeout" is required. |
 | `--schedule-to-start-timeout` | No | **duration** Maximum time an Activity task can stay in a task queue before a Worker picks it up. On expiry it results in a non-retryable failure and no further attempts are scheduled. |
-| `--search-attribute` | No | **string[]** Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. Can be passed multiple times. See /visibility. |
+| `--search-attribute` | No | **string[]** Search Attribute in `KEY=VALUE` format. Keys must be identifiers, and values must be JSON values. Can be passed multiple times. See https://docs.temporal.io/visibility. |
 | `--start-to-close-timeout` | No | **duration** Maximum time for a single Activity attempt. On expiry a new attempt may be scheduled if permitted by the retry policy and schedule-to-close timeout. Either this or "schedule-to-close-timeout" is required. |
 | `--static-details` | No | **string** Static Activity details for human consumption in UIs. Uses standard Markdown formatting excluding images, HTML, and script tags. _(Experimental)_ |
 | `--static-summary` | No | **string** Static Activity summary for human consumption in UIs. Uses standard Markdown formatting excluding images, HTML, and script tags. _(Experimental)_ |

--- a/docs/cli/command-reference/workflow.mdx
+++ b/docs/cli/command-reference/workflow.mdx
@@ -69,7 +69,7 @@ temporal workflow cancel \
     --query YourQuery
 ```
 
-Visit https://docs.temporal.io/visibility to read more about Search Attributes
+Visit /visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -94,7 +94,7 @@ temporal workflow count \
     --query YourQuery
 ```
 
-Visit https://docs.temporal.io/visibility to read more about Search Attributes
+Visit /visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -120,7 +120,7 @@ all replicas. Requests sent to a passive cluster are forwarded to the active
 cluster by default; to target the passive cluster directly, specify
 `--grpc-meta xdc-redirection=false`.
 
-Visit https://docs.temporal.io/visibility to read more about Search Attributes
+Visit /visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -290,7 +290,7 @@ temporal workflow list \
     --query YourQuery
 ```
 
-Visit https://docs.temporal.io/visibility to read more about Search Attributes
+Visit /visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 View a list of archived Workflow Executions:
@@ -391,7 +391,7 @@ temporal workflow reset \
 For batch resets, limit your resets to FirstWorkflowTask, LastWorkflowTask, or
 BuildId. Do not use Workflow IDs, run IDs, or event IDs with this command.
 
-Visit https://docs.temporal.io/visibility to read more about Search
+Visit /visibility to read more about Search
 Attributes and Query creation.
 
 ### with-workflow-update-options
@@ -458,7 +458,7 @@ temporal workflow signal \
     --input '{"YourInputKey": "YourInputValue"}'
 ```
 
-Visit https://docs.temporal.io/visibility to read more about Search Attributes
+Visit /visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -668,7 +668,7 @@ temporal workflow terminate \
 Workflow code cannot see or respond to terminations. To perform clean-up work
 in your Workflow code, use `temporal workflow cancel` instead.
 
-Visit https://docs.temporal.io/visibility to read more about Search Attributes
+Visit /visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.

--- a/docs/cli/command-reference/workflow.mdx
+++ b/docs/cli/command-reference/workflow.mdx
@@ -69,7 +69,7 @@ temporal workflow cancel \
     --query YourQuery
 ```
 
-Visit /visibility to read more about Search Attributes
+Visit https://docs.temporal.io/visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -94,7 +94,7 @@ temporal workflow count \
     --query YourQuery
 ```
 
-Visit /visibility to read more about Search Attributes
+Visit https://docs.temporal.io/visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -120,7 +120,7 @@ all replicas. Requests sent to a passive cluster are forwarded to the active
 cluster by default; to target the passive cluster directly, specify
 `--grpc-meta xdc-redirection=false`.
 
-Visit /visibility to read more about Search Attributes
+Visit https://docs.temporal.io/visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -290,7 +290,7 @@ temporal workflow list \
     --query YourQuery
 ```
 
-Visit /visibility to read more about Search Attributes
+Visit https://docs.temporal.io/visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 View a list of archived Workflow Executions:
@@ -391,7 +391,7 @@ temporal workflow reset \
 For batch resets, limit your resets to FirstWorkflowTask, LastWorkflowTask, or
 BuildId. Do not use Workflow IDs, run IDs, or event IDs with this command.
 
-Visit /visibility to read more about Search
+Visit https://docs.temporal.io/visibility to read more about Search
 Attributes and Query creation.
 
 ### with-workflow-update-options
@@ -458,7 +458,7 @@ temporal workflow signal \
     --input '{"YourInputKey": "YourInputValue"}'
 ```
 
-Visit /visibility to read more about Search Attributes
+Visit https://docs.temporal.io/visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.
@@ -668,7 +668,7 @@ temporal workflow terminate \
 Workflow code cannot see or respond to terminations. To perform clean-up work
 in your Workflow code, use `temporal workflow cancel` instead.
 
-Visit /visibility to read more about Search Attributes
+Visit https://docs.temporal.io/visibility to read more about Search Attributes
 and Query creation. See `temporal batch --help` for a quick reference.
 
 Use the following options to change the behavior of this command. You can also use any of the [global flags](#global-flags) that apply to all subcommands.

--- a/docs/cloud/audit-logs-gcp.mdx
+++ b/docs/cloud/audit-logs-gcp.mdx
@@ -59,6 +59,6 @@ If everything is configured correctly, you will see a `Success` status indicatin
 
 :::info MORE INFORMATION
 
-For more details, refer to [Audit Logs with Temporal Cloud](https://docs.temporal.io/cloud/audit-logs).
+For more details, refer to [Audit Logs with Temporal Cloud](/cloud/audit-logs).
 
 :::

--- a/docs/cloud/capacity-modes.mdx
+++ b/docs/cloud/capacity-modes.mdx
@@ -155,7 +155,7 @@ For Requests in excess of 4 TRUs in regions outside of the US, we recommend subm
 ### Provisioned Capacity Availability
 The amount of capacity available within a region may vary. 
 Temporal will check available capacity at the time of your request and aims to provision requested capacity within two minutes. 
-If you need capacity beyond what is self-serviceable or available in a region, please [file a support ticket](https://docs.temporal.io/cloud/support#ticketing) indicating the limit, region, and timeframe that the capacity is needed. 
+If you need capacity beyond what is self-serviceable or available in a region, please [file a support ticket](/cloud/support#ticketing) indicating the limit, region, and timeframe that the capacity is needed. 
 
 
 ### When should I use Provisioned Capacity?

--- a/docs/cloud/connectivity/index.mdx
+++ b/docs/cloud/connectivity/index.mdx
@@ -104,7 +104,7 @@ A GCP Private Service Connect (PSC) private Connectivity Rule requires:
 - `region`: The region of the PSC connection, prefixed with `gcp-` (ex: `gcp-us-east1`). Must be the same region as the Namespace. Refer to the [Temporal Cloud region list](/cloud/regions) for supported regions.
 - `gcp-project-id`: The identifier of the GCP project where you created the PSC connection (ex: `my-example-project-123`).
 
-Connectivity Rules can be created and managed with [tcld](https://docs.temporal.io/cloud/tcld/), [Terraform](https://github.com/temporalio/terraform-provider-temporalcloud/), or the [Cloud Ops API](/ops). There is no Temporal Cloud Web UI option for creating or managing Connectivity Rules at this time.
+Connectivity Rules can be created and managed with [tcld](/cloud/tcld/), [Terraform](https://github.com/temporalio/terraform-provider-temporalcloud/), or the [Cloud Ops API](/ops). There is no Temporal Cloud Web UI option for creating or managing Connectivity Rules at this time.
 
 :::tip Connectivity Rules give Temporal visibility into your private connections
 

--- a/docs/cloud/connectivity/ip-addresses.mdx
+++ b/docs/cloud/connectivity/ip-addresses.mdx
@@ -293,7 +293,7 @@ Take note of the following:
 
 The full list of Stable IP ranges is published as a public JSON file at:
 
-**[https://docs.temporal.io/json/stable-ip-ranges-prod.json](https://docs.temporal.io/json/stable-ip-ranges-prod.json)**
+**[/json/stable-ip-ranges-prod.json](/json/stable-ip-ranges-prod.json)**
 
 Click the link to inspect the list in your browser, or copy the URL into your firewall tooling, a `curl`/`wget` script, or a Terraform `http` data source:
 
@@ -387,7 +387,7 @@ If your Namespace is currently reached over AWS PrivateLink and protected by a p
 
 **Steps:**
 
-1. **Allowlist Stable IPs in your firewall first.** Fetch the IP ranges for your Namespace's region from [https://docs.temporal.io/json/stable-ip-ranges-prod.json](https://docs.temporal.io/json/stable-ip-ranges-prod.json) and add them to your egress allowlist before changing anything else. If you skip this step, traffic will be lost.
+1. **Allowlist Stable IPs in your firewall first.** Fetch the IP ranges for your Namespace's region from [/json/stable-ip-ranges-prod.json](/json/stable-ip-ranges-prod.json) and add them to your egress allowlist before changing anything else. If you skip this step, traffic will be lost.
 
 2. **Create (or update) the account's public Connectivity Rule with Stable IPs enabled.** This step requires the [Cloud Ops API](#how-to-enable-stable-ips-with-curl) or the [`cloud-api` client](https://github.com/temporalio/cloud-api) — `tcld` does not currently support creating a public Connectivity Rule with Stable IPs.
 
@@ -406,7 +406,7 @@ If your Namespace is currently reached over AWS PrivateLink and protected by a p
 
 4. **Switch client DNS resolution from PrivateLink to public.** This is the actual cutover. Remove the private DNS override — Route 53 private hosted zone, `/etc/hosts`, or VPC DNS resolver rules — so that `<namespace>.<account>.tmprl.cloud` resolves through public DNS to a Stable IP. Restart Workers to drop existing PrivateLink connections and force re-resolution.
 
-5. **Verify traffic is flowing over Stable IPs.** On a Worker host, run `dig <namespace>.<account>.tmprl.cloud` and confirm the answer is a Stable IP from the [published JSON list](https://docs.temporal.io/json/stable-ip-ranges-prod.json), not your VPC endpoint IP. Confirm Workers are polling and there are no `RESOURCE_EXHAUSTED` or connection errors in their logs.
+5. **Verify traffic is flowing over Stable IPs.** On a Worker host, run `dig <namespace>.<account>.tmprl.cloud` and confirm the answer is a Stable IP from the [published JSON list](/json/stable-ip-ranges-prod.json), not your VPC endpoint IP. Confirm Workers are polling and there are no `RESOURCE_EXHAUSTED` or connection errors in their logs.
 
 6. **Detach the private Connectivity Rule.** Once you are confident all traffic is on the public path, remove the private rule by re-attaching only the public rule:
 

--- a/docs/cloud/connectivity/ip-addresses.mdx
+++ b/docs/cloud/connectivity/ip-addresses.mdx
@@ -293,7 +293,7 @@ Take note of the following:
 
 The full list of Stable IP ranges is published as a public JSON file at:
 
-**[/json/stable-ip-ranges-prod.json](/json/stable-ip-ranges-prod.json)**
+**[https://docs.temporal.io/json/stable-ip-ranges-prod.json](/json/stable-ip-ranges-prod.json)**
 
 Click the link to inspect the list in your browser, or copy the URL into your firewall tooling, a `curl`/`wget` script, or a Terraform `http` data source:
 
@@ -387,7 +387,7 @@ If your Namespace is currently reached over AWS PrivateLink and protected by a p
 
 **Steps:**
 
-1. **Allowlist Stable IPs in your firewall first.** Fetch the IP ranges for your Namespace's region from [/json/stable-ip-ranges-prod.json](/json/stable-ip-ranges-prod.json) and add them to your egress allowlist before changing anything else. If you skip this step, traffic will be lost.
+1. **Allowlist Stable IPs in your firewall first.** Fetch the IP ranges for your Namespace's region from [https://docs.temporal.io/json/stable-ip-ranges-prod.json](/json/stable-ip-ranges-prod.json) and add them to your egress allowlist before changing anything else. If you skip this step, traffic will be lost.
 
 2. **Create (or update) the account's public Connectivity Rule with Stable IPs enabled.** This step requires the [Cloud Ops API](#how-to-enable-stable-ips-with-curl) or the [`cloud-api` client](https://github.com/temporalio/cloud-api) — `tcld` does not currently support creating a public Connectivity Rule with Stable IPs.
 

--- a/docs/cloud/gcp-export-gcs.mdx
+++ b/docs/cloud/gcp-export-gcs.mdx
@@ -93,7 +93,7 @@ Don't forget to click Create at the end of your setup to confirm your export.
 
 To access export-related commands in tcld, please follow these steps:
 
-1. [Download the latest version of tcld](https://docs.temporal.io/cloud/tcld/#install-tcld).
+1. [Download the latest version of tcld](/cloud/tcld#install-tcld).
 2. Make sure your tcld version is v0.35.0 or above.
 3. Run the command: `tcld n export gcs`:
    ```bash

--- a/docs/cloud/get-started/api-keys.mdx
+++ b/docs/cloud/get-started/api-keys.mdx
@@ -98,7 +98,7 @@ Check these setup details before using API keys:
 - The Global Administrator or Account Owner may need to [enable API keys access](#manage-api-keys) for your Temporal
   Account.
 - Have access to the [Temporal Cloud UI](https://cloud.temporal.io/) or Temporal Cloud CLI
-  ([tcld](https://docs.temporal.io/cloud/tcld/)) to create an API key.
+  ([tcld](/cloud/tcld/)) to create an API key.
 
 ## Global Administrator and Account Owner API key management {/* #manage-api-keys */}
 

--- a/docs/cloud/get-started/certificates.mdx
+++ b/docs/cloud/get-started/certificates.mdx
@@ -298,7 +298,7 @@ ones are generated and deployed.
 
 ### 3. Regenerate end-entity certificates with the new CA certificate
 
-[Configure all clients](https://docs.temporal.io/cloud/certificates#configure-clients-to-use-client-certificates)
+[Configure all clients](/cloud/certificates#configure-clients-to-use-client-certificates)
 (Temporal CLI, SDKs, or Workers) to use the new certificate and private key alongside the compromised key. Update the
 client configuration as described in
 [Configure clients to use client certificates](#configure-clients-to-use-client-certificates).
@@ -319,7 +319,7 @@ stricter controls, such as:
 
 - Limiting end-entity certificates to specific Namespaces
 - Rotating certificates regularly as a preventive measure
-- [Audit logs on a regular schedule](https://docs.temporal.io/cloud/audit-logs)
+- [Audit logs on a regular schedule](/cloud/audit-logs)
 
 ## How to add, update, and remove certificates in a Temporal Cloud Namespace {/* #manage-certificates */}
 

--- a/docs/cloud/get-started/namespaces.mdx
+++ b/docs/cloud/get-started/namespaces.mdx
@@ -249,7 +249,7 @@ accessing Namespace endpoints.
 Temporal Cloud supports authentication to Namespaces using [API keys](/cloud/api-keys) _or_
 [mTLS](/cloud/certificates). To migrate a Namespace from one authentication method to another, or to use both API
 key and mTLS authentication on the same Namespace, please contact
-[Support](https://docs.temporal.io/cloud/support#support-ticket).
+[Support](/cloud/support#support-ticket).
 
 :::info
 
@@ -383,7 +383,7 @@ Namespace removal is permanent.
 Closed Workflow Histories remain in Temporal storage until the user-defined retention period expires. This period
 reflects the policy in effect when the Workflow Execution was closed.
 
-For further questions or concerns, contact [Support](https://docs.temporal.io/cloud/support#support-ticket).
+For further questions or concerns, contact [Support](/cloud/support#support-ticket).
 
 ### Delete a Namespace using tcld
 

--- a/docs/cloud/high-availability/failovers/index.mdx
+++ b/docs/cloud/high-availability/failovers/index.mdx
@@ -149,7 +149,7 @@ reflected in the replica due to <ToolTipTerm term="replication lag" />, particul
 non-graceful failover, replication lag may cause a temporary setback in Workflow progress.
 
 Namespaces that are not replicated can be configured to provide _at-most-once_ semantics for Activity execution when a
-retry policy's [maximum attempts](https://docs.temporal.io/retry-policies#maximum-attempts) is set to 0. High
+retry policy's [maximum attempts](/encyclopedia/retry-policies#maximum-attempts) is set to 0. High
 Availability Namespaces provide _at-least-once_ semantics for execution of Activities. Completed Activities _may_ be
 re-dispatched in a newly active Namespace, leading to repeated executions.
 

--- a/docs/cloud/manage-access/permissions-reference.mdx
+++ b/docs/cloud/manage-access/permissions-reference.mdx
@@ -14,7 +14,7 @@ Temporal Cloud access controls are organized across two scopes:
 - Account-level role permissions
 - Namespace-level permissions
 
-Within each scope, permissions apply to publicly documented [Temporal Cloud Ops API](https://docs.temporal.io/ops)
+Within each scope, permissions apply to publicly documented [Temporal Cloud Ops API](/ops)
 endpoints and to additional non-Cloud Ops capabilities, such as Temporal Cloud UI and internal automation behaviors.
 
 ## Account-level access {/* #account-level-access */}

--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -46,7 +46,7 @@ API keys can be created using the [Temporal Cloud UI](https://cloud.temporal.io)
 
 :::info
 
-See the [docs](https://docs.temporal.io/cloud/api-keys#serviceaccount-api-keys) for more details on generating API keys.
+See the [docs](/cloud/api-keys#serviceaccount-api-keys) for more details on generating API keys.
 
 :::
 

--- a/docs/cloud/migrate/manual.mdx
+++ b/docs/cloud/migrate/manual.mdx
@@ -93,4 +93,4 @@ The volume of these requests might be high to execute against all the matches to
 [Multi-Cluster Replication](/self-hosted-guide/multi-cluster-replication) is an experimental feature which asynchronously replicates Workflow Executions from active Clusters to other passive Clusters for backup and state reconstruction.
 Migrating Execution History from a self-hosted Temporal Service to Temporal Cloud is not currently supported.
 However, a migration tool based on Multi-Cluster Replication, which will enable this, is currently in development for Temporal Cloud.
-If you have used this feature locally or you are interested in using it to migrate to Temporal Cloud, [create a support ticket](https://docs.temporal.io/cloud/support) or watch this space for more information about public availability.
+If you have used this feature locally or you are interested in using it to migrate to Temporal Cloud, [create a support ticket](/cloud/support) or watch this space for more information about public availability.

--- a/docs/cloud/terraform-provider.mdx
+++ b/docs/cloud/terraform-provider.mdx
@@ -44,7 +44,7 @@ To use the Terraform provider, you'll need the following:
 
 - The [Terraform CLI](https://developer.hashicorp.com/terraform/cli)
 - An [API Key](/cloud/api-keys): an API Key is required to use the Terraform provider.
-  - See [the API docs](https://docs.temporal.io/cloud/api-keys#generate-an-api-key) for instructions on generating an
+  - See [the API docs](/cloud/api-keys#generate-an-api-key) for instructions on generating an
     API Key.
 
 :::note OpenTofu Registry
@@ -56,7 +56,7 @@ managed by Temporal Technologies.
 
 ## Setup
 
-Generate an [API Key](https://docs.temporal.io/cloud/api-keys#generate-an-api-key) to authenticate Terraform operations
+Generate an [API Key](/cloud/api-keys#generate-an-api-key) to authenticate Terraform operations
 with your Temporal Cloud account or a Service Account. Then, either use an environment variable or pass the API Key into
 the provider manually to manage your Temporal Cloud Terraform resources.
 
@@ -722,7 +722,7 @@ process of securely accessing the API Key Token in the Create section of this gu
 
 :::note Limits and Best Practices
 
-- See the API Key [documentation](https://docs.temporal.io/cloud/api-keys) for information about the limits and best
+- See the API Key [documentation](/cloud/api-keys) for information about the limits and best
   practices for managing API Keys.
 - See Terraform's documentation on working with
   [sensitive data](https://www.terraform.io/docs/language/values/variables.html#sensitive-values) for more information

--- a/docs/develop/dotnet/activities/standalone-activities.mdx
+++ b/docs/develop/dotnet/activities/standalone-activities.mdx
@@ -58,7 +58,7 @@ Prerequisites:
 
 - **[.NET](https://dotnet.microsoft.com/download)** 8.0+
 
-- **Temporal .NET SDK** (v1.12.0 or higher). See the [.NET Quickstart](https://docs.temporal.io/develop/dotnet/set-up-your-local-dotnet) for install instructions.
+- **Temporal .NET SDK** (v1.12.0 or higher). See the [.NET Quickstart](/develop/dotnet/set-up-your-local-dotnet) for install instructions.
 
 - **Temporal CLI** v1.7.0 or higher
 

--- a/docs/develop/dotnet/best-practices/error-handling.mdx
+++ b/docs/develop/dotnet/best-practices/error-handling.mdx
@@ -97,6 +97,6 @@ catch (ActivityFailureException err)
 
 This works differently in a Workflow than raising exceptions from Activities.
 In an Activity, any C# exceptions or custom exceptions are converted to a Temporal `ApplicationError`.
-In a Workflow, any exceptions that are raised other than an explicit Temporal `ApplicationError` will only fail that particular [Workflow Task](https://docs.temporal.io/tasks#workflow-task-execution) and be retried.
+In a Workflow, any exceptions that are raised other than an explicit Temporal `ApplicationError` will only fail that particular [Workflow Task](/tasks#workflow-task-execution) and be retried.
 This includes any typical C# `RuntimeError`s that are raised automatically.
 These errors are treated as bugs that can be corrected with a fixed deployment, rather than a reason for a Temporal Workflow Execution to return unexpectedly.

--- a/docs/develop/dotnet/client/temporal-client.mdx
+++ b/docs/develop/dotnet/client/temporal-client.mdx
@@ -43,7 +43,7 @@ configuration. You can provide these options directly in code, or load them from
 configuration file for secure, repeatable configuration.
 
 When you’re running a Temporal Service locally (such as with the
-[Temporal CLI dev server](https://docs.temporal.io/cli/command-reference/server#start-dev)), the required options are minimal. If you
+[Temporal CLI dev server](/cli/command-reference/server#start-dev)), the required options are minimal. If you
 don't specify a host/port, most connections default to `127.0.0.1:7233` and the `default` Namespace.
 
 <Tabs groupId="connect-options-dotnet" defaultValue="config-file" >

--- a/docs/develop/dotnet/nexus/feature-guide.mdx
+++ b/docs/develop/dotnet/nexus/feature-guide.mdx
@@ -87,7 +87,7 @@ Defining a clear contract for the Nexus Service is crucial for smooth communicat
 
 In this example, there is a service package that describes the Service and Operation names along with input/output types for caller Workflows to use the Nexus Endpoint.
 
-Each [Temporal SDK includes and uses a default Data Converter](https://docs.temporal.io/dataconversion).
+Each [Temporal SDK includes and uses a default Data Converter](/dataconversion).
 The default data converter encodes payloads in the following order: Null, Byte array, Protobuf JSON, and JSON.
 In a polyglot environment, that is where more than one language and SDK is being used to develop a Temporal solution, Protobuf and JSON are common choices.
 This example uses .NET classes serialized into JSON.

--- a/docs/develop/dotnet/set-up.mdx
+++ b/docs/develop/dotnet/set-up.mdx
@@ -101,7 +101,7 @@ Build the solution:
   }>
     ## Install Temporal CLI and start the development server
 
-    The fastest way to get a development version of the Temporal Service running on your local machine is to use [Temporal CLI](https://docs.temporal.io/cli).
+    The fastest way to get a development version of the Temporal Service running on your local machine is to use [Temporal CLI](/cli).
 
     Choose your operating system to install Temporal CLI:
   </SetupStep>

--- a/docs/develop/go/activities/basics.mdx
+++ b/docs/develop/go/activities/basics.mdx
@@ -113,7 +113,7 @@ func (a *YourActivityObject) YourActivityDefinition(ctx context.Context, param Y
 
 All data returned from an Activity must be serializable.
 
-Activity return values are subject to payload size limits in Temporal. The default payload size limit is 2MB, and there is a hard limit of 4MB for any gRPC message size in the Event History transaction ([see Cloud limits here](https://docs.temporal.io/cloud/limits#per-message-grpc-limit)). Keep in mind that all return values are recorded in a [Workflow Execution Event History](/workflow-execution/event#event-history).
+Activity return values are subject to payload size limits in Temporal. The default payload size limit is 2MB, and there is a hard limit of 4MB for any gRPC message size in the Event History transaction ([see Cloud limits here](/cloud/limits#per-message-grpc-limit)). Keep in mind that all return values are recorded in a [Workflow Execution Event History](/workflow-execution/event#event-history).
 
 A Go-based Activity Definition can return either just an `error` or a `customValue, error` combination (same as a Workflow Definition).
 You may wish to use a `struct` type to hold all custom values, just keep in mind they must all be serializable.

--- a/docs/develop/go/activities/standalone-activities.mdx
+++ b/docs/develop/go/activities/standalone-activities.mdx
@@ -57,7 +57,7 @@ Prerequisites:
 
 - **[Go](https://go.dev/dl/)** 1.22+
 
-- **[Temporal Go SDK](https://docs.temporal.io/develop/go/core-application#install-a-temporal-sdk)** (v1.41.0 or higher)
+- **[Temporal Go SDK](/develop/go/set-up-your-local-go#install-the-temporal-go-sdk)** (v1.41.0 or higher)
 
 - **Temporal CLI** v1.7.0 or higher
 

--- a/docs/develop/go/client/namespaces.mdx
+++ b/docs/develop/go/client/namespaces.mdx
@@ -23,7 +23,7 @@ Use Namespaces to isolate your Workflow Executions according to your needs.
 For example, you can use Namespaces to match the development lifecycle by having separate `dev` and `prod` Namespaces.
 You could also use them to ensure Workflow Executions between different teams never communicate - such as ensuring that the `teamA` Namespace never impacts the `teamB` Namespace.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) to create and manage a Namespace from the UI, or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to manage Namespaces from the command-line interface.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) to create and manage a Namespace from the UI, or [tcld commands](/cloud/tcld/namespace/) to manage Namespaces from the command-line interface.
 
 On self-hosted Temporal Service, you can register and manage your Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.
@@ -36,7 +36,7 @@ You must register a Namespace with the Temporal Service before setting it in the
 
 Registering a Namespace creates a Namespace on the Temporal Service or Temporal Cloud.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to create Namespaces.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](/cloud/tcld/namespace/) to create Namespaces.
 
 On self-hosted Temporal Service, you can register your Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.
@@ -73,7 +73,7 @@ To update your Namespace using the Temporal CLI, use the [temporal operator name
 
 You can get details for your Namespaces, update Namespace configuration, and deprecate or delete your Namespaces.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to manage Namespaces.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](/cloud/tcld/namespace/) to manage Namespaces.
 
 On self-hosted Temporal Service, you can manage your registered Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.

--- a/docs/develop/go/client/temporal-client.mdx
+++ b/docs/develop/go/client/temporal-client.mdx
@@ -69,7 +69,7 @@ Environment variable and configuration file support were added in Go SDK v1.28.0
 :::
 
 When you are running a Temporal Service locally, such as the
-[Temporal CLI](https://docs.temporal.io/cli/command-reference/server#start-dev), the connection options you must provide are minimal.
+[Temporal CLI](/cli/command-reference/server#start-dev), the connection options you must provide are minimal.
 
 If you don't provide [`HostPort`](https://pkg.go.dev/go.temporal.io/sdk/internal#ClientOptions), the Client defaults the
 address and port number to `127.0.0.1:7233`, which is the port of the development Temporal Service. If you don't set a
@@ -651,7 +651,7 @@ if err != nil {
 You can configure Task Queues that are host-specific, Worker-specific or Workflow-specific to distribute your
 application load. For more information, refer to
 [Task Queues Processing Tuning](/develop/worker-performance#task-queues-processing-tuning) and
-[Worker Versioning](https://docs.temporal.io/worker-versioning).
+[Worker Versioning](/worker-versioning).
 
 ### Set custom Workflow Id {/* #workflow-id */}
 

--- a/docs/develop/go/nexus/feature-guide.mdx
+++ b/docs/develop/go/nexus/feature-guide.mdx
@@ -86,7 +86,7 @@ Defining a clear contract for the Nexus Service is crucial for smooth communicat
 
 In this example, there is a service package that describes the Service and Operation names along with input/output types for caller Workflows to use the Nexus Endpoint.
 
-Each [Temporal SDK includes and uses a default Data Converter](https://docs.temporal.io/dataconversion).
+Each [Temporal SDK includes and uses a default Data Converter](/dataconversion).
 The default data converter encodes payloads in the following order: Null, Byte array, Protobuf JSON, and JSON.
 In a polyglot environment, that is where more than one language and SDK is being used to develop a Temporal solution, Protobuf and JSON are common choices.
 This example uses native Go types.

--- a/docs/develop/go/set-up.mdx
+++ b/docs/develop/go/set-up.mdx
@@ -115,7 +115,7 @@ Finally, install the Temporal SDK with `go get`.
 ## Install Temporal CLI and start the development server
 
 The fastest way to get a development version of the Temporal Service running on your local machine is to use
-[Temporal CLI](https://docs.temporal.io/cli).
+[Temporal CLI](/cli).
 
 Choose your operating system to install Temporal CLI:
 

--- a/docs/develop/go/workflows/schedules.mdx
+++ b/docs/develop/go/workflows/schedules.mdx
@@ -262,7 +262,7 @@ if err != nil {
 
 :::caution Cron support is not recommended
 
-We recommend using [Schedules](https://docs.temporal.io/schedule) instead of Cron Jobs.
+We recommend using [Schedules](/schedule) instead of Cron Jobs.
 Schedules were built to provide a better developer experience, including more configuration options and the ability to update or pause running Schedules.
 
 :::

--- a/docs/develop/java/activities/basics.mdx
+++ b/docs/develop/java/activities/basics.mdx
@@ -116,7 +116,7 @@ For more details, see [Dynamic Activity Reference](https://www.javadoc.io/doc/io
 
 All data returned from an Activity must be serializable.
 
-Activity return values are subject to payload size limits in Temporal. The default payload size limit is 2MB, and there is a hard limit of 4MB for any gRPC message size in the Event History transaction ([see Cloud limits here](https://docs.temporal.io/cloud/limits#per-message-grpc-limit)). Keep in mind that all return values are recorded in a [Workflow Execution Event History](/workflow-execution/event#event-history).
+Activity return values are subject to payload size limits in Temporal. The default payload size limit is 2MB, and there is a hard limit of 4MB for any gRPC message size in the Event History transaction ([see Cloud limits here](/cloud/limits#per-message-grpc-limit)). Keep in mind that all return values are recorded in a [Workflow Execution Event History](/workflow-execution/event#event-history).
 
 Activity return values must be serializable and deserializable by the provided [`DataConverter`](https://www.javadoc.io/static/io.temporal/temporal-sdk/1.17.0/io/temporal/common/converter/DataConverter.html).
 

--- a/docs/develop/java/client/namespaces.mdx
+++ b/docs/develop/java/client/namespaces.mdx
@@ -23,7 +23,7 @@ Use Namespaces to isolate your Workflow Executions according to your needs.
 For example, you can use Namespaces to match the development lifecycle by having separate `dev` and `prod` Namespaces.
 You could also use them to ensure Workflow Executions between different teams never communicate - such as ensuring that the `teamA` Namespace never impacts the `teamB` Namespace.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) to create and manage a Namespace from the UI, or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to manage Namespaces from the command-line interface.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) to create and manage a Namespace from the UI, or [tcld commands](/cloud/tcld/namespace/) to manage Namespaces from the command-line interface.
 
 On self-hosted Temporal Service, you can register and manage your Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.
@@ -36,7 +36,7 @@ You must register a Namespace with the Temporal Service before setting it in the
 
 Registering a Namespace creates a Namespace on the Temporal Service or Temporal Cloud.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to create Namespaces.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](/cloud/tcld/namespace/) to create Namespaces.
 
 On self-hosted Temporal Service, you can register your Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.
@@ -76,7 +76,7 @@ To update your Namespace use the [UpdateNamespace API](#manage-namespaces) with 
 
 You can get details for your Namespaces, update Namespace configuration, and deprecate or delete your Namespaces.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to manage Namespaces.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](/cloud/tcld/namespace/) to manage Namespaces.
 
 On self-hosted Temporal Service, you can manage your registered Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.
@@ -85,7 +85,7 @@ Use a custom [Authorizer](/self-hosted-guide/security#authorizer-plugin) on your
 
 You must register a Namespace with the Temporal Service before setting it in the Temporal Client.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces) or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to manage Namespaces.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces) or [tcld commands](/cloud/tcld/namespace/) to manage Namespaces.
 
 On self-hosted Temporal Service, you can manage your registered Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.

--- a/docs/develop/java/index.mdx
+++ b/docs/develop/java/index.mdx
@@ -87,7 +87,7 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 
 ## Temporal Java technical resources
 
-- [Java SDK Quickstart - Setup Guide](https://docs.temporal.io/develop/java/set-up-your-local-java)
+- [Java SDK Quickstart - Setup Guide](/develop/java/set-up-your-local-java)
 - [Java API Documentation](https://javadoc.io/doc/io.temporal/temporal-sdk)
 - [Java SDK Code Samples](https://github.com/temporalio/samples-java)
 - [Java SDK GitHub](https://github.com/temporalio/sdk-java)

--- a/docs/develop/java/nexus/feature-guide.mdx
+++ b/docs/develop/java/nexus/feature-guide.mdx
@@ -91,7 +91,7 @@ Defining a clear contract for the Nexus Service is crucial for smooth communicat
 In this example, there is a service package that describes the Service and Operation names along with input/output types
 for caller Workflows to use the Nexus Endpoint.
 
-Each [Temporal SDK includes and uses a default Data Converter](https://docs.temporal.io/dataconversion). The default
+Each [Temporal SDK includes and uses a default Data Converter](/dataconversion). The default
 data converter encodes payloads in the following order: Null, Byte array, Protobuf JSON, and JSON. In a polyglot
 environment, that is where more than one language and SDK is being used to develop a Temporal solution, Protobuf and
 JSON are common choices. This example uses Java classes serialized into JSON.

--- a/docs/develop/java/set-up.mdx
+++ b/docs/develop/java/set-up.mdx
@@ -211,7 +211,7 @@ Next, you'll configure a local Temporal Service for development.
 ## Install Temporal CLI and start the development server
 
 The fastest way to get a development version of the Temporal Service running on your local machine is to use
-[Temporal CLI](https://docs.temporal.io/cli).
+[Temporal CLI](/cli).
 
 Choose your operating system to install Temporal CLI:
 

--- a/docs/develop/java/workflows/message-passing.mdx
+++ b/docs/develop/java/workflows/message-passing.mdx
@@ -209,7 +209,7 @@ public class MessagePassingIntro {
   - When a Validator throws an error, the Update is rejected, the Update is not run, and `WorkflowExecutionUpdateAccepted` _won't_ be added to the Event History.
     The caller receives an "Update failed" error.
 
-- Use [`getCurrentUpdateInfo`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/internal/sync/WorkflowInternal.html#getCurrentUpdateInfo()) to obtain information about the current Update. This includes the Update ID, which can be useful for deduplication when using Continue-As-New: see [Ensuring your messages are processed exactly once](https://docs.temporal.io/handling-messages#exactly-once-message-processing).
+- Use [`getCurrentUpdateInfo`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/internal/sync/WorkflowInternal.html#getCurrentUpdateInfo()) to obtain information about the current Update. This includes the Update ID, which can be useful for deduplication when using Continue-As-New: see [Ensuring your messages are processed exactly once](/handling-messages#exactly-once-message-processing).
 
 - Signal (and Update) handlers can be blocking, letting them use Activities, Child Workflows, durable [`Workflow.sleep`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#sleep(java.time.Duration)) Timers, [`Workflow.await`](https://www.javadoc.io/doc/io.temporal/temporal-sdk/latest/io/temporal/workflow/Workflow.html#await(java.time.Duration,java.util.function.Supplier)) conditions, and more.
   See [Blocking handlers](#blocking-handlers) and [Workflow message passing](/encyclopedia/workflow-message-passing) for safe usage guidelines.

--- a/docs/develop/java/workflows/schedules.mdx
+++ b/docs/develop/java/workflows/schedules.mdx
@@ -180,7 +180,7 @@ handle.update(
 
 :::caution Cron support is not recommended
 
-We recommend using [Schedules](https://docs.temporal.io/schedule) instead of Cron Jobs.
+We recommend using [Schedules](/schedule) instead of Cron Jobs.
 Schedules were built to provide a better developer experience, including more configuration options and the ability to update or pause running Schedules.
 
 :::

--- a/docs/develop/php/activities/basics.mdx
+++ b/docs/develop/php/activities/basics.mdx
@@ -65,7 +65,7 @@ The default implementation uses a JSON serializer, but an alternative implementa
 
 All data returned from an Activity must be serializable.
 
-Activity return values are subject to payload size limits in Temporal. The default payload size limit is 2MB, and there is a hard limit of 4MB for any gRPC message size in the Event History transaction ([see Cloud limits here](https://docs.temporal.io/cloud/limits#per-message-grpc-limit)). Keep in mind that all return values are recorded in a [Workflow Execution Event History](/workflow-execution/event#event-history).
+Activity return values are subject to payload size limits in Temporal. The default payload size limit is 2MB, and there is a hard limit of 4MB for any gRPC message size in the Event History transaction ([see Cloud limits here](/cloud/limits#per-message-grpc-limit)). Keep in mind that all return values are recorded in a [Workflow Execution Event History](/workflow-execution/event#event-history).
 
 Return values must be serializable to a byte array using the provided [DataConverter](https://github.com/temporalio/sdk-php/blob/master/src/DataConverter/DataConverterInterface.php) interface.
 The default implementation uses a JSON serializer, but an alternative implementation can be easily configured.

--- a/docs/develop/php/client/temporal-client.mdx
+++ b/docs/develop/php/client/temporal-client.mdx
@@ -44,7 +44,7 @@ However, it is acceptable and common to use a Temporal Client inside an Activity
 
 :::
 
-When you are running a Temporal Service locally (such as the [Temporal CLI](https://docs.temporal.io/cli/command-reference/server#start-dev)), the number of connection options you must provide is minimal.
+When you are running a Temporal Service locally (such as the [Temporal CLI](/cli/command-reference/server#start-dev)), the number of connection options you must provide is minimal.
 Many SDKs default to `127.0.0.1:7233`.
 
 In the PHP SDK, different client classes are responsible for different functional areas.

--- a/docs/develop/php/set-up.mdx
+++ b/docs/develop/php/set-up.mdx
@@ -222,7 +222,7 @@ Create a simple configuration file named `.rr.yaml` with the following content:
 ## Install Temporal CLI and start the development server
 
 The fastest way to get a development version of the Temporal Service running on your local machine is to use
-[Temporal CLI](https://docs.temporal.io/cli).
+[Temporal CLI](/cli).
 
 Choose your operating system to install Temporal CLI:
 

--- a/docs/develop/php/workflows/schedules.mdx
+++ b/docs/develop/php/workflows/schedules.mdx
@@ -40,7 +40,7 @@ $workflowClient->start($workflow, 'Hello world!');
 
 :::caution Cron support is not recommended
 
-We recommend using [Schedules](https://docs.temporal.io/schedule) instead of Cron Jobs.
+We recommend using [Schedules](/schedule) instead of Cron Jobs.
 Schedules were built to provide a better developer experience, including more configuration options and the ability to update or pause running Schedules.
 
 :::

--- a/docs/develop/python/activities/basics.mdx
+++ b/docs/develop/python/activities/basics.mdx
@@ -110,7 +110,7 @@ All data returned from an Activity must be serializable.
 
 Activity return values are subject to payload size limits in Temporal. The default payload size limit is 2MB, and there
 is a hard limit of 4MB for any gRPC message size in the Event History transaction
-([see Cloud limits here](https://docs.temporal.io/cloud/limits#per-message-grpc-limit)). Keep in mind that all return
+([see Cloud limits here](/cloud/limits#per-message-grpc-limit)). Keep in mind that all return
 values are recorded in a [Workflow Execution Event History](/workflow-execution/event#event-history).
 
 An Activity Execution can return inputs and other Activity values.

--- a/docs/develop/python/client/temporal-client.mdx
+++ b/docs/develop/python/client/temporal-client.mdx
@@ -55,7 +55,7 @@ options directly in code, load them from **environment variables**, or a **TOML 
 configuration file for secure, repeatable configuration.
 
 When you’re running a Temporal Service locally (such as with the
-[Temporal CLI dev server](https://docs.temporal.io/cli/command-reference/server#start-dev)), the required options are minimal. If you
+[Temporal CLI dev server](/cli/command-reference/server#start-dev)), the required options are minimal. If you
 don't specify a host/port, most connections default to `127.0.0.1:7233` and the `default` Namespace.
 
 <Tabs groupId="connect-options" defaultValue="config-file" >

--- a/docs/develop/python/integrations/langsmith.mdx
+++ b/docs/develop/python/integrations/langsmith.mdx
@@ -26,7 +26,7 @@ import { ReleaseNoteHeader } from '@site/src/components';
 Temporal's LangSmith integration lets you trace AI agent Workflows in [LangSmith](https://smith.langchain.com/)
 alongside every LLM call, tool execution, and Temporal operation.
 
-Temporal gives your agent code [durable execution](https://docs.temporal.io/temporal#durable-execution). 
+Temporal gives your agent code [durable execution](/temporal#durable-execution). 
 LangSmith adds the observability side, so you can inspect LLM inputs and outputs, follow a
 request from the Client through to the model, and compare runs over time.
 

--- a/docs/develop/python/nexus/feature-guide.mdx
+++ b/docs/develop/python/nexus/feature-guide.mdx
@@ -87,7 +87,7 @@ Defining a clear contract for the Nexus Service is crucial for smooth communicat
 
 In this example, there is a service package that describes the Service and Operation names along with input/output types for caller Workflows to use the Nexus Endpoint.
 
-Each [Temporal SDK includes and uses a default Data Converter](https://docs.temporal.io/dataconversion).
+Each [Temporal SDK includes and uses a default Data Converter](/dataconversion).
 The default data converter encodes payloads in the following order: Null, Byte array, Protobuf JSON, and JSON.
 In a polyglot environment, that is where more than one language and SDK is being used to develop a Temporal solution, Protobuf and JSON are common choices.
 This example uses Python dataclasses serialized into JSON.
@@ -322,7 +322,7 @@ See [hello_nexus/caller/app.py](https://github.com/temporalio/samples-python/blo
 
 ## Exceptions in Nexus operations {/* #exceptions-in-nexus-operations */}
 
-Temporal provides general guidance on [Errors in Nexus operations](https://docs.temporal.io/references/failures#errors-in-nexus-operations).
+Temporal provides general guidance on [Errors in Nexus operations](/references/failures#errors-in-nexus-operations).
 In Python, there are three Nexus-specific exception classes:
 
 - [`nexusrpc.OperationError`](https://nexus-rpc.github.io/sdk-python/nexusrpc.OperationError.html): this is the exception type you should raise in a Nexus operation to indicate that it has failed according to its own application logic and should not be retried.

--- a/docs/develop/python/set-up.mdx
+++ b/docs/develop/python/set-up.mdx
@@ -107,7 +107,7 @@ Next, you'll configure a local Temporal Service for development.
 ## Install Temporal CLI
 
 The fastest way to get a development version of the Temporal Service running on your local machine is to use
-[Temporal CLI](https://docs.temporal.io/cli).
+[Temporal CLI](/cli).
 
 Choose your operating system to install Temporal CLI.
 

--- a/docs/develop/python/workflows/schedules.mdx
+++ b/docs/develop/python/workflows/schedules.mdx
@@ -265,7 +265,7 @@ The following example updates the Schedule to use a new argument.
 
 :::caution Cron support is not recommended
 
-We recommend using [Schedules](https://docs.temporal.io/schedule) instead of Cron Jobs.
+We recommend using [Schedules](/schedule) instead of Cron Jobs.
 Schedules were built to provide a better developer experience, including more configuration options and the ability to update or pause running Schedules.
 
 :::

--- a/docs/develop/ruby/best-practices/error-handling.mdx
+++ b/docs/develop/ruby/best-practices/error-handling.mdx
@@ -95,6 +95,6 @@ class SagaWorkflow < Temporalio::Workflow::Definition
 
 This works differently in a Workflow than raising exceptions from Activities.
 In an Activity, any Ruby exceptions or custom exceptions are converted to a Temporal `ApplicationError`.
-In a Workflow, any exceptions that are raised other than an explicit Temporal `ApplicationError` will only fail that particular [Workflow Task](https://docs.temporal.io/tasks#workflow-task-execution) and be retried.
+In a Workflow, any exceptions that are raised other than an explicit Temporal `ApplicationError` will only fail that particular [Workflow Task](/tasks#workflow-task-execution) and be retried.
 This includes any typical Ruby `RuntimeError`s that are raised automatically.
 These errors are treated as bugs that can be corrected with a fixed deployment, rather than a reason for a Temporal Workflow Execution to return unexpectedly.

--- a/docs/develop/ruby/client/temporal-client.mdx
+++ b/docs/develop/ruby/client/temporal-client.mdx
@@ -41,7 +41,7 @@ these options directly in code, load them from **environment variables**, or a *
 configuration file for secure, repeatable configuration.
 
 When you’re running a Temporal Service locally (such as with the
-[Temporal CLI dev server](https://docs.temporal.io/cli/command-reference/server#start-dev)), the required options are minimal. If you
+[Temporal CLI dev server](/cli/command-reference/server#start-dev)), the required options are minimal. If you
 don't specify a host/port, most connections default to `127.0.0.1:7233` and the `default` Namespace.
 
 <Tabs groupId="connect-options" defaultValue="config-file" >

--- a/docs/develop/ruby/index.mdx
+++ b/docs/develop/ruby/index.mdx
@@ -86,7 +86,7 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 
 ## Temporal Ruby Technical Resources
 
-- [Ruby SDK Quickstart - Setup Guide](https://docs.temporal.io/develop/ruby/set-up-local-ruby)
+- [Ruby SDK Quickstart - Setup Guide](/develop/ruby/set-up-local-ruby)
 - [Ruby SDK Code Samples](https://github.com/temporalio/samples-ruby)
 - [Ruby API Documentation](https://ruby.temporal.io/)
 - [Ruby SDK GitHub](https://github.com/temporalio/sdk-ruby)

--- a/docs/develop/ruby/set-up.mdx
+++ b/docs/develop/ruby/set-up.mdx
@@ -123,7 +123,7 @@ Follow the steps to create a directory, initialize the project with a `Gemfile`,
 ## Install Temporal CLI
 
 The fastest way to get a development version of the Temporal Service running on your local machine is to use
-[Temporal CLI](https://docs.temporal.io/cli).
+[Temporal CLI](/cli).
 
 Choose your operating system to install Temporal CLI.
 

--- a/docs/develop/ruby/workflows/basics.mdx
+++ b/docs/develop/ruby/workflows/basics.mdx
@@ -85,7 +85,7 @@ end
 
 ## Workflow logic requirements {/* #workflow-logic-requirements */}
 
-Temporal Workflows [must be deterministic](https://docs.temporal.io/workflows#deterministic-constraints), which includes
+Temporal Workflows [must be deterministic](/workflow-definition#deterministic-constraints), which includes
 Ruby Workflows. This means there are several things Workflows cannot do such as:
 
 - Perform IO (network, disk, stdio, etc)

--- a/docs/develop/rust/quickstart.mdx
+++ b/docs/develop/rust/quickstart.mdx
@@ -135,7 +135,7 @@ sudo mv temporal /usr/local/bin
 ## Install Temporal CLI and start the development server
 
 The fastest way to get a development version of the Temporal Service running on your local machine is to use
-[Temporal CLI](https://docs.temporal.io/cli).
+[Temporal CLI](/cli).
 
 Choose your operating system to install Temporal CLI:
 

--- a/docs/develop/typescript/activities/basics.mdx
+++ b/docs/develop/typescript/activities/basics.mdx
@@ -75,7 +75,7 @@ All data returned from an Activity must be serializable.
 
 Activity return values are subject to payload size limits in Temporal. The default payload size limit is 2MB, and there
 is a hard limit of 4MB for any gRPC message size in the Event History transaction
-([see Cloud limits here](https://docs.temporal.io/cloud/limits#per-message-grpc-limit)). Keep in mind that all return
+([see Cloud limits here](/cloud/limits#per-message-grpc-limit)). Keep in mind that all return
 values are recorded in a [Workflow Execution Event History](/workflow-execution/event#event-history).
 
 In TypeScript, the return value is always a Promise.

--- a/docs/develop/typescript/client/namespaces.mdx
+++ b/docs/develop/typescript/client/namespaces.mdx
@@ -21,7 +21,7 @@ Use Namespaces to isolate your Workflow Executions according to your needs.
 For example, you can use Namespaces to match the development lifecycle by having separate `dev` and `prod` Namespaces.
 You could also use them to ensure Workflow Executions between different teams never communicate - such as ensuring that the `teamA` Namespace never impacts the `teamB` Namespace.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) to create and manage a Namespace from the UI, or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to manage Namespaces from the command-line interface.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) to create and manage a Namespace from the UI, or [tcld commands](/cloud/tcld/namespace/) to manage Namespaces from the command-line interface.
 
 On self-hosted Temporal Service, you can register and manage your Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.
@@ -34,7 +34,7 @@ You must register a Namespace with the Temporal Service before setting it in the
 
 Registering a Namespace creates a Namespace on the Temporal Service or Temporal Cloud.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to create Namespaces.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](/cloud/tcld/namespace/) to create Namespaces.
 
 On self-hosted Temporal Service, you can register your Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.
@@ -45,7 +45,7 @@ Use a custom [Authorizer](/self-hosted-guide/security#authorizer-plugin) on your
 
 You can get details for your Namespaces, update Namespace configuration, and deprecate or delete your Namespaces.
 
-On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](https://docs.temporal.io/cloud/tcld/namespace/) to manage Namespaces.
+On Temporal Cloud, use the [Temporal Cloud UI](/cloud/namespaces#create-a-namespace) or [tcld commands](/cloud/tcld/namespace/) to manage Namespaces.
 
 On self-hosted Temporal Service, you can manage your registered Namespaces using the Temporal CLI (recommended) or programmatically using APIs.
 Note that these APIs and Temporal CLI commands will not work with Temporal Cloud.

--- a/docs/develop/typescript/integrations/openai-agents.mdx
+++ b/docs/develop/typescript/integrations/openai-agents.mdx
@@ -238,7 +238,7 @@ const agent = new Agent({
 
 ### Nexus operation tools
 
-Use `nexusOperationAsTool` to expose a [Nexus](https://docs.temporal.io/nexus) Operation as an agent tool. The Workflow
+Use `nexusOperationAsTool` to expose a [Nexus](/nexus) Operation as an agent tool. The Workflow
 starts the Operation through a Nexus client and feeds the stringified result back to the agent.
 
 ```typescript

--- a/docs/develop/typescript/nexus/feature-guide.mdx
+++ b/docs/develop/typescript/nexus/feature-guide.mdx
@@ -90,7 +90,7 @@ Defining a clear contract for the Nexus Service is crucial for smooth communicat
 
 In this example, there is a service package that describes the Service and Operation names along with input/output types for caller Workflows to use the Nexus Endpoint.
 
-Each [Temporal SDK includes and uses a default Data Converter](https://docs.temporal.io/dataconversion).
+Each [Temporal SDK includes and uses a default Data Converter](/dataconversion).
 The default data converter encodes payloads in the following order: Null, Byte array, and JSON.
 In a polyglot environment, that is where more than one language and SDK is being used to develop a Temporal solution, JSON is a common choice.
 This example uses plain TypeScript objects, serialized into JSON.
@@ -336,7 +336,7 @@ Refer to the [complete TypeScript sample](https://github.com/temporalio/samples-
 
 ## Exceptions in Nexus operations {/* #exceptions-in-nexus-operations */}
 
-Temporal provides general guidance on [Errors in Nexus operations](https://docs.temporal.io/references/failures#errors-in-nexus-operations).
+Temporal provides general guidance on [Errors in Nexus operations](/references/failures#errors-in-nexus-operations).
 In TypeScript, there are three Nexus-specific exception classes:
 
 - `nexus-rpc`'s [`OperationError`](https://nexus-rpc.github.io/sdk-typescript/classes/OperationError.html): this is the exception type you should throw in a Nexus operation to indicate that it has failed according to its own application logic and should not be retried.

--- a/docs/develop/typescript/set-up.mdx
+++ b/docs/develop/typescript/set-up.mdx
@@ -93,7 +93,7 @@ Next, you'll configure a local Temporal Service for development.
 ## Install Temporal CLI
 
 The fastest way to get a development version of the Temporal Service running on your local machine is to use
-[Temporal CLI](https://docs.temporal.io/cli).
+[Temporal CLI](/cli).
 
 Choose your operating system to install Temporal CLI.
 

--- a/docs/develop/typescript/workflows/schedules.mdx
+++ b/docs/develop/typescript/workflows/schedules.mdx
@@ -268,7 +268,7 @@ async function run() {
 
 :::caution Cron support is not recommended
 
-We recommend using [Schedules](https://docs.temporal.io/schedule) instead of Cron Jobs.
+We recommend using [Schedules](/schedule) instead of Cron Jobs.
 Schedules were built to provide a better developer experience, including more configuration options and the ability to update or pause running Schedules.
 
 :::

--- a/docs/develop/typescript/workflows/timeouts.mdx
+++ b/docs/develop/typescript/workflows/timeouts.mdx
@@ -99,7 +99,7 @@ try {
 
 This works differently in a Workflow than raising exceptions from Activities.
 In an Activity, any Typescript exceptions or custom exceptions are converted to a Temporal `ApplicationFailure`.
-In a Workflow, any exceptions that are raised other than an explicit Temporal `ApplicationFailure` will only fail that particular [Workflow Task](https://docs.temporal.io/tasks#workflow-task-execution) and be retried.
+In a Workflow, any exceptions that are raised other than an explicit Temporal `ApplicationFailure` will only fail that particular [Workflow Task](/tasks#workflow-task-execution) and be retried.
 This includes any typical Typescript runtime errors like an `undefined` error that are raised automatically.
 These errors are treated as bugs that can be corrected with a fixed deployment, rather than a reason for a Temporal Workflow Execution to return unexpectedly.
 

--- a/docs/develop/worker-performance.mdx
+++ b/docs/develop/worker-performance.mdx
@@ -756,8 +756,8 @@ While individual `add` and `dispatch` rates may be inaccurate due to Eager and S
 
 ## Evaluate Task Queue performance {/* #evaluate-worker-loads */}
 
-A [Task Queue](https://docs.temporal.io/task-queue) is a lightweight, dynamically allocated queue.
-[Worker Entities](/workers#worker-entity) poll the queue for [Tasks](https://docs.temporal.io/tasks#task) and retrieve Tasks to work on.
+A [Task Queue](/task-queue) is a lightweight, dynamically allocated queue.
+[Worker Entities](/workers#worker-entity) poll the queue for [Tasks](/tasks#task) and retrieve Tasks to work on.
 Tasks are contexts that a Worker progresses using a specific Workflow Execution, Activity Execution, or a Nexus Task Execution.
 Each Task Queue type offers its Tasks to compatible Workers for Task completion.
 The Temporal Service dynamically creates different [Task Queue types](/task-queue) including Activity Task Queues, Workflow Task Queues, and Nexus Task Queues.
@@ -819,7 +819,7 @@ for _, taskQueueName := range taskQueueNames {
 
 ### Evaluate Worker availability and capacity issues {/* #worker-capacity-issues */}
 
-Each Temporal [Server](https://docs.temporal.io/temporal-service/temporal-server) records the last time of each poll request.
+Each Temporal [Server](/temporal-service/temporal-server) records the last time of each poll request.
 This time is displayed in the `temporal task-queue describe` output.
 
 - A `LastAccessTime` value exceeding one minute may indicate that the Worker fleet is at capacity or that Workers have shut down or been removed.

--- a/docs/encyclopedia/event-history/dotnet.mdx
+++ b/docs/encyclopedia/event-history/dotnet.mdx
@@ -253,7 +253,7 @@ the Workflow Execution, ultimately resulting in a completed execution that's ide
 ## Example of a Non-Deterministic Workflow {/* #Example-of-Non-Deterministic-Workflow */}
 
 Now that Replay has been covered, this section will explain why Workflows need to be
-[deterministic](https://docs.temporal.io/workflow-definition#deterministic-constraints) in order for Replay to work.
+[deterministic](/workflow-definition#deterministic-constraints) in order for Replay to work.
 
 A Workflow is deterministic if every execution of its Workflow Definition produces the same Commands in the same
 sequence given the same input.
@@ -301,11 +301,11 @@ number generator.
 />
 
 Note that non-deterministic failures do not fail the Workflow Execution by default. A non-deterministic failure is
-considered a [Workflow Task Failure](https://docs.temporal.io/references/failures#workflow-task-failures) which is
+considered a [Workflow Task Failure](/references/failures#workflow-task-failures) which is
 considered a transient failure, meaning it retries over and over. Users can also fix the source of non-determinism,
 perhaps by removing the Activity, and then restart the Workers. This means that this type of failure can recover by
 itself. You can also use a strategy called versioning to address this non-determinism error. See
-[versioning](https://docs.temporal.io/develop/dotnet/workflows/versioning) to learn more.
+[versioning](/develop/dotnet/workflows/versioning) to learn more.
 
 For more information on how Temporal handles Durable Execution or to see these slides in a video format with more
 explanation, check out our free, self-paced courses: [Temporal 102](https://learn.temporal.io/courses/temporal_102/) and

--- a/docs/encyclopedia/event-history/event-history.mdx
+++ b/docs/encyclopedia/event-history/event-history.mdx
@@ -28,7 +28,7 @@ keywords:
   - worker process execution
 ---
 
-With Temporal, your Workflows can seamlessly recover from crashes. This is made possible by the [Event History](https://docs.temporal.io/workflow-execution/event), a complete and durable log of everything that has happened in the lifecycle of a Workflow Execution, as well as the ability of the Temporal Service to durably persist the Events during Replay.
+With Temporal, your Workflows can seamlessly recover from crashes. This is made possible by the [Event History](/workflow-execution/event), a complete and durable log of everything that has happened in the lifecycle of a Workflow Execution, as well as the ability of the Temporal Service to durably persist the Events during Replay.
 
 Temporal uses the Event History to record every step taken along the way. Each time your Workflow Definition makes an API call to execute an Activity or start a Timer for instance, it doesn’t perform the action directly. Instead, it sends a Command to the Temporal Service.
 

--- a/docs/encyclopedia/event-history/go.mdx
+++ b/docs/encyclopedia/event-history/go.mdx
@@ -267,7 +267,7 @@ the Workflow Execution, ultimately resulting in a completed execution that's ide
 ## Example of a Non-Deterministic Workflow {/* #Example-of-Non-Deterministic-Workflow */}
 
 Now that Replay has been covered, this section will explain why Workflows need to be
-[deterministic](https://docs.temporal.io/workflow-definition#deterministic-constraints) in order for Replay to work.
+[deterministic](/workflow-definition#deterministic-constraints) in order for Replay to work.
 
 A Workflow is deterministic if every execution of its Workflow Definition produces the same Commands in the same
 sequence given the same input.
@@ -314,7 +314,7 @@ number generator.
 />
 
 Note that non-deterministic failures do not fail the Workflow Execution by default. A non-deterministic failure is
-considered a [Workflow Task Failure](https://docs.temporal.io/references/failures#workflow-task-failures) which is
+considered a [Workflow Task Failure](/references/failures#workflow-task-failures) which is
 considered a transient failure, meaning it retries over and over. Users can also fix the source of non-determinism,
 perhaps by removing the Activity, and then restart the Workers. This means that this type of failure can recover by
 itself. You can also use a strategy called versioning to address this non-determinism error. See

--- a/docs/encyclopedia/event-history/java.mdx
+++ b/docs/encyclopedia/event-history/java.mdx
@@ -257,7 +257,7 @@ the Workflow Execution, ultimately resulting in a completed execution that's ide
 ## Example of a Non-Deterministic Workflow {/* #Example-of-Non-Deterministic-Workflow */}
 
 Now that Replay has been covered, this section will explain why Workflows need to be
-[deterministic](https://docs.temporal.io/workflow-definition#deterministic-constraints) in order for Replay to work.
+[deterministic](/workflow-definition#deterministic-constraints) in order for Replay to work.
 
 A Workflow is deterministic if every execution of its Workflow Definition produces the same Commands in the same
 sequence given the same input.
@@ -306,11 +306,11 @@ number generator.
 />
 
 Note that non-deterministic failures do not fail the Workflow Execution by default. A non-deterministic failure is
-considered a [Workflow Task Failure](https://docs.temporal.io/references/failures#workflow-task-failures) which is
+considered a [Workflow Task Failure](/references/failures#workflow-task-failures) which is
 considered a transient failure, meaning it retries over and over. Users can also fix the source of non-determinism,
 perhaps by removing the Activity, and then restart the Workers. This means that this type of failure can recover by
 itself. You can also use a strategy called versioning to address this non-determinism error. See
-[versioning](https://docs.temporal.io/develop/java/versioning) to learn more.
+[versioning](/develop/java/workflows/versioning) to learn more.
 
 For more information on how Temporal handles Durable Execution or to see these slides in a video format with more
 explanation, check out our free, self-paced courses: [Temporal 102](https://learn.temporal.io/courses/temporal_102/) and

--- a/docs/encyclopedia/event-history/python.mdx
+++ b/docs/encyclopedia/event-history/python.mdx
@@ -259,7 +259,7 @@ the Workflow Execution, ultimately resulting in a completed execution that's ide
 ## Example of a Non-Deterministic Workflow {/* #Example-of-Non-Deterministic-Workflow */}
 
 Now that Replay has been covered, this section will explain why Workflows need to be
-[deterministic](https://docs.temporal.io/workflow-definition#deterministic-constraints) in order for Replay to work.
+[deterministic](/workflow-definition#deterministic-constraints) in order for Replay to work.
 
 A Workflow is deterministic if every execution of its Workflow Definition produces the same Commands in the same
 sequence given the same input.
@@ -308,7 +308,7 @@ number generator.
 />
 
 Note that non-deterministic failures do not fail the Workflow Execution by default. A non-deterministic failure is
-considered a [Workflow Task Failure](https://docs.temporal.io/references/failures#workflow-task-failures) which is
+considered a [Workflow Task Failure](/references/failures#workflow-task-failures) which is
 considered a transient failure, meaning it retries over and over. Users can also fix the source of non-determinism,
 perhaps by removing the Activity, and then restart the Workers. This means that this type of failure can recover by
 itself. You can also use a strategy called versioning to address this non-determinism error. See

--- a/docs/encyclopedia/event-history/typescript.mdx
+++ b/docs/encyclopedia/event-history/typescript.mdx
@@ -261,7 +261,7 @@ the Workflow Execution, ultimately resulting in a completed execution that's ide
 ## Example of a Non-Deterministic Workflow {/* #Example-of-Non-Deterministic-Workflow */}
 
 Now that Replay has been covered, this section will explain why Workflows need to be
-[deterministic](https://docs.temporal.io/workflow-definition#deterministic-constraints) in order for Replay to work.
+[deterministic](/workflow-definition#deterministic-constraints) in order for Replay to work.
 
 A Workflow is deterministic if every execution of its Workflow Definition produces the same Commands in the same
 sequence given the same input.
@@ -310,11 +310,11 @@ number generator.
 />
 
 Note that non-deterministic failures do not fail the Workflow Execution by default. A non-deterministic failure is
-considered a [Workflow Task Failure](https://docs.temporal.io/references/failures#workflow-task-failures) which is
+considered a [Workflow Task Failure](/references/failures#workflow-task-failures) which is
 considered a transient failure, meaning it retries over and over. Users can also fix the source of non-determinism,
 perhaps by removing the Activity, and then restart the Workers. This means that this type of failure can recover by
 itself. You can also use a strategy called versioning to address this non-determinism error. See
-[versioning](https://docs.temporal.io/develop/typescript/workflows/versioning) to learn more.
+[versioning](/develop/typescript/workflows/versioning) to learn more.
 
 For more information on how Temporal handles Durable Execution or to see these slides in a video format with more
 explanation, check out our free, self-paced courses: [Temporal 102](https://learn.temporal.io/courses/temporal_102/) and

--- a/docs/encyclopedia/nexus/nexus-operations.mdx
+++ b/docs/encyclopedia/nexus/nexus-operations.mdx
@@ -188,9 +188,9 @@ The Schedule-to-Close timeout limits the total duration from when the Operation 
 This is the overall timeout for the entire Operation.
 The Nexus Machinery [automatically retries](#automatic-retries) failed requests internally until this timeout is exceeded, at which point the Operation fails with a [NexusOperationTimedOut](/references/events#nexusoperationtimedout) event.
 
-This timeout covers the full [Nexus Operation lifecycle](https://docs.temporal.io/nexus/operations#operation-lifecycle). Asynchronous Operations are scheduled, started, and completed. Synchronous Operations don't have an intermediate started state because they complete as part of the start request.
+This timeout covers the full [Nexus Operation lifecycle](/nexus/operations#operation-lifecycle). Asynchronous Operations are scheduled, started, and completed. Synchronous Operations don't have an intermediate started state because they complete as part of the start request.
 
-In Temporal Cloud, the [maximum Schedule-to-Close timeout is 60 days](https://docs.temporal.io/cloud/limits#nexus-operation-duration-limits).
+In Temporal Cloud, the [maximum Schedule-to-Close timeout is 60 days](/cloud/limits#nexus-operation-duration-limits).
 
 ### Schedule-to-Start timeout {/* #schedule-to-start-timeout */}
 

--- a/docs/encyclopedia/temporal-sdks.mdx
+++ b/docs/encyclopedia/temporal-sdks.mdx
@@ -271,7 +271,7 @@ A Workflow executes Activities (other functions that interact with external syst
 
 This Workflow code, while executing, can be paused, resumed, and migrated across physical machines without losing state.
 
-When a Workflow calls the API to execute an Activity, the Worker sends a [Command](https://docs.temporal.io/references/commands) back to the Temporal Service. The Temporal Service creates Activity Tasks in response which the same or a different Worker can then pick up and begin executing. In this way, the Worker and Temporal Service work together to incrementally execute Workflow code in a reliable way.
+When a Workflow calls the API to execute an Activity, the Worker sends a [Command](/references/commands) back to the Temporal Service. The Temporal Service creates Activity Tasks in response which the same or a different Worker can then pick up and begin executing. In this way, the Worker and Temporal Service work together to incrementally execute Workflow code in a reliable way.
 We discuss this more in detail in [The SDK and Temporal Service relationship](/encyclopedia/temporal-sdks#sdk-and-cluster-relationship) section.
 
 The SDK APIs also enable developers to write code that more genuinely maps to their process. This is because without a specialized SDK, developers might have to write a lot of boilerplate code. This can lead to code that's hard to maintain, difficult to understand, or that doesn't directly correspond to the underlying business process.

--- a/docs/encyclopedia/temporal-service/multi-cluster-replication.mdx
+++ b/docs/encyclopedia/temporal-service/multi-cluster-replication.mdx
@@ -39,7 +39,7 @@ This feature must be enabled through a Dynamic Config flag per [Global Namespace
 When the feature is enabled, Tasks are sent to the Parent Task Queue partition that matches that Namespace, if it exists.
 
 All Visibility APIs can be used against active and standby Clusters.
-This enables [Temporal UI](https://docs.temporal.io/web-ui) to work seamlessly for Global Namespaces.
+This enables [Temporal UI](/web-ui) to work seamlessly for Global Namespaces.
 Applications making API calls directly to the Temporal Visibility API continue to work even if a Global Namespace is in standby mode.
 However, they might see a lag due to replication delay when querying the Workflow Execution state from a standby Cluster.
 

--- a/docs/encyclopedia/workers/worker-versioning.mdx
+++ b/docs/encyclopedia/workers/worker-versioning.mdx
@@ -85,7 +85,7 @@ A Worker Deployment Version moves through the following states:
 1. **Inactive**: The version exists because a Worker with that version has polled the server. If this version never becomes Active, it will never be Draining or Drained.
 2. **Active**: The version is either Current or Ramping, so it is accepting new Workflows and existing auto-upgrade Workflows.
 3. **Draining**: The version has open pinned Workflows running on it, but stopped being Current or Ramping, usually because a newer version has been deployed. It is possible to be Draining and have no open pinned Workflows for a short time, since the drainage status is updated only periodically.
-4. **Drained**: The version was draining and now all the pinned Workflows that were running on it are closed. Closed Workflows may still re-run some code paths if they are [Queried](https://docs.temporal.io/sending-messages#sending-queries) within their [Retention Period](https://docs.temporal.io/temporal-service/temporal-server#retention-period) and Workers with that version are still polling.
+4. **Drained**: The version was draining and now all the pinned Workflows that were running on it are closed. Closed Workflows may still re-run some code paths if they are [Queried](/sending-messages#sending-queries) within their [Retention Period](/temporal-service/temporal-server#retention-period) and Workers with that version are still polling.
 
 ## Continue-as-new, Child Workflow, and Retry Semantics {/* #inheritance-semantics */}
 
@@ -95,10 +95,10 @@ When Workflows start new runs (e.g. by continuing-as-new or retrying) the new ru
 
 A Workflow can start a new run through:
 
-- Starting a [Child Workflow](https://docs.temporal.io/child-workflows)
-- Invoking [Continue-As-New](https://docs.temporal.io/workflow-execution/continue-as-new)
-- Retrying per its [Retry Policy](https://docs.temporal.io/encyclopedia/retry-policies)
-- Starting another iteration of a [Cron Job](https://docs.temporal.io/cron-job) (superseded by [Schedules](https://docs.temporal.io/schedule))
+- Starting a [Child Workflow](/child-workflows)
+- Invoking [Continue-As-New](/workflow-execution/continue-as-new)
+- Retrying per its [Retry Policy](/encyclopedia/retry-policies)
+- Starting another iteration of a [Cron Job](/cron-job) (superseded by [Schedules](/schedule))
 
 ### Inheritance Rules Overview
 

--- a/docs/encyclopedia/workflow-message-passing/handling-messages.mdx
+++ b/docs/encyclopedia/workflow-message-passing/handling-messages.mdx
@@ -177,16 +177,16 @@ The following content applies in every SDK except the Go SDK. See below.
 #### Exceptions in Signals
 
 In Signal handlers, throw [Application Failures](/references/failures#application-failure) only for unrecoverable errors, because the entire Workflow will fail.
-Similarly, allowing a failing Activity or Child Workflow to exhaust its retries, so that it throws an [Activity Failure](https://docs.temporal.io/references/failures#activity-failure) or [Child Workflow Failure](https://docs.temporal.io/references/failures#child-workflow-failure) will cause the entire Workflow to fail.
-Note that for Activities, this will only happen if you change the default Activity [Retry Policy](https://docs.temporal.io/encyclopedia/retry-policies), since by default they retry forever.
+Similarly, allowing a failing Activity or Child Workflow to exhaust its retries, so that it throws an [Activity Failure](/references/failures#activity-failure) or [Child Workflow Failure](/references/failures#child-workflow-failure) will cause the entire Workflow to fail.
+Note that for Activities, this will only happen if you change the default Activity [Retry Policy](/encyclopedia/retry-policies), since by default they retry forever.
 If you throw any other exception, by default, it will cause a [Workflow Task Failure](/references/failures#workflow-task-failures). This means the Workflow will get stuck and will retry the handler periodically until the exception is fixed, for example by a code change.
 
 #### Exceptions in Updates
 
 Doing any of the following will fail the Update and cause the client to receive the error:
 
-- Reject the Update by throwing any exception from your [Validator](https://docs.temporal.io/handling-messages#update-validators).
-- Allow a failing Activity or Child Workflow to exhaust its retries, so that it throws an [Activity Failure](https://docs.temporal.io/references/failures#activity-failure) or [Child Workflow Failure](https://docs.temporal.io/references/failures#child-workflow-failure). Note that for Activities, this will only happen if you change the default Activity [Retry Policy](https://docs.temporal.io/encyclopedia/retry-policies), since by default they retry forever.
+- Reject the Update by throwing any exception from your [Validator](/handling-messages#update-validators).
+- Allow a failing Activity or Child Workflow to exhaust its retries, so that it throws an [Activity Failure](/references/failures#activity-failure) or [Child Workflow Failure](/references/failures#child-workflow-failure). Note that for Activities, this will only happen if you change the default Activity [Retry Policy](/encyclopedia/retry-policies), since by default they retry forever.
 - Throw an [Application Failure](/references/failures#application-failure) from your Update handler.
 
 Unlike with Signals, the Workflow will keep going in these cases.

--- a/docs/encyclopedia/workflow-message-passing/sending-messages.mdx
+++ b/docs/encyclopedia/workflow-message-passing/sending-messages.mdx
@@ -139,12 +139,12 @@ For open source server users, Temporal Server version [Temporal Server version 1
 :::
 
 Update-with-Start sends an Update request, starting a Workflow if necessary.
-A [`WorkflowIDConflictPolicy`](https://docs.temporal.io/workflow-execution/workflowid-runid#workflow-id-conflict-policy) must be specified.
+A [`WorkflowIDConflictPolicy`](/workflow-execution/workflowid-runid#workflow-id-conflict-policy) must be specified.
 Workflow ID and Update ID can be used as idempotency keys as follows:
 
 - If the Workflow exists and you provided an Update ID, and the Update exists in the latest Workflow Run, then Update-With-Start attaches to the existing Update (regardless of `WorkflowIDConflictPolicy`)
   - If the Workflow is closed, it attaches only if the Update has completed.
-- Otherwise it uses [`WorkflowIDConflictPolicy`](https://docs.temporal.io/workflow-execution/workflowid-runid#workflow-id-conflict-policy) and [`WorkflowIDReusePolicy`](https://docs.temporal.io/workflow-execution/workflowid-runid#workflow-id-reuse-policy) as usual to determine whether to start a Workflow, and then starts a new Update immediately.
+- Otherwise it uses [`WorkflowIDConflictPolicy`](/workflow-execution/workflowid-runid#workflow-id-conflict-policy) and [`WorkflowIDReusePolicy`](/workflow-execution/workflowid-runid#workflow-id-reuse-policy) as usual to determine whether to start a Workflow, and then starts a new Update immediately.
 
 Update-With-Start is great for latency-sensitive use cases:
 

--- a/docs/encyclopedia/workflow/workflow-execution/event.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/event.mdx
@@ -156,7 +156,7 @@ Possible values are as follows:
 
 Anyone who has permission to read Event history in the Namespace (ReadOnly access and above) can see the Principal (and the metadata such as email address).
 
-To enable Principal Attribution for a Namespace, contact [Temporal Cloud support](https://docs.temporal.io/cloud/support#support-ticket).
+To enable Principal Attribution for a Namespace, contact [Temporal Cloud support](/cloud/support#support-ticket).
 
 ### Self-hosted Temporal
 

--- a/docs/evaluate/development-production-features/cloud-automation.mdx
+++ b/docs/evaluate/development-production-features/cloud-automation.mdx
@@ -29,13 +29,13 @@ Cloud Automation offers secure authentication across all interfaces, reducing er
 
 **Key Features:**
 
-- [Secure API Keys](https://docs.temporal.io/cloud/api-keys): Manage resources securely with Temporal Cloud API Keys.
-- [Temporal Cloud CLI (tcld)](https://docs.temporal.io/cloud/tcld): Automate operations directly from the command line.
-- [Terraform Provider for Cloud](https://docs.temporal.io/cloud/terraform-provider#prerequisites): Scale effortlessly with infrastructure-as-code.
+- [Secure API Keys](/cloud/api-keys): Manage resources securely with Temporal Cloud API Keys.
+- [Temporal Cloud CLI (tcld)](/cloud/tcld): Automate operations directly from the command line.
+- [Terraform Provider for Cloud](/cloud/terraform-provider#prerequisites): Scale effortlessly with infrastructure-as-code.
 
 <RelatedReadContainer>
-  <RelatedReadItem path="https://docs.temporal.io/cloud/api-keys" text="API Keys documentation" archetype="cloud-guide" />
-  <RelatedReadItem path="https://docs.temporal.io/ops?_gl=1*1yf937l*_gcl_au*MTg1MTAxMTEwNC4xNzEzOTcxMjYw*_ga*MTgwODU1MzQyNi4xNzA3NzA4ODIz*_ga_R90Q9SJD3D*MTcyMTI0MTAyNy41MjIuMS4xNzIxMjQ5NTYxLjAuMC4w" text="Cloud Ops API documentation" archetype="cloud-guide" />
+  <RelatedReadItem path="/cloud/api-keys" text="API Keys documentation" archetype="cloud-guide" />
+  <RelatedReadItem path="/ops" text="Cloud Ops API documentation" archetype="cloud-guide" />
   <RelatedReadItem path="/cloud/tcld" text="Temporal Cloud CLI" archetype="cloud-guide" />
   <RelatedReadItem path="/cloud/terraform-provider" text="Terraform Provider for Cloud" archetype="cloud-guide" />
 </RelatedReadContainer>

--- a/docs/evaluate/development-production-features/low-latency.mdx
+++ b/docs/evaluate/development-production-features/low-latency.mdx
@@ -41,6 +41,6 @@ Temporal Cloud provides lower latency, making it suitable for latency-sensitive,
   <RelatedReadItem path="https://temporal.io/blog/how-to-migrate-your-self-hosted-service-to-temporal-cloud" text="How to Migrate Your Self-Hosted Service to Temporal Cloud" archetype="blog-post" />
   <RelatedReadItem path="https://temporal.io/blog/scaling-temporal-the-basics" text="Scaling your self-hosted instance" archetype="blog-post" />
   <RelatedReadItem path="https://temporal.io/blog/benchmarking-latency-temporal-cloud-vs-self-hosted-temporal" text="Benchmarking Latency: Temporal Cloud vs. Self-Hosted Temporal" archetype="blog-post" />
-  <RelatedReadItem path="https://docs.temporal.io/cloud/service-availability#latency" text="Temporal Cloud’s Latency SLO" archetype="cloud-guide" />
+  <RelatedReadItem path="/cloud/service-availability#latency" text="Temporal Cloud’s Latency SLO" archetype="cloud-guide" />
   <RelatedReadItem path="https://www.youtube.com/watch?v=SQv9ot-jB6o&list=PLl9kRkvFJrlREHL7fiEKBWTp5QuFeYS2r&index=5" text="Replay Conference Talk: Custom Persistence Layer" archetype="replay-talk" />
 </RelatedReadContainer>

--- a/docs/evaluate/temporal-cloud/actions.mdx
+++ b/docs/evaluate/temporal-cloud/actions.mdx
@@ -58,7 +58,7 @@ endpoints can differ based on what is visible to a system. Action Categories and
 billing API.
 
 Usage and Billing data will have the most complete Actions data while Event history and metrics will help with
-detailed _estimates_. For example, [History Event Types](https://docs.temporal.io/workflow-execution/event) are provided
+detailed _estimates_. For example, [History Event Types](/workflow-execution/event) are provided
 for transparency, but do not always have a simple 1:1 relationship with Action Types. The Categories, Action types, and
 available endpoints are listed in the following sections:
 
@@ -142,9 +142,9 @@ available endpoints are listed in the following sections:
 
 ## Signal {/* #signal */}
 
-- **Signal sent**. An Action occurs for every [Signal](https://docs.temporal.io/sending-messages#sending-signals),
+- **Signal sent**. An Action occurs for every [Signal](/sending-messages#sending-signals),
   whether sent from a Client or from a Workflow. Also, one total action occurs for any
-  [Signal-With-Start](https://docs.temporal.io/sending-messages#signal-with-start), regardless of whether the Workflow
+  [Signal-With-Start](/sending-messages#signal-with-start), regardless of whether the Workflow
   starts.
 
 | Usage Name                 | Metric Name                  | History Event Type                                                                                                                                                                                                                                                           |
@@ -156,7 +156,7 @@ available endpoints are listed in the following sections:
 ## Query {/* #query */}
 
 - **Query received by Worker**. An Action occurs for every
-  [Query](https://docs.temporal.io/sending-messages#sending-queries), including viewing the call stack in the Temporal
+  [Query](/sending-messages#sending-queries), including viewing the call stack in the Temporal
   Cloud UI, which results in a Query behind the scenes. `__temporal_workflow_metadata` is a built-in query used to
   retrieve workflow metadata at runtime and is excluded.
 
@@ -167,9 +167,9 @@ available endpoints are listed in the following sections:
 ## Update {/* #update */}
 
 - **Update received by Worker**.
-  - Occurs for every successful [Update](https://docs.temporal.io/sending-messages#sending-updates) and every
-    [rejected](https://docs.temporal.io/handling-messages#update-validators) Update.
-  - This includes [Update-With-Start](https://docs.temporal.io/sending-messages#update-with-start), and is in addition
+  - Occurs for every successful [Update](/sending-messages#sending-updates) and every
+    [rejected](/handling-messages#update-validators) Update.
+  - This includes [Update-With-Start](/sending-messages#update-with-start), and is in addition
     to the start Action in the case when the Workflow starts as well.
   - De-duplicated Updates that share an Update ID do _not_ count as an Action.
 

--- a/docs/evaluate/temporal-cloud/limits.mdx
+++ b/docs/evaluate/temporal-cloud/limits.mdx
@@ -121,7 +121,7 @@ Nexus requests (such as starting a Nexus Operation or sending a Nexus completion
 If too many Nexus requests are sent at once, they may be throttled, along with other requests to the Namespace.
 Throttling limits the rate at which Nexus requests are processed, ensuring the RPS limit isn't exceeded.
 
-You can request this limit be manually raised by [opening a support ticket](https://docs.temporal.io/cloud/support#support-ticket).
+You can request this limit be manually raised by [opening a support ticket](/cloud/support#support-ticket).
 
 :::note
 

--- a/docs/evaluate/temporal-cloud/pricing.mdx
+++ b/docs/evaluate/temporal-cloud/pricing.mdx
@@ -156,8 +156,8 @@ For additional storage within a calendar month, you are billed for Active and Re
 
 :::tip Storage costs are also affected by Temporal System Workflows that back features such as:
 
-- [Schedules](https://docs.temporal.io/schedule): Each Scheduled Workflow contributes to storage usage. Supplied inputs, outputs, and failures all account for the storage usage incurred from Scheduled Workflows.
-- [Batch jobs](https://docs.temporal.io/cli/command-reference/batch): Batch Workflow executions also consume storage.
+- [Schedules](/schedule): Each Scheduled Workflow contributes to storage usage. Supplied inputs, outputs, and failures all account for the storage usage incurred from Scheduled Workflows.
+- [Batch jobs](/cli/command-reference/batch): Batch Workflow executions also consume storage.
 
 These Workflow executions contribute to overall active and retained storage consumption.
 

--- a/docs/evaluate/understanding-temporal.mdx
+++ b/docs/evaluate/understanding-temporal.mdx
@@ -155,7 +155,7 @@ The Temporal CLI provides developers with direct access to a Temporal Service fo
 
 ### Event History
 
-With Temporal, your Workflows can seamlessly recover from crashes. This is made possible by the [Event History](https://docs.temporal.io/workflow-execution/event), a complete and durable log of everything that has happened in the lifecycle of a Workflow Execution, as well as the ability of the Temporal Service to durably persist the Events during [Replay](/workflow-execution#replay).
+With Temporal, your Workflows can seamlessly recover from crashes. This is made possible by the [Event History](/workflow-execution/event), a complete and durable log of everything that has happened in the lifecycle of a Workflow Execution, as well as the ability of the Temporal Service to durably persist the Events during [Replay](/workflow-execution#replay).
 
 Temporal uses the Event History to record every step taken along the way. Each time your Workflow Definition makes an API call to execute an Activity or start a Timer for instance, it doesn’t perform the action directly. Instead, it sends a Command to the Temporal Service.
 

--- a/docs/production-deployment/self-hosted-guide/multi-cluster-replication.mdx
+++ b/docs/production-deployment/self-hosted-guide/multi-cluster-replication.mdx
@@ -26,7 +26,7 @@ This feature must be enabled through a Dynamic Config flag per [Global Namespace
 When the feature is enabled, Tasks are sent to the Parent Task Queue partition that matches that Namespace, if it exists.
 
 All Visibility APIs can be used against active and standby Clusters.
-This enables [Temporal UI](https://docs.temporal.io/web-ui) to work seamlessly for Global Namespaces.
+This enables [Temporal UI](/web-ui) to work seamlessly for Global Namespaces.
 Applications making API calls directly to the Temporal Visibility API continue to work even if a Global Namespace is in standby mode.
 However, they might see a lag due to replication delay when querying the Workflow Execution state from a standby Cluster.
 

--- a/docs/production-deployment/self-hosted-guide/server-frontend-api-reference.mdx
+++ b/docs/production-deployment/self-hosted-guide/server-frontend-api-reference.mdx
@@ -18,7 +18,7 @@ tags:
 import { CaptionedImage } from '@site/src/components';
 
 While it's usually easiest to interact with [Temporal Server](/temporal-service/temporal-server) via a
-[Client SDK](/encyclopedia/temporal-sdks#temporal-client) or the [Temporal CLI](https://docs.temporal.io/cli), you can
+[Client SDK](/encyclopedia/temporal-sdks#temporal-client) or the [Temporal CLI](/cli), you can
 also use its gRPC API.
 
 Our Client and Worker SDKs use the gRPC API. The API reference is located here:

--- a/docs/references/errors.mdx
+++ b/docs/references/errors.mdx
@@ -14,7 +14,7 @@ tags:
 
 This reference lists possible [Workflow Task](/tasks#workflow-task) errors and how to resolve them.
 
-> For other types of errors, see [Temporal Failures](https://docs.temporal.io/kb/failures).
+> For other types of errors, see [Temporal Failures](/references/failures).
 
 Each of the below errors corresponds with a [WorkflowTaskFailedCause](https://api-docs.temporal.io/#temporal.api.enums.v1.WorkflowTaskFailedCause), which appears in [Events](/workflow-execution/event#event) under `workflow_task_failed_event_attributes`.
 

--- a/docs/references/failures.mdx
+++ b/docs/references/failures.mdx
@@ -67,7 +67,7 @@ Workflow Execution Timeout, which is unlimited by default.
 
 An `ApplicationError`, an extension of `FailureError`, can be raised in a Workflow to fail the Workflow Execution.
 Workflow Execution Failures put the Workflow Execution into the "Failed" state and no more attempts will be made in progressing this execution.
-If you are creating custom exceptions you would need to extend the [`ApplicationError`](https://docs.temporal.io/references/failures#application-failure) class—a child class of [`FailureError`](https://docs.temporal.io/references/failures#temporal-failure).
+If you are creating custom exceptions you would need to extend the [`ApplicationError`](/references/failures#application-failure) class—a child class of [`FailureError`](/references/failures#temporal-failure).
 
 ### Errors in Activities
 

--- a/docs/troubleshooting/performance-bottlenecks.mdx
+++ b/docs/troubleshooting/performance-bottlenecks.mdx
@@ -33,8 +33,8 @@ The following sections detail common metrics, their potential causes for high la
 High [`temporal_workflow_task_schedule_to_start_latency`](/references/sdk-metrics#workflow_task_schedule_to_start_latency) (P95 higher than one second) can be caused by several factors.
 This metric represents the time between when a [Workflow Task](/tasks#workflow-task) is scheduled (enqueued) and when it is picked up by a Worker for processing. Here are some potential causes:
 
-- Insufficient Worker capacity: If there aren't enough Workers or if the Workers are overloaded, they may not be able to pick up Tasks quickly enough. This can lead to Tasks waiting longer in the queue ([Detect Task Backlog](https://docs.temporal.io/cloud/worker-health#detect-task-backlog)).
-- Worker configuration issues: Improperly configured Workers, such as having too few pollers or Task slots, can lead to increased latency ([Detect Task Backlog](https://docs.temporal.io/cloud/worker-health#detect-task-backlog)).
+- Insufficient Worker capacity: If there aren't enough Workers or if the Workers are overloaded, they may not be able to pick up Tasks quickly enough. This can lead to Tasks waiting longer in the queue ([Detect Task Backlog](/cloud/worker-health#detect-task-backlog)).
+- Worker configuration issues: Improperly configured Workers, such as having too few pollers or Task slots, can lead to increased latency ([Detect Task Backlog](/cloud/worker-health#detect-task-backlog)).
 - High Workflow lock latency: If many updates are made to a single execution, this can cause Workflow lock latency, which in turn affects the Schedule-to-start latency. Reduce the rate of Signals.
 - Network latency: Workers in a different region from the Temporal cluster, or large payload size, can introduce additional latency.
 
@@ -51,8 +51,8 @@ High [`temporal_activity_schedule_to_start_latency`](/references/sdk-metrics#act
 This metric represents the time between when an [Activity Task](/tasks#activity-task) is scheduled (enqueued) and when it is picked up by a Worker for processing.
 Here are some potential causes:
 
-- Insufficient Worker capacity: If there aren't enough Workers or if the Workers are overloaded, they may not be able to pick up Tasks quickly enough. This can lead to Tasks waiting longer in the queue ([Detect Task Backlog](https://docs.temporal.io/cloud/worker-health#detect-task-backlog)).
-- Worker configuration issues: Improperly configured Workers, such as having too few pollers or Task slots, can lead to increased latency ([Detect Task Backlog](https://docs.temporal.io/cloud/worker-health#detect-task-backlog)).
+- Insufficient Worker capacity: If there aren't enough Workers or if the Workers are overloaded, they may not be able to pick up Tasks quickly enough. This can lead to Tasks waiting longer in the queue ([Detect Task Backlog](/cloud/worker-health#detect-task-backlog)).
+- Worker configuration issues: Improperly configured Workers, such as having too few pollers or Task slots, can lead to increased latency ([Detect Task Backlog](/cloud/worker-health#detect-task-backlog)).
 - Task Queue configuration: Setting `TaskQueueActivitiesPerSecond` too low can limit the rate at which Activities are started, leading to increased Schedule-to-start latency.
 - Network latency: Workers in a different region from the Temporal cluster, or large payload size can introduce additional latency.
 
@@ -70,7 +70,7 @@ Normal ranges for this metric depend on the use case, but here are some potentia
 
 - Complex Workflows: If the Workflows have many Activities or if the Activities take a long time to execute.
 - Workflow and Activity retries: If Workflows or Activities are configured to retry upon failure and they fail often, this can increase the end-to-end latency as the system will wait for the retry delay before reattempting the failed operation.
-- Worker capacity and configuration: If there aren't enough Workers or if the Workers are overloaded, they may not be able to pick up and process Tasks quickly enough. This can lead to Tasks waiting longer in the queue, thereby increasing the end-to-end latency ([Detect Task Backlog](https://docs.temporal.io/cloud/worker-health#detect-task-backlog)).
+- Worker capacity and configuration: If there aren't enough Workers or if the Workers are overloaded, they may not be able to pick up and process Tasks quickly enough. This can lead to Tasks waiting longer in the queue, thereby increasing the end-to-end latency ([Detect Task Backlog](/cloud/worker-health#detect-task-backlog)).
 - External dependencies: If your Workflows or Activities depend on external systems or services (such as databases or APIs) and these systems are slow or unreliable, they can increase the end-to-end latency.
 - Network latency: Workers in a different region from the Temporal cluster can introduce additional latency.
 
@@ -228,7 +228,7 @@ To diagnose and address high `temporal_request_latency`:
 2. Check the network connection between the Temporal Client and the Temporal Server.
 3. Monitor the resource usage on both the Temporal Client and the Temporal Server.
 4. Review your Temporal Client configuration to ensure it is optimized for your workload.
-5. If you're using Temporal Cloud, check if the Cloud’s [service-latency](https://docs.temporal.io/cloud/metrics/reference#service-latency) metric spikes up and reach out to Temporal Support for help.
+5. If you're using Temporal Cloud, check if the Cloud’s [service-latency](/cloud/metrics/reference#service-latency) metric spikes up and reach out to Temporal Support for help.
 
 ### `rate(temporal_long_request_total{operation="PollActivityTaskQueue"})`
 
@@ -279,8 +279,8 @@ Conversely, if you have available memory and want to improve performance, you mi
 
 ### `temporal_sticky_cache_hit_total` and `temporal_sticky_cache_miss_total`
 
-The [`temporal_sticky_cache_hit_total`](https://docs.temporal.io/references/sdk-metrics#sticky_cache_hit) metric is a counter that measures the total number of times a Workflow Task found a cached Workflow Execution to run against, and
-the opposite is [`temporal_sticky_cache_miss_total`](https://docs.temporal.io/references/sdk-metrics#sticky_cache_miss), which is a counter that measures the total number of times a Workflow Task did not find a cached Workflow Execution to run against.
+The [`temporal_sticky_cache_hit_total`](/references/sdk-metrics#sticky_cache_hit) metric is a counter that measures the total number of times a Workflow Task found a cached Workflow Execution to run against, and
+the opposite is [`temporal_sticky_cache_miss_total`](/references/sdk-metrics#sticky_cache_miss), which is a counter that measures the total number of times a Workflow Task did not find a cached Workflow Execution to run against.
 
 Sticky Execution is a feature where a Worker caches a Workflow Execution and creates a dedicated Task Queue to listen on.
 This improves performance because the Temporal Service only sends new events to the Worker instead of entire Event Histories, and the Workflow doesn't have to Replay.
@@ -293,7 +293,7 @@ A high rate of cache hits with a low rate of cache misses indicates that your Wo
 
 ### `temporal_sticky_cache_total_forced_eviction_total`
 
-The [`temporal_sticky_cache_total_forced_eviction_total`](https://docs.temporal.io/references/sdk-metrics#sticky_cache_hit) metric is a counter that measures the total number of Workflow Executions that have been forcibly evicted from the sticky cache.
+The [`temporal_sticky_cache_total_forced_eviction_total`](/references/sdk-metrics#sticky_cache_hit) metric is a counter that measures the total number of Workflow Executions that have been forcibly evicted from the sticky cache.
 
 Sticky Execution is a feature where a Worker caches a Workflow Execution and creates a dedicated Task Queue to listen on.
 This improves performance because the Temporal Service only sends new events to the Worker instead of entire Event Histories, and the Workflow doesn't have to Replay.

--- a/vale/styles/Temporal/RelativeLinks.yml
+++ b/vale/styles/Temporal/RelativeLinks.yml
@@ -1,0 +1,13 @@
+# scope: raw is required to see link destinations at all (the default text
+# scope strips markdown link URLs entirely), but as a side effect it also
+# sees inside fenced code blocks/inline code, which the default scope would
+# normally skip. That's an accepted tradeoff: a handful of legitimate
+# absolute URLs shown in code samples (e.g. curl/CLI output) may get flagged
+# too, alongside the real links this rule targets.
+extends: existence
+message: "Use a relative path instead of the absolute docs.temporal.io URL '%s'."
+level: warning
+scope: raw
+ignorecase: true
+tokens:
+  - 'https?://docs\.temporal\.io[^\s()"''<>`\[\]]*'

--- a/vale/styles/Temporal/RelativeLinks.yml
+++ b/vale/styles/Temporal/RelativeLinks.yml
@@ -4,10 +4,19 @@
 # normally skip. That's an accepted tradeoff: a handful of legitimate
 # absolute URLs shown in code samples (e.g. curl/CLI output) may get flagged
 # too, alongside the real links this rule targets.
+#
+# Only match a docs.temporal.io URL when it's the destination of an actual
+# link — i.e. immediately preceded by `](` (Markdown link syntax) or by a
+# quote after `=` (an href/path/src/to prop on a JSX component). Bare URLs
+# (plain text with no link syntax, e.g. generated CLI reference docs) rely on
+# Docusaurus/remark autolinking, which only works for absolute URLs — a bare
+# relative path just renders as unlinked text, so those must stay absolute
+# and should NOT be flagged here.
 extends: existence
 message: "Use a relative path instead of the absolute docs.temporal.io URL '%s'."
 level: warning
 scope: raw
 ignorecase: true
 tokens:
-  - 'https?://docs\.temporal\.io[^\s()"''<>`\[\]]*'
+  - '(?<=\]\()https?://docs\.temporal\.io[^\s()"''<>`\[\]]*(?=\))'
+  - '(?<==["''])https?://docs\.temporal\.io[^\s()"''<>`]*(?=["''])'

--- a/vale/test/relative-links-bad.md
+++ b/vale/test/relative-links-bad.md
@@ -1,0 +1,7 @@
+## Absolute links
+
+See the [Task Queue](https://docs.temporal.io/task-queue) documentation for more information.
+
+Visit https://docs.temporal.io/visibility to read more about Search Attributes.
+
+<RelatedReadItem path="https://docs.temporal.io/cloud/api-keys" text="API Keys documentation" />

--- a/vale/test/relative-links-bad.md
+++ b/vale/test/relative-links-bad.md
@@ -2,6 +2,4 @@
 
 See the [Task Queue](https://docs.temporal.io/task-queue) documentation for more information.
 
-Visit https://docs.temporal.io/visibility to read more about Search Attributes.
-
 <RelatedReadItem path="https://docs.temporal.io/cloud/api-keys" text="API Keys documentation" />

--- a/vale/test/relative-links-good.md
+++ b/vale/test/relative-links-good.md
@@ -5,3 +5,5 @@ See the [Task Queue](/task-queue) documentation for more information.
 Read about [Workflow Executions](/workflow-execution) and [Signals](/encyclopedia/workflow-message-passing#signals).
 
 External sites keep their full URL, for example [the Go SDK on GitHub](https://github.com/temporalio/sdk-go) or the [API reference](https://api-docs.temporal.io/).
+
+Bare URLs (no link syntax) must stay absolute, since Docusaurus only autolinks absolute URLs: Visit https://docs.temporal.io/visibility to read more about Search Attributes.

--- a/vale/test/relative-links-good.md
+++ b/vale/test/relative-links-good.md
@@ -1,0 +1,7 @@
+## Relative links
+
+See the [Task Queue](/task-queue) documentation for more information.
+
+Read about [Workflow Executions](/workflow-execution) and [Signals](/encyclopedia/workflow-message-passing#signals).
+
+External sites keep their full URL, for example [the Go SDK on GitHub](https://github.com/temporalio/sdk-go) or the [API reference](https://api-docs.temporal.io/).


### PR DESCRIPTION
So I added a new rule, to flag use of docs.temporal.io in URLs instead of relative links, then I fixed the 182 instances of that... which led to the build flagging a ton of them as broken links, because we moved things around. Fixed all those up, then saw how many false positives came from the Headings rule, so added some exclusions of pages that are using code/enum/cli commands as headings

## Vale changes

- **Added `Temporal.RelativeLinks`** ([[vale/styles/Temporal/RelativeLinks.yml](https://claude.ai/epitaxy/vale/styles/Temporal/RelativeLinks.yml)](vale/styles/Temporal/RelativeLinks.yml)): new CI-enforced rule flagging absolute `https://docs.temporal.io/...` links in prose/JSX — internal doc links should be relative (e.g. `/foo`, not `https://docs.temporal.io/foo`). Added corresponding test fixtures (`vale/test/relative-links-good.md` / `-bad.md`).
- **Excluded 11 more reference-doc paths from `Temporal.Headings`** (in both `.vale.ini` and `.vale-ci.ini`), on top of the existing `sdk-metrics.mdx` exclusion: `docs/cloud/tcld/**`, `docs/cloud/references/regions/**`, `docs/cloud/metrics/reference.mdx`, `docs/cloud/metrics/openmetrics/metrics-reference.mdx`, `docs/references/{cluster-metrics,configuration,web-ui-configuration,server-options,errors,commands,events}.mdx`. These files' headings are literal command/config/metric/error names rather than prose, so sentence-case capitalization doesn't apply — excluding them cut `Temporal.Headings` noise from 1402 → 745 hits across `docs/` with no loss of real coverage (verified no genuine prose violations were silenced).

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216543170786757">EDU-6712 Major Vale related update</a>
