### PR TITLE
IntegrationsGrid: add Go as an SDK option

### DIFF
--- a/COMPONENTS.md
+++ b/COMPONENTS.md
@@ -155,7 +155,7 @@ For example, the Python SDK integrations page pre-filters to Python:
 <IntegrationsGrid defaultSdks={["Python"]} />
 ```
 
-Valid SDK values are `"Java"`, `"Python"`, `"TypeScript"`, and `"Ruby"`.
+Valid SDK values are `"Go"`, `"Java"`, `"Python"`, `"TypeScript"`, and `"Ruby"`.
 
 ### Filter behavior
 

--- a/docs/develop/go/index.mdx
+++ b/docs/develop/go/index.mdx
@@ -93,7 +93,7 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 
 - [Google ADK integration](/develop/go/integrations/google-adk)
 
-## Temporal Go Technical Resources
+## Temporal Go technical resources
 
 - [Go SDK Quickstart - Setup Guide](/develop/go/set-up-your-local-go)
 - [Go API Documentation](https://pkg.go.dev/go.temporal.io/sdk)

--- a/docs/develop/go/index.mdx
+++ b/docs/develop/go/index.mdx
@@ -89,6 +89,10 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 - [Testing](/develop/go/best-practices/testing-suite)
 - [Data handling](/develop/go/data-handling)
 
+## [Integrations](/develop/go/integrations)
+
+- [Google ADK integration](/develop/go/integrations/google-adk)
+
 ## Temporal Go Technical Resources
 
 - [Go SDK Quickstart - Setup Guide](/develop/go/set-up-your-local-go)

--- a/docs/develop/go/integrations/index.mdx
+++ b/docs/develop/go/integrations/index.mdx
@@ -1,21 +1,22 @@
 ---
 id: index
-title: Integrations
+title: Integrations - Go SDK
 sidebar_label: Integrations
-toc_max_heading_level: 2
+description: This section covers integrations with the Go SDK
+toc_max_heading_level: 4
 keywords:
+  - Go SDK
   - integrations
   - ai frameworks
-  - agent frameworks
 tags:
+  - Go SDK
+  - Temporal SDKs
   - Integrations
-  - AI Frameworks
-  - Agent Frameworks
-description: Integrations with other tools and services.
 ---
 
 import IntegrationsGrid from '@site/src/components/IntegrationsGrid';
 
 The following integrations are available for the Temporal Go SDK.
+You can also use the Temporal Go SDK's [Plugin system](/develop/plugins-guide) to build your own integrations.
 
 <IntegrationsGrid defaultSdks={["Go"]} />

--- a/src/components/IntegrationsGrid/index.tsx
+++ b/src/components/IntegrationsGrid/index.tsx
@@ -10,12 +10,13 @@ import integrations, { type SDK, type Integration } from "./integrations-data";
 import SdkSvg from "../elements/SdkSvgs/SdkSvg";
 import styles from "./IntegrationsGrid.module.css";
 
-const ALL_SDKS: SDK[] = ["Java", "Python", "Ruby", "TypeScript"];
+const ALL_SDKS: SDK[] = ["Go", "Java", "Python", "Ruby", "TypeScript"];
 const LANGUAGE_AGNOSTIC = "Language-agnostic";
 type SdkFilter = SDK | typeof LANGUAGE_AGNOSTIC;
 const ALL_SDK_FILTERS: SdkFilter[] = [...ALL_SDKS, LANGUAGE_AGNOSTIC];
 
 const SDK_BLOCK_NAMES: Record<SDK, string> = {
+  Go: "goLangBlock",
   Java: "javaBlock",
   Python: "pythonBlock",
   Ruby: "rubyBlock",


### PR DESCRIPTION
## What

Stacked on #4894 (base branch: `dabh/go-adk-integration-docs`). Makes **Go** a first-class citizen of the Integrations UI and navigation, addressing https://github.com/temporalio/documentation/pull/4894#discussion_r3591682472 and https://github.com/temporalio/documentation/pull/4914#issuecomment-5006465190:

- `IntegrationsGrid/index.tsx` — `Go` added to `ALL_SDKS` (the filter pill now appears) and to `SDK_BLOCK_NAMES` mapped to `goLangBlock` (cards with `"sdk": "Go"` render an icon instead of nothing)
- `COMPONENTS.md` — valid `defaultSdks` values updated
- `docs/develop/go/index.mdx` — the Go dev guide landing page now has an [Integrations](/develop/go/integrations) section, mirroring the Java dev guide
- `docs/develop/go/integrations/index.mdx` — frontmatter/format aligned with the Java integrations page (SDK-suffixed title, SDK keywords/tags, pointer to the [Plugin system guide](/develop/plugins-guide))

The `/develop/go/integrations` page itself and the `SDK` union change come from #4894, which this PR builds on.

## Icon

No new asset: `Go` maps to the existing `SdkSvgs/GoLangBlock.js` icon that the SDK guide cards, release-note headers, and SDK logo blocks already ship — the same reuse pattern as the grid's Java/Python/Ruby/TypeScript entries (`GuidesGrid` already maps `Go: "goLangBlock"`).

## Notes

- The LLM markdown pipeline handler (`scripts/component-handlers/integrations.mjs`) is data-driven and needs no change — verified `defaultSdks={["Go"]}` resolves the Go entries #4894 adds and existing SDKs are unaffected.
- Verified the `SDK` union, `ALL_SDKS`, and `SDK_BLOCK_NAMES` are mutually consistent and every block name resolves in the `SdkSvg` dispatcher.
