### PR TITLE
fix(vale): sentence-case recurring headings; more Temporal.Headings exceptions

### DIFF
--- a/docs/best-practices/managing-aps-limits.mdx
+++ b/docs/best-practices/managing-aps-limits.mdx
@@ -64,7 +64,7 @@ Additionally, there are often business reasons to start multiple Workflows at th
 
 These can all contribute to the multiplier effect. 
 
-### The Effect of Rate Limiting
+### The Effect of Rate limiting
 
 In Temporal Cloud, the effect of rate limiting is increased latency, not lost work. 
 Workers [might take longer](/cloud/service-availability#throughput) to complete Workflows. 
@@ -89,7 +89,7 @@ Common bursty patterns include:
 
 These types of processes can result in your Namespace averaging 200 APS over a day, but spiking to 800 APS or more during your peak hour/day/event/etc. 
 
-#### How to Mitigate
+#### How to mitigate
 
 You can’t change the patterns of how customers interact with your systems, but there are some adjustments you can make to your Workflows to make traffic patterns more consistent, especially for use cases where immediate response isn’t necessary. 
 
@@ -113,7 +113,7 @@ This pattern appears frequently in:
 
 This challenge additionally compounds when you have multiple levels of nesting--parent Workflows that create children, which create their own children. 
 
-#### How to Mitigate
+#### How to mitigate
 
 - Evaluate whether Child Workflows are necessary--other options include Activities or Workflows in another Namespace (via Nexus)
 - When you do use Child Workflows, limit fan-out size--design a Child Workflow to process its work in batches rather than one Child per work item. [This sample application](https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/batch/slidingwindow) shows more detail.
@@ -127,7 +127,7 @@ These Workflows can involve Queries from UIs to display current state and pendin
 
 At small scale, this is manageable. But when you're running thousands of them at the same time--like a content moderation queue with pending reviews, or a loan approval system processing applications, or a support ticket system managing thousands of open cases--the cumulative APS load from all of those long-running Workflows adds up.
 
-#### How to Mitigate
+#### How to mitigate
 
 - Avoid polling patterns where UIs constantly query Workflow state. Instead, push state changes to a database that UIs can read. 
 
@@ -140,7 +140,7 @@ Each of these Timers/monitoring actions affect APS.
 When you have thousands of in-flight Workflows all actively monitoring their own SLAs, the background load becomes significant.
 You're consuming substantial APS capacity even when Workflows aren't doing their primary work.
 
-#### How to Mitigate
+#### How to mitigate
 
 - Use longer monitoring intervals where possible. For example, check SLAs every 30 minutes rather than every 1 minute.
 - Where possible, consolidate Timers. Rather than 10 Timers that check 10 tasks, have 1 Timer and then check those 10 tasks.
@@ -161,7 +161,7 @@ Approach B will clearly result in less APS.
 This is a simple example, but this pattern shows up everywhere: processing individual transactions versus batches, sending individual notifications versus bulk operations, or making separate API calls versus batch endpoints. 
 Each separate Activity adds Action overhead.
 
-#### How to Mitigate
+#### How to mitigate
 
 - Consider if you can combine multiple external calls within a single Activity.
 - If processing a large amount of data, process it in chunks.
@@ -173,7 +173,7 @@ When the second Temporal use case is implemented, it runs in the same Namespace,
 
 An APS limit is set per Namespace, so multiple use cases with multiple traffic patterns in the same Namespace can exhaust this limit quickly.
 
-#### How to Mitigate
+#### How to mitigate
 
 Plan for a set of Namespaces (one per environment) per use case. This gives each use case its own APS envelope and
 reduces the blast radius when one workload spikes or misbehaves.

--- a/docs/best-practices/security-controls.mdx
+++ b/docs/best-practices/security-controls.mdx
@@ -33,7 +33,7 @@ Subscribe to Temporal’s security updates on the [Temporal Trust Portal](https:
 
 Strong identity management in Temporal Cloud is crucial for ensuring secure access for your Temporal account. It’s critical that only authorized users and services can access your Temporal Cloud account and that each has the minimum necessary permissions needed for their role. 
 
-### Best Practices:
+### Best practices:
 
 #### 1. Enable [SAML Single Sign-on](/cloud/manage-access/saml) (SSO) for User Access
 
@@ -57,7 +57,7 @@ Clients interact with the Temporal Service to initiate and manage Workflows, whi
 
 A crucial aspect of strengthening your usage involves securing these interactions. Temporal Cloud offers two authentication methods for your applications: mutual TLS certificates and API keys.
 
-### Best Practices:
+### Best practices:
 
 #### 1. Using Mutual TLS (mTLS) provides comprehensive security
 
@@ -82,7 +82,7 @@ Temporal Cloud API keys are an alternative to mTLS for authentication of SDKs, C
 
 Although Temporal Cloud is a SaaS offering, you retain control over its networking configurations, allowing for tailored security measures. By minimizing public internet exposure and segmenting Temporal workflows into suitable network zones, you can significantly bolster security and reduce potential vulnerabilities. This approach ensures that your workflows are isolated and protected within your defined network boundaries, even while leveraging the benefits of a cloud-based service. 
 
-### Best Practices:
+### Best practices:
 
 #### 1. Use Private Connectivity
 
@@ -98,7 +98,7 @@ Ensure that your production Namespace uses stricter network controls (e.g. only 
 
 Temporal's data encryption capabilities ensure the security and confidentiality of your Workflows and provide protection without compromising performance. Protecting the data that you send to and store in Temporal Cloud is a joint responsibility. Temporal Cloud already encrypts all data at rest on the server side, but you can add additional layers of encryption and control. 
 
-### Best Practices:
+### Best practices:
 
 #### 1. Enable Client-Side Encryption for Workflow Data
 
@@ -127,7 +127,7 @@ Temporal Cloud’s platform is engineered for fault-tolerance out of the box, bu
 | **Multi-Region Replication** | **If a disruption of your workflow will cause loss of revenue, poor end-user experience, or issues with regulatory compliance.** | 99.99% | ≤ 20 minutes | Near-zero (≈ seconds) |
 | **Multi-Cloud Replication** | **If you need the highest level of disaster tolerance, protecting against outages of an entire cloud provider (e.g., AWS or GCP)** | 99.99% | ≤ 20 minutes | Near-zero (≈ seconds) |
 
-### Best Practices:
+### Best practices:
 
 #### 1. Identify Availability-sensitive Namespaces
 

--- a/docs/cloud/aws-export-s3.mdx
+++ b/docs/cloud/aws-export-s3.mdx
@@ -150,7 +150,7 @@ The following is an example of the output:
 See the [terraform export support](https://registry.terraform.io/providers/temporalio/temporalcloud/latest/docs/resources/namespace_export_sink) for setup instructions.
 
 
-### Next Steps
+### Next steps
 
 - [Verify export setup](/cloud/export#verify)
 - [Monitor export progress](/cloud/export#monitor)

--- a/docs/cloud/gcp-export-gcs.mdx
+++ b/docs/cloud/gcp-export-gcs.mdx
@@ -158,7 +158,7 @@ tcld n export gcs g -n test.ns --sink-name test-sink
 See the [Terraform export support](https://registry.terraform.io/providers/temporalio/temporalcloud/latest/docs/resources/namespace_export_sink) for setup instructions.
 
 
-### Next Steps
+### Next steps
 
 - [Verify export setup](/cloud/export#verify)
 - [Monitor export progress](/cloud/export#monitor)

--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -95,7 +95,7 @@ A [Metric Family](https://github.com/prometheus/OpenMetrics/blob/main/specificat
 
 ## Client Considerations
 
-### Rate Limiting
+### Rate limiting
 
 To protect the stability of the API and keep it available to all users, Temporal employs multiple safeguards.
 
@@ -153,7 +153,7 @@ Returns metrics in OpenMetrics format suitable for scraping by Prometheus-compat
 
 To account for metric data latency, this endpoint returns metrics from the current timestamp minus a fixed offset.  The current offset is 3 minutes rounded down to the start of the minute. To accommodate this offset, the timestamps in the response should be honored when importing the metrics. For example, in Prometheus this can be controlled using the `honor\_timestamps` flag.
 
-#### Query Parameters
+#### Query parameters
 
 | Parameter | Type | Description |
 | ----- | ----- | ----- |
@@ -215,7 +215,7 @@ temporal_cloud_v1_approximate_backlog_count{temporal_namespace="production",temp
 
 Lists all metric descriptors including metadata, data types, and available dimensions (a.k.a. labels).
 
-#### Query Parameters
+#### Query parameters
 
 | Parameter | Type | Description |
 | ----- | ----- | ----- |

--- a/docs/develop/dotnet/best-practices/error-handling.mdx
+++ b/docs/develop/dotnet/best-practices/error-handling.mdx
@@ -19,7 +19,7 @@ tags:
   - Errors
 ---
 
-## Raise and Handle Exceptions {/* #exception-handling */}
+## Raise and handle exceptions {/* #exception-handling */}
 
 In each Temporal SDK, error handling is implemented idiomatically, following the conventions of the language.
 Temporal uses several different error classes internally — for example, [`CancelledFailureException`](https://dotnet.temporal.io/api/Temporalio.Exceptions.CanceledFailureException.html) in the .NET SDK, to handle a Workflow cancellation. 

--- a/docs/develop/dotnet/nexus/quickstart.mdx
+++ b/docs/develop/dotnet/nexus/quickstart.mdx
@@ -306,7 +306,7 @@ Open the [Temporal Web UI](http://localhost:8233) and find the `CallerWorkflow` 
 
 </SetupSteps>
 
-## Next Steps
+## Next steps
 
 Now that you have a working Nexus Service, here are some resources to deepen your understanding:
 

--- a/docs/develop/dotnet/platform/enriching-ui.mdx
+++ b/docs/develop/dotnet/platform/enriching-ui.mdx
@@ -20,7 +20,7 @@ tags:
 Temporal supports adding context to Workflows and events with metadata. 
 This helps users identify and understand Workflows and their operations.
 
-## Adding Summary and Details to Workflows
+## Adding summary and details to Workflows
 
 ### Starting a Workflow
 
@@ -142,12 +142,12 @@ public class YourWorkflow
 
 The input format for `Summary` is a string, and limited to 200 bytes.
 
-## Viewing Summary and Details in the UI
+## Viewing summary and details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and timers, you can view this enriched information in the Temporal Web UI. 
 Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
-### Workflow Overview Section
+### Workflow overview section
 
 At the top of the Workflow details page, you'll find the Workflow-level metadata:
 

--- a/docs/develop/dotnet/platform/observability.mdx
+++ b/docs/develop/dotnet/platform/observability.mdx
@@ -87,7 +87,7 @@ var runtime = new TemporalRuntime(new()
 var client = await Temporalio.ConnectAsync(new("localhost:7233") { Runtime = runtime });
 ```
 
-## Setup Tracing {/* #tracing */}
+## Set up tracing {/* #tracing */}
 
 Tracing allows you to view the call graph of a Workflow along with its Activities, Nexus Operations, and any Child Workflows.
 

--- a/docs/develop/dotnet/set-up.mdx
+++ b/docs/develop/dotnet/set-up.mdx
@@ -137,7 +137,7 @@ Build the solution:
   </SetupStep>
 </SetupSteps>
 
-## Run Hello World: Test Your Installation
+## Run Hello World: Test your installation
 
 Now let's verify your setup is working by creating and running a complete Temporal application with both a Workflow and Activity.
 
@@ -310,7 +310,7 @@ While the Worker is still running, run the Workflow:
 dotnet run --project Client/Client.csproj
 ```
 
-### Verify Success
+### Verify success
 
 If everything is working correctly, you should see:
 

--- a/docs/develop/dotnet/workers/interceptors.mdx
+++ b/docs/develop/dotnet/workers/interceptors.mdx
@@ -68,7 +68,7 @@ var client = await TemporalClient.ConnectAsync(new()
 The `Interceptors` list can contain multiple interceptors.
 The default behavior for interceptors is to form a chain. A method implemented on an interceptor instance in the list can perform side effects, and modify the data, before passing it on to the corresponding method on the next interceptor in the list.
 
-### Register via a Plugin
+### Register via a plugin
 
 If you're building a reusable library or want to bundle interceptors with other primitives, you can register them through a [Plugin](/develop/plugins-guide#interceptors).
 

--- a/docs/develop/dotnet/workflows/cancellation.mdx
+++ b/docs/develop/dotnet/workflows/cancellation.mdx
@@ -134,7 +134,7 @@ public async Task MyActivityAsync()
 }
 ```
 
-### Request Cancellation {/* #request-cancellation */}
+### Request cancellation {/* #request-cancellation */}
 
 Use `CancelAsync` on the `WorkflowHandle` to cancel a Workflow Execution.
 

--- a/docs/develop/dotnet/workflows/continue-as-new.mdx
+++ b/docs/develop/dotnet/workflows/continue-as-new.mdx
@@ -66,7 +66,7 @@ throw Workflow.CreateContinueAsNewException((ClusterManagerWorkflow wf) => wf.Ru
 }));
 ````
 
-### Considerations for Workflows with Message Handlers {/* #with-message-handlers */}
+### Considerations for Workflows with message handlers {/* #with-message-handlers */}
 
 If you use Updates or Signals, don't call Continue-as-New from the handlers.
 Instead, wait for your handlers to finish in your main Workflow before you throw `CreateContinueAsNewException`.

--- a/docs/develop/go/nexus/quickstart.mdx
+++ b/docs/develop/go/nexus/quickstart.mdx
@@ -318,7 +318,7 @@ func main() {
 </>
 }>
 
-## 6. Run and Verify
+## 6. Run and verify
 
 Create `caller/main.go` to start the caller Worker and execute the Workflow.
 
@@ -360,7 +360,7 @@ In `default`, find the `HelloNexusWorkflow` execution that was started by the Ne
 </SetupStep>
 </SetupSteps>
 
-## Next Steps
+## Next steps
 
 Now that you have a working Nexus Service, here are some resources to deepen your understanding:
 

--- a/docs/develop/go/platform/enriching-ui.mdx
+++ b/docs/develop/go/platform/enriching-ui.mdx
@@ -20,7 +20,7 @@ tags:
 Temporal supports adding context to Workflows and Events with metadata. 
 This helps users identify and understand Workflows and their operations.
 
-## Adding Summary and Details to Workflows
+## Adding summary and details to Workflows
 
 ### Starting a Workflow
 
@@ -139,12 +139,12 @@ func YourWorkflow(ctx workflow.Context, input string) (string, error) {
 
 The input format for `Summary` is a string, and limited to 200 bytes. 
 
-## Viewing Summary and Details in the UI
+## Viewing summary and details in the UI
 
 Once you've added summaries and details to your workflows, activities, and timers, you can view this enriched information in the Temporal Web UI. 
 Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
-### Workflow Overview Section
+### Workflow overview section
 
 At the top of the workflow details page, you'll find the workflow-level metadata:
 

--- a/docs/develop/go/set-up.mdx
+++ b/docs/develop/go/set-up.mdx
@@ -155,7 +155,7 @@ Once you have everything installed, you're ready to build apps with Temporal on 
 </SetupStep>
 </SetupSteps>
 
-## Run Hello World: Test Your Installation
+## Run Hello World: Test your installation
 
 Now let's verify your setup is working by creating and running a complete Temporal application with both a Workflow and
 Activity.
@@ -324,7 +324,7 @@ Then run:
 go run start/main.go Temporal
 ```
 
-### Verify Success
+### Verify success
 
 If everything is working correctly, you should see:
 

--- a/docs/develop/go/workflows/cancellation.mdx
+++ b/docs/develop/go/workflows/cancellation.mdx
@@ -107,7 +107,7 @@ func (a *Activities) ActivityToBeCanceled(ctx context.Context) (string, error) {
 // ...
 ```
 
-## Request Cancellation {/* #request-cancellation */}
+## Request cancellation {/* #request-cancellation */}
 
 **How to request Cancellation of a Workflow and Activities in Go.**
 

--- a/docs/develop/go/workflows/continue-as-new.mdx
+++ b/docs/develop/go/workflows/continue-as-new.mdx
@@ -66,7 +66,7 @@ return ClusterManagerResult{}, workflow.NewContinueAsNewError(
 )
 ````
 
-### Considerations for Workflows with Message Handlers {/* #with-message-handlers */}
+### Considerations for Workflows with message handlers {/* #with-message-handlers */}
 
 If you use Updates or Signals, don't call Continue-as-New from the handlers.
 Instead, wait for your handlers to finish in your main Workflow before you return `NewContinueAsNewError`.

--- a/docs/develop/go/workflows/versioning.mdx
+++ b/docs/develop/go/workflows/versioning.mdx
@@ -38,7 +38,7 @@ Temporal's [Worker Versioning](/production-deployment/worker-deployments/worker-
 
 ## Versioning with Patching {/* #patching */}
 
-### Patching with GetVersion
+### Patching with `GetVersion`
 
 A Patch defines a logical branch in a Workflow for a specific change, similar to a feature flag.
 It applies a code change to new Workflow Executions while avoiding disruptive changes to in-progress Workflow Executions.

--- a/docs/develop/java/nexus/quickstart.mdx
+++ b/docs/develop/java/nexus/quickstart.mdx
@@ -326,7 +326,7 @@ public class NexusCallerStarter {
 </>
 }>
 
-## 6. Run and Verify
+## 6. Run and verify
 
 Create `NexusCallerStarter.java` to start the caller Worker and execute the Workflow.
 
@@ -362,7 +362,7 @@ In `default`, find the `SayHelloWorkflow` execution that was started by the Nexu
 </SetupStep>
 </SetupSteps>
 
-## Next Steps
+## Next steps
 
 Now that you have a working Nexus Service, here are some resources to deepen your understanding:
 

--- a/docs/develop/java/platform/enriching-ui.mdx
+++ b/docs/develop/java/platform/enriching-ui.mdx
@@ -20,7 +20,7 @@ tags:
 Temporal supports adding context to Workflows and Events with metadata. 
 This helps users identify and understand Workflows and their operations.
 
-## Adding Summary and Details to Workflows
+## Adding summary and details to Workflows
 
 ### Starting a Workflow
 
@@ -140,12 +140,12 @@ public class YourWorkflowImpl implements YourWorkflow {
 
 The input format for `setSummary()` is a string, and limited to 200 bytes.
 
-## Viewing Summary and Details in the UI
+## Viewing summary and details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI. 
 Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
-### Workflow Overview Section
+### Workflow overview section
 
 At the top of the workflow details page, you'll find the workflow-level metadata:
 

--- a/docs/develop/java/set-up.mdx
+++ b/docs/develop/java/set-up.mdx
@@ -72,7 +72,7 @@ You'll also need either Maven or Gradle installed.
 </>
 }>
 
-## Create a Project
+## Create a project
 
 Now that you have your build tool installed, create a project to manage your dependencies and build your Temporal
 application.
@@ -250,7 +250,7 @@ Once you have everything installed, you're ready to build apps with Temporal on 
 
 </SetupStep>
 </SetupSteps>
-## Run Hello World: Test Your Installation
+## Run Hello World: Test your installation
 
 Now let's verify your setup is working by creating and running a complete Temporal application with both a Workflow and
 Activity.
@@ -479,7 +479,7 @@ mvn compile exec:java -Dexec.mainClass="helloworkflow.Starter"
 </TabItem>
 </Tabs>
 
-### Verify Success
+### Verify success
 
 If everything is working correctly, you should see:
 

--- a/docs/develop/java/workflows/continue-as-new.mdx
+++ b/docs/develop/java/workflows/continue-as-new.mdx
@@ -61,7 +61,7 @@ Workflow.continueAsNew(
   new ClusterManagerInput(Optional.of(state), input.isTestContinueAsNew()));
 ````
 
-### Considerations for Workflows with Message Handlers {/* #with-message-handlers */}
+### Considerations for Workflows with message handlers {/* #with-message-handlers */}
 
 If you use Updates or Signals, don't call Continue-as-New from the handlers.
 Instead, wait for your handlers to finish in your main Workflow before you run `continueAsNew`.

--- a/docs/develop/java/workflows/versioning.mdx
+++ b/docs/develop/java/workflows/versioning.mdx
@@ -39,7 +39,7 @@ Temporal's [Worker Versioning](/production-deployment/worker-deployments/worker-
 
 ## Versioning with Patching {/* #patching */}
 
-### Patching with GetVersion
+### Patching with `GetVersion`
 
 A Patch defines a logical branch in a Workflow for a specific change, similar to a feature flag.
 It applies a code change to new Workflow Executions while avoiding disruptive changes to in-progress Workflow Executions.

--- a/docs/develop/php/platform/enriching-ui.mdx
+++ b/docs/develop/php/platform/enriching-ui.mdx
@@ -20,7 +20,7 @@ tags:
 Temporal supports adding context to Workflows and Events with metadata. 
 This helps users identify and understand Workflows and their operations.
 
-## Adding Summary and Details to Workflows
+## Adding summary and details to Workflows
 
 ### Starting a Workflow
 
@@ -120,12 +120,12 @@ class YourWorkflowImpl implements YourWorkflow
 
 The input format for `summary` is a string, and limited to 200 bytes.
 
-## Viewing Summary and Details in the UI
+## Viewing summary and details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI. 
 Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
-### Workflow Overview Section
+### Workflow overview section
 
 At the top of the Workflow details page, you'll find the Workflow-level metadata:
 

--- a/docs/develop/php/set-up.mdx
+++ b/docs/develop/php/set-up.mdx
@@ -74,7 +74,7 @@ composer init --name="myproject/quickstart" -n
 </>
 }>
 
-## Create a Project
+## Create a project
 
 Now that you have PHP installed, create a project to manage your dependencies and build your Temporal application.
 
@@ -290,7 +290,7 @@ Once you have everything installed, you're ready to build apps with Temporal on 
 
 </SetupStep>
 </SetupSteps>
-## Run Hello World: Test Your Installation
+## Run Hello World: Test your installation
 
 Now let's verify your setup is working by creating and running a complete Temporal application with both a Workflow and
 Activity.
@@ -443,7 +443,7 @@ While your Worker is still running, open a new terminal and run:
 php client.php
 ```
 
-### Verify Success
+### Verify success
 
 If everything is working correctly, you should see:
 

--- a/docs/develop/php/workflows/continue-as-new.mdx
+++ b/docs/develop/php/workflows/continue-as-new.mdx
@@ -69,7 +69,7 @@ Workflow::continueAsNew(
 );
 ````
 
-### Considerations for Workflows with Message Handlers {/* #with-message-handlers */}
+### Considerations for Workflows with message handlers {/* #with-message-handlers */}
 
 If you use Updates or Signals, don't call Continue-as-New from the handlers.
 Instead, wait for your handlers to finish in your main Workflow before you run `continueAsNew`.

--- a/docs/develop/php/workflows/versioning.mdx
+++ b/docs/develop/php/workflows/versioning.mdx
@@ -43,7 +43,7 @@ Temporal's [Worker Versioning](/production-deployment/worker-deployments/worker-
 
 ## Versioning with Patching {/* #php-sdk-patching-api */}
 
-### Patching with GetVersion
+### Patching with `GetVersion`
 
 A Patch defines a logical branch in a Workflow for a specific change, similar to a feature flag.
 It applies a code change to new Workflow Executions while avoiding disruptive changes to in-progress Workflow Executions.

--- a/docs/develop/python/nexus/quickstart.mdx
+++ b/docs/develop/python/nexus/quickstart.mdx
@@ -274,7 +274,7 @@ if __name__ == "__main__":
 </>
 }>
 
-## 6. Run and Verify
+## 6. Run and verify
 
 Create a file called `caller_starter.py` to start the caller Worker and execute the Workflow.
 
@@ -309,7 +309,7 @@ You should see `NexusOperationScheduled`, `NexusOperationStarted`, and `NexusOpe
 </SetupStep>
 </SetupSteps>
 
-## Next Steps
+## Next steps
 
 Now that you have a working Nexus Service, here are some resources to deepen your understanding:
 

--- a/docs/develop/python/platform/enriching-ui.mdx
+++ b/docs/develop/python/platform/enriching-ui.mdx
@@ -21,7 +21,7 @@ tags:
 Temporal supports adding context to Workflows and events with metadata. 
 This helps users identify and understand Workflows and their operations.
 
-## Adding Summary and Details to Workflows
+## Adding summary and details to Workflows
 
 ### Starting a Workflow
 
@@ -110,12 +110,12 @@ class YourWorkflow:
 ```
 The input format for `summary` is a string, and limited to 200 bytes.
 
-## Viewing Summary and Details in the UI
+## Viewing summary and details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI. 
 Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
-### Workflow Overview Section
+### Workflow overview section
 
 At the top of the Workflow details page, you'll find the Workflow-level metadata:
 

--- a/docs/develop/python/set-up.mdx
+++ b/docs/develop/python/set-up.mdx
@@ -148,7 +148,7 @@ Once you have everything installed, you're ready to build apps with Temporal on 
 </SetupStep>
 </SetupSteps>
 
-## Run Hello World: Test Your Installation
+## Run Hello World: Test your installation
 
 Now let's verify your setup is working by creating and running a complete Temporal application with both a Workflow and
 Activity.
@@ -283,7 +283,7 @@ source env/bin/activate
 python3 starter.py
 ```
 
-### Verify Success
+### Verify success
 
 If everything is working correctly, you should see:
 

--- a/docs/develop/python/workers/interceptors.mdx
+++ b/docs/develop/python/workers/interceptors.mdx
@@ -68,7 +68,7 @@ client = await Client.connect(
 The `interceptors` list can contain multiple interceptors.
 In this case they form a chain: a method implemented on an interceptor instance in the list can perform side effects, and modify the data, before passing it on to the corresponding method on the next interceptor in the list.
 
-### Register via a Plugin
+### Register via a plugin
 
 If you're building a reusable library or want to bundle interceptors with other primitives, you can register them through a [Plugin](/develop/plugins-guide#interceptors).
 

--- a/docs/develop/python/workflows/continue-as-new.mdx
+++ b/docs/develop/python/workflows/continue-as-new.mdx
@@ -65,7 +65,7 @@ workflow.continue_as_new(
 )
 ````
 
-### Considerations for Workflows with Message Handlers {/* #with-message-handlers */}
+### Considerations for Workflows with message handlers {/* #with-message-handlers */}
 
 If you use Updates or Signals, don't call Continue-as-New from the handlers.
 Instead, wait for your handlers to finish in your main Workflow before you run `continue_as_new`.

--- a/docs/develop/ruby/best-practices/error-handling.mdx
+++ b/docs/develop/ruby/best-practices/error-handling.mdx
@@ -19,7 +19,7 @@ tags:
   - Errors
 ---
 
-## Raise and Handle Exceptions {/* #exception-handling */}
+## Raise and handle exceptions {/* #exception-handling */}
 
 In each Temporal SDK, error handling is implemented idiomatically, following the conventions of the language.
 Temporal uses several different error classes internally — for example, [`CancelledError`](https://ruby.temporal.io/Temporalio/Error/CanceledError.html) in the Ruby SDK, to handle a Workflow cancellation. 

--- a/docs/develop/ruby/platform/enriching-ui.mdx
+++ b/docs/develop/ruby/platform/enriching-ui.mdx
@@ -20,7 +20,7 @@ tags:
 Temporal supports adding context to Workflows and Events with metadata. 
 This helps users identify and understand Workflows and their operations.
 
-## Adding Summary and Details to Workflows
+## Adding summary and details to Workflows
 
 ### Starting a Workflow
 
@@ -124,12 +124,12 @@ end
 
 The input format for `summary:` is a string, and limited to 200 bytes.
 
-## Viewing Summary and Details in the UI
+## Viewing summary and details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI. 
 Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
-### Workflow Overview Section
+### Workflow overview section
 
 At the top of the workflow details page, you'll find the workflow-level metadata:
 

--- a/docs/develop/ruby/platform/observability.mdx
+++ b/docs/develop/ruby/platform/observability.mdx
@@ -60,7 +60,7 @@ Temporalio::Runtime.default = Temporalio::Runtime.new(
 Instead of Prometheus or OpenTelemetry, an instance of `Temporalio::Runtime::MetricBuffer` can be provided as a `buffer` argument to the `MetricsOptions`.
 `retrieve_updates` can then be periodically called on the buffer to get metric updates.
 
-## Setup Tracing {/* #tracing */}
+## Set up tracing {/* #tracing */}
 
 Tracing enables observability into the sequence of calls across your application, including Workflows and Activities.
 

--- a/docs/develop/ruby/set-up.mdx
+++ b/docs/develop/ruby/set-up.mdx
@@ -164,7 +164,7 @@ Once you have everything installed, you're ready to build apps with Temporal on 
 </SetupStep>
 </SetupSteps>
 
-## Run Hello World: Test Your Installation
+## Run Hello World: Test your installation
 
 Now let's verify your setup is working by creating and running a complete Temporal application with both a Workflow and
 Activity.
@@ -276,7 +276,7 @@ Then run:
 ruby starter.rb
 ```
 
-### Verify Success
+### Verify success
 
 If everything is working correctly, you should see:
 

--- a/docs/develop/ruby/workflows/cancellation.mdx
+++ b/docs/develop/ruby/workflows/cancellation.mdx
@@ -107,7 +107,7 @@ class MyActivity < Temporalio::Activity::Definition
 end
 ```
 
-## Request Cancellation {/* #request-cancellation */}
+## Request cancellation {/* #request-cancellation */}
 
 Use `cancel` on the `WorkflowHandle` to cancel a Workflow Execution.
 

--- a/docs/develop/rust/quickstart.mdx
+++ b/docs/develop/rust/quickstart.mdx
@@ -47,7 +47,7 @@ After installation, verify it's working by checking the version. You'll also nee
 </>
 }>
 
-## Create a Project
+## Create a project
 
 Now that you have Rust and Cargo installed, create a new Rust project to manage your dependencies.
 
@@ -170,7 +170,7 @@ Leave the local Temporal Service running as you work through tutorials and other
 </SetupStep>
 </SetupSteps>
 
-## Run Hello World: Test Your Installation
+## Run Hello World: Test your installation
 
 Now let's verify your setup is working by creating and running a complete Temporal application with both a Workflow and Activity.
 
@@ -296,7 +296,7 @@ temporal workflow start \
   --input '"Ziggy"'
 ```
 
-## Next Steps
+## Next steps
 
 Now that you have the basics working, explore the following resources to build more sophisticated applications:
 

--- a/docs/develop/typescript/nexus/quickstart.mdx
+++ b/docs/develop/typescript/nexus/quickstart.mdx
@@ -288,7 +288,7 @@ main().catch((err) => {
 </>
 }>
 
-## 6. Run and Verify
+## 6. Run and verify
 
 Create a file called `caller-starter.ts` to start the caller Worker and execute the Workflow.
 
@@ -321,7 +321,7 @@ You should see `NexusOperationScheduled`, `NexusOperationStarted`, and `NexusOpe
 </SetupStep>
 </SetupSteps>
 
-## Next Steps
+## Next steps
 
 Now that you have a working Nexus Service, here are some resources to deepen your understanding:
 

--- a/docs/develop/typescript/platform/enriching-ui.mdx
+++ b/docs/develop/typescript/platform/enriching-ui.mdx
@@ -20,7 +20,7 @@ tags:
 Temporal supports adding context to Workflows and Events with metadata. 
 This helps users identify and understand Workflows and their operations.
 
-## Adding Summary and Details to Workflows
+## Adding summary and details to Workflows
 
 ### Starting a Workflow
 
@@ -119,12 +119,12 @@ export async function yourWorkflow(input: string): Promise<string> {
 
 The input format for `summary` is a string, and limited to 200 bytes.
 
-## Viewing Summary and Details in the UI
+## Viewing summary and details in the UI
 
 Once you've added summaries and details to your Workflows, Activities, and Timers, you can view this enriched information in the Temporal Web UI.
 Navigate to your Workflow's details page to see the metadata displayed in three key locations:
 
-### Workflow Overview Section
+### Workflow overview section
 
 At the top of the workflow details page, you'll find the workflow-level metadata:
 

--- a/docs/develop/typescript/set-up.mdx
+++ b/docs/develop/typescript/set-up.mdx
@@ -134,7 +134,7 @@ Once you have everything installed, you're ready to build apps with Temporal on 
 </SetupStep>
 </SetupSteps>
 
-## Run Hello World: Test Your Installation
+## Run Hello World: Test your installation
 
 Now let's verify your setup is working by creating and running a complete Temporal application with both a Workflow and
 Activity.
@@ -299,7 +299,7 @@ Then run:
 npm run workflow
 ```
 
-### Verify Success
+### Verify success
 
 If everything is working correctly, you should see:
 

--- a/docs/develop/typescript/workers/interceptors.mdx
+++ b/docs/develop/typescript/workers/interceptors.mdx
@@ -112,7 +112,7 @@ export class NexusOperationLogInterceptor implements NexusInboundCallsIntercepto
 
 Registering an interceptor means providing it to the SDK so Temporal can invoke it when matching Client or Worker calls occur. Once registered, it runs in the call path and can observe or modify request and response data.
 
-### Register via a Plugin
+### Register via a plugin
 
 If you're building a reusable library or want to bundle interceptors with other primitives, you can register them
 through a [Plugin](/develop/plugins-guide#interceptors).

--- a/docs/develop/typescript/workflows/continue-as-new.mdx
+++ b/docs/develop/typescript/workflows/continue-as-new.mdx
@@ -61,7 +61,7 @@ return await wf.continueAsNew<typeof clusterManagerWorkflow>({
 });
 ````
 
-### Considerations for Workflows with Message Handlers {/* #with-message-handlers */}
+### Considerations for Workflows with message handlers {/* #with-message-handlers */}
 
 If you use Updates or Signals, don't call Continue-as-New from the handlers.
 Instead, wait for your handlers to finish in your main Workflow before you run `ContinueAsNew`.

--- a/docs/develop/typescript/workflows/timeouts.mdx
+++ b/docs/develop/typescript/workflows/timeouts.mdx
@@ -19,12 +19,12 @@ tags:
 
 This page shows how to do the following:
 
-- [Raise and Handle Exceptions](#exception-handling)
+- [Raise and handle exceptions](#exception-handling)
 - [Deliberately Fail Workflows](#workflow-failure)
 - [Workflow Timeouts](#workflow-timeouts)
 - [Workflow retries](#workflow-retries)
 
-## Raise and Handle Exceptions {/* #exception-handling */}
+## Raise and handle exceptions {/* #exception-handling */}
 
 In each Temporal SDK, error handling is implemented idiomatically, following the conventions of the language.
 Temporal uses several different error classes internally — for example, [`CancelledFailure`](https://typescript.temporal.io/api/classes/common.CancelledFailure) in the Typescript SDK, to handle a Workflow cancellation. 

--- a/docs/develop/worker-performance.mdx
+++ b/docs/develop/worker-performance.mdx
@@ -898,7 +898,7 @@ Consider manual adjustment if:
 
 Then consider increasing the number of pollers by adjusting `maxConcurrentWorkflowTaskPollers` or `maxConcurrentActivityTaskPollers`, depending on which type of `schedule_to_start` metric is elevated.
 
-### Rate Limiting
+### Rate limiting
 
 If, after adjusting the poller and executors count as specified earlier, you still observe an elevated `schedule_to_start`, underutilized Worker hosts, or high `worker_task_slots_available`, you might want to check the following:
 

--- a/docs/encyclopedia/event-history/dotnet.mdx
+++ b/docs/encyclopedia/event-history/dotnet.mdx
@@ -35,12 +35,12 @@ import PhotoCarousel from '@site/src/components/elements/PhotoCarousel';
 
 In order to understand how Workflow Replay works, this page will go through the following walkthroughs:
 
-1. [How Workflow Code Maps to Commands](#How-Workflow-Code-Maps-To-Commands)
-2. [How Workflow Commands Map to Events](#How-Workflow-Commands-Map-To-Events)
-3. [How History Replay Provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
+1. [How Workflow code maps to commands](#How-Workflow-Code-Maps-To-Commands)
+2. [How Workflow commands map to events](#How-Workflow-Commands-Map-To-Events)
+3. [How History replay provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
 4. [Example of a Non-Deterministic Workflow](#Example-of-Non-Deterministic-Workflow)
 
-## How Workflow Code Maps to Commands {/* #How-Workflow-Code-Maps-To-Commands */}
+## How Workflow code maps to commands {/* #How-Workflow-Code-Maps-To-Commands */}
 
 This walkthrough will cover how the Workflow code maps to Commands that get sent to the Temporal Service, letting the
 Temporal Service know what to do.
@@ -75,7 +75,7 @@ images={[
   ]}
 />
 
-## How Workflow Commands Map to Events {/* #How-Workflow-Commands-Map-To-Events */}
+## How Workflow commands map to events {/* #How-Workflow-Commands-Map-To-Events */}
 
 The Commands that are sent to the Temporal Service are then turned into Events, which build up the Event History. The
 Event History is a detailed log of Events that occur during the lifecycle of a Workflow Execution, such as the execution
@@ -119,7 +119,7 @@ These Events are what are used to recreate a Workflow Execution's state in the c
   ]}
 />
 
-## How History Replay Provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
+## How History replay provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
 
 Now that you have seen how code maps to Commands, and how Commands map to Events, this next walkthrough will take a look
 at how Temporal uses Replay with the Events to provide Durable Execution and restore a Workflow Execution in the case of
@@ -311,7 +311,7 @@ For more information on how Temporal handles Durable Execution or to see these s
 explanation, check out our free, self-paced courses: [Temporal 102](https://learn.temporal.io/courses/temporal_102/) and
 [Versioning Workflows](https://learn.temporal.io/courses/versioning/).
 
-## Temporal Applications Support Non-Deterministic Operations
+## Temporal applications support Non-Deterministic Operations
 
 We want to emphasize that although your Workflows themselves need to be deterministic, your application itself does not!
 

--- a/docs/encyclopedia/event-history/go.mdx
+++ b/docs/encyclopedia/event-history/go.mdx
@@ -34,12 +34,12 @@ import PhotoCarousel from '@site/src/components/elements/PhotoCarousel';
 
 In order to understand how Workflow Replay works, this page will go through the following walkthroughs:
 
-1. [How Workflow Code Maps to Commands](#How-Workflow-Code-Maps-To-Commands)
-2. [How Workflow Commands Map to Events](#How-Workflow-Commands-Map-To-Events)
-3. [How History Replay Provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
+1. [How Workflow code maps to commands](#How-Workflow-Code-Maps-To-Commands)
+2. [How Workflow commands map to events](#How-Workflow-Commands-Map-To-Events)
+3. [How History replay provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
 4. [Example of a Non-Deterministic Workflow](#Example-of-Non-Deterministic-Workflow)
 
-## How Workflow Code Maps to Commands {/* #How-Workflow-Code-Maps-To-Commands */}
+## How Workflow code maps to commands {/* #How-Workflow-Code-Maps-To-Commands */}
 
 This walkthrough will cover how the Workflow code maps to Commands that get sent to the Temporal Service, letting the
 Temporal Service know what to do.
@@ -73,7 +73,7 @@ Temporal Service know what to do.
   ]}
 />
 
-## How Workflow Commands Map to Events {/* #How-Workflow-Commands-Map-To-Events */}
+## How Workflow commands map to events {/* #How-Workflow-Commands-Map-To-Events */}
 
 The Commands that are sent to the Temporal Service are then turned into Events, which build up the Event History. The
 Event History is a detailed log of Events that occur during the lifecycle of a Workflow Execution, such as the execution
@@ -117,7 +117,7 @@ These Events are what are used to recreate a Workflow Execution's state in the c
   ]}
 />
 
-## How History Replay Provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
+## How History replay provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
 
 Now that you have seen how code maps to Commands, and how Commands map to Events, this next walkthrough will take a look
 at how Temporal uses Replay with the Events to provide Durable Execution and restore a Workflow Execution in the case of
@@ -324,7 +324,7 @@ For more information on how Temporal handles Durable Execution or to see these s
 explanation, check out our free, self-paced courses: [Temporal 102](https://learn.temporal.io/courses/temporal_102/) and
 [Versioning Workflows](https://learn.temporal.io/courses/versioning/).
 
-## Temporal Applications Support Non-Deterministic Operations
+## Temporal applications support Non-Deterministic Operations
 
 We want to emphasize that although your Workflows themselves need to be deterministic, your application itself does not!
 

--- a/docs/encyclopedia/event-history/java.mdx
+++ b/docs/encyclopedia/event-history/java.mdx
@@ -34,12 +34,12 @@ import PhotoCarousel from '@site/src/components/elements/PhotoCarousel';
 
 In order to understand how Workflow Replay works, this page will go through the following walkthroughs:
 
-1. [How Workflow Code Maps to Commands](#How-Workflow-Code-Maps-To-Commands)
-2. [How Workflow Commands Map to Events](#How-Workflow-Commands-Map-To-Events)
-3. [How History Replay Provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
+1. [How Workflow code maps to commands](#How-Workflow-Code-Maps-To-Commands)
+2. [How Workflow commands map to events](#How-Workflow-Commands-Map-To-Events)
+3. [How History replay provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
 4. [Example of a Non-Deterministic Workflow](#Example-of-Non-Deterministic-Workflow)
 
-## How Workflow Code Maps to Commands {/* #How-Workflow-Code-Maps-To-Commands */}
+## How Workflow code maps to commands {/* #How-Workflow-Code-Maps-To-Commands */}
 
 This walkthrough will cover how the Workflow code maps to Commands that get sent to the Temporal Service, letting the
 Temporal Service know what to do.
@@ -73,7 +73,7 @@ Temporal Service know what to do.
   ]}
 />
 
-## How Workflow Commands Map to Events {/* #How-Workflow-Commands-Map-To-Events */}
+## How Workflow commands map to events {/* #How-Workflow-Commands-Map-To-Events */}
 
 The Commands that are sent to the Temporal Service are then turned into Events, which build up the Event History. The
 Event History is a detailed log of Events that occur during the lifecycle of a Workflow Execution, such as the execution
@@ -117,7 +117,7 @@ These Events are what are used to recreate a Workflow Execution's state in the c
   ]}
 />
 
-## How History Replay Provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
+## How History replay provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
 
 Now that you have seen how code maps to Commands, and how Commands map to Events, this next walkthrough will take a look
 at how Temporal uses Replay with the Events to provide Durable Execution and restore a Workflow Execution in the case of
@@ -316,7 +316,7 @@ For more information on how Temporal handles Durable Execution or to see these s
 explanation, check out our free, self-paced courses: [Temporal 102](https://learn.temporal.io/courses/temporal_102/) and
 [Versioning Workflows](https://learn.temporal.io/courses/versioning/).
 
-## Temporal Applications Support Non-Deterministic Operations
+## Temporal applications support Non-Deterministic Operations
 
 We want to emphasize that although your Workflows themselves need to be deterministic, your application itself does not!
 

--- a/docs/encyclopedia/event-history/python.mdx
+++ b/docs/encyclopedia/event-history/python.mdx
@@ -34,12 +34,12 @@ import PhotoCarousel from '@site/src/components/elements/PhotoCarousel';
 
 In order to understand how Workflow Replay works, this page will go through the following walkthroughs:
 
-1. [How Workflow Code Maps to Commands](#How-Workflow-Code-Maps-To-Commands)
-2. [How Workflow Commands Map to Events](#How-Workflow-Commands-Map-To-Events)
-3. [How History Replay Provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
+1. [How Workflow code maps to commands](#How-Workflow-Code-Maps-To-Commands)
+2. [How Workflow commands map to events](#How-Workflow-Commands-Map-To-Events)
+3. [How History replay provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
 4. [Example of a Non-Deterministic Workflow](#Example-of-Non-Deterministic-Workflow)
 
-## How Workflow Code Maps to Commands {/* #How-Workflow-Code-Maps-To-Commands */}
+## How Workflow code maps to commands {/* #How-Workflow-Code-Maps-To-Commands */}
 
 This walkthrough will cover how the Workflow code maps to Commands that get sent to the Temporal Service, letting the
 Temporal Service know what to do.
@@ -73,7 +73,7 @@ Temporal Service know what to do.
   ]}
 />
 
-## How Workflow Commands Map to Events {/* #How-Workflow-Commands-Map-To-Events */}
+## How Workflow commands map to events {/* #How-Workflow-Commands-Map-To-Events */}
 
 The Commands that are sent to the Temporal Service are then turned into Events, which build up the Event History. The
 Event History is a detailed log of Events that occur during the lifecycle of a Workflow Execution, such as the execution
@@ -117,7 +117,7 @@ These Events are what are used to recreate a Workflow Execution's state in the c
   ]}
 />
 
-## How History Replay Provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
+## How History replay provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
 
 Now that you have seen how code maps to Commands, and how Commands map to Events, this next walkthrough will take a look
 at how Temporal uses Replay with the Events to provide Durable Execution and restore a Workflow Execution in the case of
@@ -318,7 +318,7 @@ For more information on how Temporal handles Durable Execution or to see these s
 explanation, check out our free, self-paced courses: [Temporal 102](https://learn.temporal.io/courses/temporal_102/) and
 [Versioning Workflows](https://learn.temporal.io/courses/versioning/).
 
-## Temporal Applications Support Non-Deterministic Operations
+## Temporal applications support Non-Deterministic Operations
 
 We want to emphasize that although your Workflows themselves need to be deterministic, your application itself does not!
 

--- a/docs/encyclopedia/event-history/typescript.mdx
+++ b/docs/encyclopedia/event-history/typescript.mdx
@@ -34,12 +34,12 @@ import PhotoCarousel from '@site/src/components/elements/PhotoCarousel';
 
 In order to understand how Workflow Replay works, this page will go through the following walkthroughs:
 
-1. [How Workflow Code Maps to Commands](#How-Workflow-Code-Maps-To-Commands)
-2. [How Workflow Commands Map to Events](#How-Workflow-Commands-Map-To-Events)
-3. [How History Replay Provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
+1. [How Workflow code maps to commands](#How-Workflow-Code-Maps-To-Commands)
+2. [How Workflow commands map to events](#How-Workflow-Commands-Map-To-Events)
+3. [How History replay provides Durable Execution](#How-History-Replay-Provides-Durable-Execution)
 4. [Example of a Non-Deterministic Workflow](#Example-of-Non-Deterministic-Workflow)
 
-## How Workflow Code Maps to Commands {/* #How-Workflow-Code-Maps-To-Commands */}
+## How Workflow code maps to commands {/* #How-Workflow-Code-Maps-To-Commands */}
 
 This walkthrough will cover how the Workflow code maps to Commands that get sent to the Temporal Service, letting the
 Temporal Service know what to do.
@@ -75,7 +75,7 @@ Temporal Service know what to do.
   ]}
 />
 
-## How Workflow Commands Map to Events {/* #How-Workflow-Commands-Map-To-Events */}
+## How Workflow commands map to events {/* #How-Workflow-Commands-Map-To-Events */}
 
 The Commands that are sent to the Temporal Service are then turned into Events, which build up the Event History. The
 Event History is a detailed log of Events that occur during the lifecycle of a Workflow Execution, such as the execution
@@ -119,7 +119,7 @@ These Events are what are used to recreate a Workflow Execution's state in the c
   ]}
 />
 
-## How History Replay Provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
+## How History replay provides Durable Execution {/* #How-History-Replay-Provides-Durable-Execution */}
 
 Now that you have seen how code maps to Commands, and how Commands map to Events, this next walkthrough will take a look
 at how Temporal uses Replay with the Events to provide Durable Execution and restore a Workflow Execution in the case of
@@ -320,7 +320,7 @@ For more information on how Temporal handles Durable Execution or to see these s
 explanation, check out our free, self-paced courses: [Temporal 102](https://learn.temporal.io/courses/temporal_102/) and
 [Versioning Workflows](https://learn.temporal.io/courses/versioning/).
 
-## Temporal Applications Support Non-Deterministic Operations
+## Temporal applications support Non-Deterministic Operations
 
 We want to emphasize that although your Workflows themselves need to be deterministic, your application itself does not!
 

--- a/docs/encyclopedia/temporal-service/multi-cluster-replication.mdx
+++ b/docs/encyclopedia/temporal-service/multi-cluster-replication.mdx
@@ -20,7 +20,7 @@ tags:
 This page discusses the following:
 
 - [Multi-Cluster Replication](#multi-cluster-replication)
-- [Namespace Versions](#namespace-versions)
+- [Namespace versions](#namespace-versions)
 - [Version History](#version-history)
 - [Conflict Resolution](#conflict-resolution)
 - [Zombie Workflows](#zombie-workflows)
@@ -44,7 +44,7 @@ This enables [Temporal UI](/web-ui) to work seamlessly for Global Namespaces.
 Applications making API calls directly to the Temporal Visibility API continue to work even if a Global Namespace is in standby mode.
 However, they might see a lag due to replication delay when querying the Workflow Execution state from a standby Cluster.
 
-## Namespace Versions
+## Namespace versions
 
 A _version_ is a concept in Multi-Cluster Replication that describes the chronological order of events per Namespace.
 

--- a/docs/production-deployment/self-hosted-guide/multi-cluster-replication.mdx
+++ b/docs/production-deployment/self-hosted-guide/multi-cluster-replication.mdx
@@ -31,7 +31,7 @@ This enables [Temporal UI](/web-ui) to work seamlessly for Global Namespaces.
 Applications making API calls directly to the Temporal Visibility API continue to work even if a Global Namespace is in standby mode.
 However, they might see a lag due to replication delay when querying the Workflow Execution state from a standby Cluster.
 
-#### Namespace Versions
+#### Namespace versions
 
 A _version_ is a concept in Multi-Cluster Replication that describes the chronological order of events per Namespace.
 

--- a/vale/styles/Temporal/Headings.yml
+++ b/vale/styles/Temporal/Headings.yml
@@ -179,3 +179,19 @@ exceptions:
   - Terraform
   - Prometheus
   - Grafana
+  # Company / product proper nouns
+  - Amazon
+  - Google
+  - Microsoft
+  - S3
+  # Temporal Cloud feature names
+  - Ops
+  - Audit
+  - Log
+  - Saved
+  - View
+  - Actions
+  - Non-Deterministic
+  # Conventional programming idiom
+  - Hello
+  - World

--- a/vale/test/headings-good.md
+++ b/vale/test/headings-good.md
@@ -51,3 +51,9 @@
 ## Configure mTLS and PrivateLink for AWS
 
 ## Worker Versioning and Patching
+
+## Store and retrieve large payloads with Amazon S3
+
+## Create a Saved View
+
+## Run Hello World: Test your installation


### PR DESCRIPTION
## Summary
Follow-up to #4983. Two related changes, bundled since they serve the same goal (reducing `Temporal.Headings` false positives / noise):

- **More exceptions**: while combing through remaining flags to find content worth fixing, found more proper nouns that were tripping the rule on already-correctly-cased headings: brand/product names (`Amazon`, `Google`, `Microsoft`, `S3`), Temporal Cloud feature names (`Ops`, `Audit`, `Log`, `Saved`, `View`, `Actions`, `Non-Deterministic` — all verified as consistently capitalized in prose, e.g. "Cloud Ops API", "Audit Log", "Saved View"), and the `Hello`/`World` programming idiom used across every SDK's setup guide.
- **Content fixes**: sentence-cased the recurring title-case headings duplicated across the per-SDK-language doc sets — `Next Steps`, `Verify Success`, `Best Practices:`, `Considerations for Workflows with Message Handlers`, the `encyclopedia/event-history/*` "How Workflow code maps to commands / How Workflow commands map to events / How History replay provides Durable Execution" trio, and a handful of one-offs (`Rate Limiting`, `Query Parameters`, `Namespace Versions`, `Create a Project`). Also formatted `` `GetVersion` `` as inline code in a heading instead of leaving it as bare prose text.
- Matching table-of-contents link text was updated alongside each renamed heading; anchor IDs are untouched (Docusaurus slugs are case-insensitive, so links don't break).

Left the long tail of one-off headings (single-occurrence title-case violations, third-party proper nouns like PKCS8/Route 53/JUnit) out of scope for this pass.

## Test plan
- [x] `vale --config=.vale-ci.ini docs/` — live `Temporal.Headings` suggestions drop from 446 to 340, 0 errors
- [x] `vale --config=.vale-ci.ini vale/test/headings-good.md` / `headings-bad.md` — new exceptions covered, no regressions
- [x] Compiled every changed `.mdx` file with `@mdx-js/mdx` directly — all pass (2 pre-existing unrelated compile failures confirmed present on `main` before this change too)
- [x] Grepped for cross-file links to the renamed anchors — none found; only same-file TOC links, which were updated in place

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1216967487390814">EDU-6837 fix(vale): sentence-case recurring headings; more Temporal.Headings exceptions</a>
