### PR TITLE
update nexus page to include default limits for policy specs

### DIFF
--- a/docs/cloud/nexus/limits.mdx
+++ b/docs/cloud/nexus/limits.mdx
@@ -23,7 +23,7 @@ Nexus limits are documented in [Temporal Cloud limits](/cloud/limits):
 
 - [Nexus rate limits](/cloud/limits#nexus-rate-limits) - Nexus requests count toward the Namespace RPS limit.
 - [Nexus Endpoint limits](/cloud/limits#nexus-endpoints-limits) - 100 Endpoints per Account (default).
-- [Nexus caller Namespace limits](/cloud/limits#nexus-endpoint-access-policy-limits) - 1,000 caller Namespaces per Endpoint.
+- [Nexus caller Namespace limits](/cloud/limits#nexus-endpoint-access-policy-limits) - 1,000 caller Namespaces per Endpoint (default).
 - [Per-Workflow Nexus Operation limits](/cloud/limits#per-workflow-nexus-operation-limits) - 30 in-flight Operations per Workflow.
 - [Nexus Operation request timeout](/cloud/limits#nexus-operation-request-timeout) - Less than 10 seconds for a handler to process a start or cancel request.
 - [Nexus Operation duration limits](/cloud/limits#nexus-operation-duration-limits) - 60-day maximum ScheduleToClose duration.

--- a/docs/evaluate/temporal-cloud/limits.mdx
+++ b/docs/evaluate/temporal-cloud/limits.mdx
@@ -216,7 +216,8 @@ You can request further increases beyond the initial 100 Endpoint limit by [open
 
 ### Nexus caller Namespace limits {/* #nexus-endpoint-access-policy-limits */}
 
-A single Nexus Endpoint can have a maximum of 1,000 caller Namespaces in its [Access Policy](/nexus/security#runtime-access-controls), the allowlist of Namespaces permitted to use the Endpoint.
+By default, a single Nexus Endpoint can have a maximum of 1,000 caller Namespaces in its [Access Policy](/nexus/security#runtime-access-controls), the allowlist of Namespaces permitted to use the Endpoint.
+You can request further increases beyond the initial 1,000 caller Namespace limit by [opening a support ticket](/cloud/support#support-ticket).
 
 ## Programming model level
 


### PR DESCRIPTION
## What does this PR do?
- defines the default limit for nexus caller limits
- inform user to reach out to support if they request larger limits

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217000776929601">EDU-6844 update nexus page to include default limits for policy specs</a>
