### PR TITLE
Putting the text back to Copy for LLM :)

### DIFF
--- a/src/components/LLMActions/LLMActions.tsx
+++ b/src/components/LLMActions/LLMActions.tsx
@@ -68,7 +68,7 @@ export default function LLMActions() {
           ) : (
             <FaRegCopy className={styles.icon} />
           )}
-          {loading ? 'Loading...' : copied ? 'Copied!' : 'Copy Markdown'}
+          {loading ? 'Loading...' : copied ? 'Copied!' : 'Copy for LLM'}
         </button>
 
         <a


### PR DESCRIPTION
We have gone through some changes with these buttons. The original copy button used to say "Copy for LLM" ... then it became "Copy" with a dropdown and we saw a huge drop in engagement. Moved the options out of the dropdown and changed it to "Copy Markdown" and while it went *up*, it never went back to the original level. So trying putting the LLM buzzword back in :)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216768160721270">EDU-6774 Putting the text back to Copy for LLM :)</a>
