### PR TITLE
fix(vale): reduce Temporal.Headings false positives on proper nouns

### DIFF
--- a/vale/styles/Temporal/Headings.yml
+++ b/vale/styles/Temporal/Headings.yml
@@ -140,3 +140,42 @@ exceptions:
   - Transition
   - Type
   - Visibility
+  # SDK language names (parallel to existing TypeScript)
+  - Go
+  - Java
+  - Python
+  - Ruby
+  - PHP
+  - Rust
+  - .NET
+  # Identifier casing per this repo's style guide (Id, not ID)
+  - Id
+  # Temporal feature / primitive names
+  - Versioning
+  - Patching
+  - Endpoint
+  - Metrics
+  - Account
+  - Capacity
+  - Connectivity
+  - Continue-As-New
+  # Cloud provider / networking / industry acronyms
+  - AWS
+  - GCP
+  - DNS
+  - TLS
+  - mTLS
+  - SAML
+  - SSO
+  - API
+  - APIs
+  - UI
+  - HA
+  - RTO
+  - RPO
+  - SLA
+  - APS
+  - PrivateLink
+  - Terraform
+  - Prometheus
+  - Grafana

--- a/vale/test/headings-bad.md
+++ b/vale/test/headings-bad.md
@@ -7,3 +7,7 @@
 ## Building And Testing The Code
 
 ## Configure And Deploy Your Application
+
+## Related Resources
+
+## Best Practices

--- a/vale/test/headings-good.md
+++ b/vale/test/headings-good.md
@@ -43,3 +43,11 @@
 ## Durable External Storage for large payloads
 
 ## Highly available Worker patterns {/* #ha-worker-patterns */}
+
+## Add Temporal Rust SDK dependencies
+
+## Workflow Id reuse policy
+
+## Configure mTLS and PrivateLink for AWS
+
+## Worker Versioning and Patching


### PR DESCRIPTION
## Summary
- Scanned Vale-bot comments across the last ~48 PRs that triggered `Temporal.Headings`, then cross-checked against a live `vale --config=.vale-ci.ini docs/` run to separate real gaps from stale/already-fixed flags.
- Adds exceptions for SDK language names (Go, Java, Python, Ruby, PHP, Rust, .NET — TypeScript was already covered), the `Id` casing this repo's own style guide mandates (only `ID`/`IDs` were previously excepted, which was backwards), Temporal Cloud/Nexus feature names (Versioning, Patching, Endpoint, Metrics, Account, Capacity, Connectivity, Continue-As-New), and common cloud/networking acronyms (AWS, GCP, DNS, TLS, mTLS, SAML, SSO, API, UI, HA, RTO, RPO, SLA, APS, PrivateLink, Terraform, Prometheus, Grafana).
- Left out generic English words that show up in recurring title-case boilerplate headings (e.g. "Related Resources," "Best Practices," "Next Steps") — those are real sentence-case violations, not term-list gaps, and exempting them would blunt the rule for unrelated headings. Follow-up content fixes for those are in progress separately.

## Test plan
- [x] `vale --config=.vale-ci.ini docs/` — live `Temporal.Headings` suggestions drop from 638 to 481, 0 errors
- [x] `vale --config=.vale-ci.ini vale/test/headings-good.md` — 0 flags (added new good-case coverage for the new exceptions)
- [x] `vale --config=.vale-ci.ini vale/test/headings-bad.md` — still flags all pre-existing bad cases plus 2 new ones (`Related Resources`, `Best Practices`)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216966479448493">EDU-6836 fix(vale): reduce Temporal.Headings false positives on proper nouns</a>
