### PR TITLE
Mark LangGraph and LangSmith integrations as Public Preview

### DIFF
--- a/docs/develop/python/integrations/langgraph.mdx
+++ b/docs/develop/python/integrations/langgraph.mdx
@@ -28,7 +28,7 @@ The plugin supports both the LangGraph **Graph API** (`StateGraph` with nodes an
 directly inside the Workflow — Activity nodes get configurable timeouts and retry policies, while Workflow nodes run
 inline and must be deterministic.
 
-<ReleaseNoteHeader type="prerelease" />
+<ReleaseNoteHeader type="publicPreview" />
 
 Code snippets in this guide are taken from the
 [LangGraph plugin samples](https://github.com/temporalio/samples-python/tree/main/langgraph_plugin). Refer to the

--- a/docs/develop/python/integrations/langsmith.mdx
+++ b/docs/develop/python/integrations/langsmith.mdx
@@ -19,10 +19,6 @@ description:
 
 import { ReleaseNoteHeader } from '@site/src/components';
 
-<ReleaseNoteHeader type="prerelease">
-  All APIs are experimental and may be subject to backwards-incompatible changes.
-</ReleaseNoteHeader>
-
 Temporal's LangSmith integration lets you trace AI agent Workflows in [LangSmith](https://smith.langchain.com/)
 alongside every LLM call, tool execution, and Temporal operation.
 
@@ -33,6 +29,8 @@ request from the Client through to the model, and compare runs over time.
 The `LangSmithPlugin` is what connects the two. It propagates trace context across Temporal boundaries so that runs
 started on the Client nest correctly under Workflow and Activity runs on the Worker. It can also create LangSmith
 runs for Temporal operations themselves: Workflow executions, Activity executions, Signals, Updates, and Queries.
+
+<ReleaseNoteHeader type="publicPreview" />
 
 All code snippets in this guide are taken from the
 [LangSmith tracing sample](https://github.com/temporalio/samples-python/tree/main/langsmith_tracing). Refer to the


### PR DESCRIPTION
## Summary
- Mark the LangGraph and LangSmith Python integrations as Public Preview.
- Align the LangSmith callout with the standard release-stage structure used by other Public Preview integration guides.
- Remove the Pre-release-specific experimental and backwards-incompatible API warning from the LangSmith page.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216631366355211">EDU-6735 Mark LangGraph and LangSmith integrations as Public Preview</a>
