### PR TITLE
Clarify Nexus failover behavior when the Handler Namespace fails over

### DIFF
--- a/docs/production-deployment/self-hosted-guide/temporal-nexus.mdx
+++ b/docs/production-deployment/self-hosted-guide/temporal-nexus.mdx
@@ -130,9 +130,20 @@ target an external URL (`--target-url`), which is experimental and not covered h
 
 ### What to expect on failover
 
-For a Nexus Operation started before a Cluster failover completes on the new active
-Cluster, the completion callback is delivered to the caller Namespace's current
-active Cluster, re-resolved on each attempt:
+An asynchronous Nexus Operation completes even when the Handler Namespace fails
+over before its completion callback is delivered. Two properties make this work:
+
+- The pending completion callback is **durable state on the Handler Workflow**, so
+  it fails over together with the Handler Namespace and is re-driven from the new
+  active Cluster.
+- Each Namespace resolves its active Cluster **independently**. The callback is
+  routed to the **Caller Namespace's** current active Cluster (re-resolved on each
+  attempt), which is unaffected by the Handler Namespace's failover.
+
+The sequence below shows the Handler Namespace failing over from Cluster A to
+Cluster B while the Caller Namespace stays active on Cluster A. The Handler
+Workflow finishes on Cluster B, and its completion callback is still delivered back
+to the Caller on Cluster A:
 
 ```mermaid
 sequenceDiagram
@@ -141,14 +152,14 @@ sequenceDiagram
     participant haA as Handler Namespace
     end
     box Cluster B
-    participant caB as Caller Namespace
     participant haB as Handler Namespace
     end
-    Note over caA,haA: Cluster A active
+    Note over caA,haA: Caller and Handler Namespaces active on Cluster A
     caA->>haA: start Nexus Operation
     haA-->>caA: Operation started, token returned
-    Note over caA,haB: 💥 Fail over both namespaces from Cluster A to B
-    Note over caB,haB: Cluster B active
-    haB->>caB: deliver completion callback
-    Note over caB: Nexus Operation completes
+    Note over haA: Handler Workflow running, completion callback pending
+    Note over haA,haB: 💥 Handler Namespace fails over to Cluster B (Caller stays on Cluster A)
+    Note over haB: Handler Workflow resumes on B, pending callback re-driven from B
+    haB->>caA: deliver completion callback to Caller's active Cluster (A)
+    Note over caA: Operation completes on the Caller
 ```


### PR DESCRIPTION
## What

Reworks the **What to expect on failover** section of the self-hosted Nexus page to clearly explain the case where the **Handler Namespace fails over before the completion callback is delivered** (while the Caller Namespace stays on its Cluster) — the question that came up after the original PR merged.

- Explains the two properties that make it work: the pending callback is durable state on the Handler Workflow (fails over with it, re-driven from the new active Cluster), and each Namespace resolves its active Cluster independently (so the callback still reaches the Caller).
- Updates the sequence diagram to depict this asymmetric case instead of the symmetric "both Namespaces fail over" one.

## Why

The original diagram (merged in #4906) only showed both Namespaces failing over together, which obscured that callback delivery targets the Caller Namespace's active Cluster independently of where the Handler runs.

Mermaid lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216766953911381">EDU-6773 Clarify Nexus failover behavior when the Handler Namespace fails over</a>
