### PR TITLE
Clarify Support-set APS limit persists across capacity mode switches

### DIFF
--- a/docs/best-practices/managing-aps-limits.mdx
+++ b/docs/best-practices/managing-aps-limits.mdx
@@ -207,6 +207,7 @@ Use Provisioned capacity when the on-demand model can't respond quickly enough:
 
 :::note
 When switching back to on-demand mode, your APS limit resets to the running average from the last 7 days.
+If Temporal Support has set a custom limit for your Namespace, that limit is preserved across the switch.
 Plan for this if your workload is sensitive to the transition.
 :::
 

--- a/docs/cloud/capacity-modes.mdx
+++ b/docs/cloud/capacity-modes.mdx
@@ -100,7 +100,7 @@ Actions that are external to the core Temporal service do not contribute to your
 ## On-Demand Capacity {/* #on-demand-capacity */}
 
 Using On-Demand Capacity, your rate limit grows automatically along with your usage.
-Each Namespace has an Actions per second (APS), Requests per second (RPS), and Operations per second (OPS) limit that scales automatically with usage. Your APS limit never falls below its [default limit](/cloud/limits#actions-per-second).
+Each Namespace has an Actions per second (APS), Requests per second (RPS), and Operations per second (OPS) limit that scales automatically with usage. Your APS limit never falls below its [default limit](/cloud/limits#actions-per-second). If Temporal Support has manually set your Namespace's limit, that value becomes your floor in place of the default, and it persists across capacity mode changes.
 
 Scaling automatically adjusts based on the lesser of 4 * APS Average or 2 * APS P90 over the past 7 days.
 
@@ -179,6 +179,10 @@ For the metrics to watch and how to alert on utilization, see [Provisioned capac
 ## Setting Capacity Modes
 Capacity Modes and TRUs can be set via the Temporal Cloud UI, CLI, or API. 
 Capacity modes can be set and adjusted by Global Admin and Namespace Admin. 
+
+When you switch to Provisioned Capacity, your limit is set by the number of TRUs you select.
+When you switch back to On-Demand, your limit is recalculated from the trailing 7-day usage formula and never falls below your floor.
+If Temporal Support has set a custom limit for your Namespace, that limit is your floor, so switching to Provisioned and back to On-Demand preserves it.
 
 ### Setting Capacity Modes from the UI
 


### PR DESCRIPTION
A Support-set APS limit acts as a floor and is preserved when switching to Provisioned and back to On-Demand (it is not reset). Updates capacity-modes and managing-aps-limits accordingly.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216599257136627">EDU-6718 Clarify Support-set APS limit persists across capacity mode switches</a>
