### PR TITLE
docs: reword Fairness pricing 'for each hour' to 'during each hour'

### DIFF
--- a/docs/evaluate/temporal-cloud/pricing.mdx
+++ b/docs/evaluate/temporal-cloud/pricing.mdx
@@ -339,7 +339,7 @@ When upgrading an existing Namespace, some points to consider:
 
 **How does pricing for Fairness work?**
 
-When [Fairness](/develop/task-queue-priority-fairness#task-queue-fairness) is enabled on a Namespace, an additional `0.1` Action is charged per Action in that Namespace for each hour the feature is on, regardless of whether individual Workflows or Activities use fairness keys.
+When [Fairness](/develop/task-queue-priority-fairness#task-queue-fairness) is enabled on a Namespace, an additional `0.1` Action is charged per Action in that Namespace during each hour the feature is on, regardless of whether individual Workflows or Activities use fairness keys.
 
 The examples below use a Namespace, `your-namespace`, that normally generates 10,000 Actions per hour.
 


### PR DESCRIPTION
Change "for each hour" to "during each hour" in the Fairness pricing sentence.