### PR TITLE
pre-release limitations for Standalone Nexus Operations

### DIFF
--- a/docs/encyclopedia/nexus/standalone-nexus-operation.mdx
+++ b/docs/encyclopedia/nexus/standalone-nexus-operation.mdx
@@ -124,6 +124,12 @@ queued tasks.
 Standalone Nexus Operations are at Pre-release. APIs are experimental and may be subject to
 backwards-incompatible changes.
 
+The following features are not supported yet:
+  - Delete and reset
+  - Batch `--query` support for cancel, terminate, and delete
+  - UI list-page operator actions
+  - HA / multi-region (global) namespaces using selective API forwarding
+
 ## Temporal CLI support
 
 Standalone Nexus Operations require a Pre-release build of the [Temporal CLI](/cli) that includes


### PR DESCRIPTION
## What does this PR do?
- adds pre-release limitations for Standalone Nexus Operations

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216886231783036">EDU-6806 pre-release limitations for Standalone Nexus Operations</a>
