### PR TITLE
Document CLI flag precedence in Environment Configuration

### DIFF
--- a/docs/develop/environment-configuration.mdx
+++ b/docs/develop/environment-configuration.mdx
@@ -109,6 +109,16 @@ These CLI commands directly manipulate the `temporal.toml` file. This differs fr
 file and environment at runtime to establish a client connection. You can select a profile for the CLI to use with the
 `--profile` flag. For example, `temporal --profile prod ...`.
 
+Connection flags on other `temporal` commands (for example, `--address`, `--namespace`, `--api-key`) sit above both
+environment variables and the TOML file in precedence. The full order for the CLI is:
+
+1. Command-line flags
+2. Environment variables
+3. TOML configuration file (active profile)
+
+So `temporal workflow list --address localhost:7233` uses `localhost:7233` even if `TEMPORAL_ADDRESS` or the active
+profile's `address` sets something else.
+
 The following code blocks provide copy-paste-friendly examples for setting up CLI profiles for both local development
 and Temporal Cloud.
 


### PR DESCRIPTION
## Summary
- The Environment Configuration page states that environment variables take precedence over the TOML config file, but never says where `temporal` CLI flags (`--address`, `--namespace`, `--api-key`, etc.) rank in that order.
- Adds the missing rule to the CLI integration section: command-line flags > environment variables > TOML configuration file (active profile).

## Verification
Confirmed empirically against a local `temporal server start-dev` instance with an isolated `TEMPORAL_CONFIG_FILE`:
- An explicit `--address` flag overrode both a conflicting `TEMPORAL_ADDRESS` env var and a conflicting TOML `default` profile address.
- `TEMPORAL_ADDRESS` overrode a conflicting TOML `default` profile address.
- With neither a flag nor an env var set, the TOML `default` profile's address was used (proved via a DNS failure against a deliberately bogus hostname placed in the profile).

## Test plan
- [ ] Read the updated CLI integration section for clarity

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216954949046265">EDU-6828 Document CLI flag precedence in Environment Configuration</a>
