### PR TITLE
Cross-link Design Patterns and Guides

### DIFF
--- a/docs/best-practices/error-handling.mdx
+++ b/docs/best-practices/error-handling.mdx
@@ -123,7 +123,7 @@ consistent across retries but unique across Workflow Executions.
 ## Implement compensation with the Saga pattern {/* #saga-pattern */}
 
 When a multi-step process fails partway through, previous steps may need to be undone. The
-[Saga pattern](/evaluate/use-cases-design-patterns#saga) coordinates a sequence of operations where each step has a
+[Saga pattern](/design-patterns/saga-pattern) coordinates a sequence of operations where each step has a
 compensating action that reverses its effects. If any step fails, the compensating actions for previously completed
 steps execute in reverse order.
 

--- a/docs/design-patterns/approval.mdx
+++ b/docs/design-patterns/approval.mdx
@@ -863,6 +863,10 @@ If the approver's interface needs immediate confirmation that the approval was a
 - [Updatable Timer](/design-patterns/updatable-timer): Extending approval deadlines dynamically.
 - [Saga Pattern](/design-patterns/saga-pattern): Executing compensating actions on rejection.
 
+## Guides
+
+- [Reliable document approvals](/guides/reliable-document-approvals): A complete Python implementation with SLA timers, automatic escalation, resubmission loops, and audit logging.
+
 ## Sample code
 
 **Java**

--- a/docs/design-patterns/batch-iterator.mdx
+++ b/docs/design-patterns/batch-iterator.mdx
@@ -244,7 +244,7 @@ public class BatchIteratorWorkflowImpl implements BatchIteratorWorkflow {
 - **Passing unnecessary state into `continueAsNew`.** All arguments are serialized and stored in history. Pass only the minimal state needed (offset, counters) — not accumulated result lists or large collections that grow with each page.
 - **Sequential processing bottlenecks.** The default implementation processes one record at a time per page. You can fan out Activities concurrently within a page using the SDK's async primitives for higher per-page throughput — note this increases per-page event count accordingly. If record-set-wide throughput matters more than rate limiting, consider [Sliding Window](/design-patterns/sliding-window) or [MapReduce Tree](/design-patterns/mapreduce-tree).
 
-## Related resources
+## Related patterns
 
 - [Continue-as-New pattern](/design-patterns/continue-as-new) — core concepts for history management via `continueAsNew`
 - [Sliding Window](/design-patterns/sliding-window) — bounded concurrency that progresses at the rate of the fastest processor

--- a/docs/design-patterns/continue-as-new.mdx
+++ b/docs/design-patterns/continue-as-new.mdx
@@ -414,6 +414,11 @@ You cannot undo Continue-As-New once triggered.
 - **[Child Workflows](/design-patterns/child-workflows)**: Decomposing work into sub-Workflows. Consider Parent Close Policy when combining with Continue-As-New.
 - **[Signal with Start](/design-patterns/signal-with-start)**: Idempotent Workflow start with an initial Signal — use Workflow ID without Run ID to interact with continued executions.
 
+## Guides
+
+- [Track customer loyalty points with durable Workflows](/guides/entity-pattern-loyalty-points): Uses Continue-As-New to keep a long-lived customer loyalty account within Event History limits, including an upgrade path at the Continue-As-New boundary for Worker Versioning.
+- [Player Sessions That Survive Anything](/guides/durable-gaming-sessions): Uses Continue-As-New so a multiplayer game session can run for weeks without unbounded history growth.
+
 ## Sample code
 
 **Java:**

--- a/docs/design-patterns/downstream-rate-limiting.mdx
+++ b/docs/design-patterns/downstream-rate-limiting.mdx
@@ -287,6 +287,10 @@ The concurrency slots (`MaxConcurrentActivityExecutionSize`, `MaxConcurrentWorkf
 - **[Fairness](/design-patterns/fairness)**: Give each tenant an equal throughput share when multiple tenants share capacity.
 - **[Worker-Specific Task Queues](/design-patterns/worker-specific-taskqueue)**: Route Activities to a specific Worker host for resource or data affinity.
 
+## Guides
+
+- [Rate-limit downstream APIs with separate Task Queues](/guides/rate-limit-downstream-apis): A Python walkthrough covering multiple rate-limited APIs (SendGrid, Stripe, OpenAI), 429 handling with `Retry-After`, and backlog draining strategies.
+
 ## References
 
 - **Python** — [`max_task_queue_activities_per_second`](https://python.temporal.io/temporalio.worker.WorkerConfig.html#max_task_queue_activities_per_second) on [`Worker`](https://python.temporal.io/temporalio.worker.Worker.html)

--- a/docs/design-patterns/entity-workflow.mdx
+++ b/docs/design-patterns/entity-workflow.mdx
@@ -536,6 +536,11 @@ Trade-offs:
 - **[Request-Response via Updates](/design-patterns/request-response-via-updates)**: Synchronous operations with validation.
 - **[Signal with Start](/design-patterns/signal-with-start)**: Idempotent Workflow start with an initial Signal.
 
+## Guides
+
+- [Track customer loyalty points with durable Workflows](/guides/entity-pattern-loyalty-points): A complete Python implementation of this pattern, including tier calculation, Continue-As-New, and Worker Versioning for accounts that span years.
+- [Player Sessions That Survive Anything](/guides/durable-gaming-sessions): Extends the Entity Workflow into an Actor Workflow that executes game actions — joining rooms, resolving combat — rather than only holding state.
+
 ## Sample code
 
 **Python:**

--- a/docs/design-patterns/fanout-child-workflows.mdx
+++ b/docs/design-patterns/fanout-child-workflows.mdx
@@ -317,7 +317,7 @@ public class RecordBatchWorkflowImpl implements RecordBatchWorkflow {
 - **Passing large lists of IDs.** Workflow inputs are stored in event history. Passing millions of record IDs as a list will blow the history size limit. Use offset + length instead.
 - **Ignoring child failures.** A failed child does not automatically fail the parent unless you await all results. Always await child handles and handle errors explicitly.
 
-## Related resources
+## Related patterns
 
 - [Child Workflows pattern](/design-patterns/child-workflows) — core concepts for parent/child Workflow coordination
 - [Batch Iterator](/design-patterns/batch-iterator) — unbounded record sets with Continue-as-New pagination

--- a/docs/design-patterns/mapreduce-tree.mdx
+++ b/docs/design-patterns/mapreduce-tree.mdx
@@ -431,7 +431,7 @@ public class NodeWorkflowImpl implements NodeWorkflow {
 - **History bloat in the Root Workflow.** Each child start and signal received adds events to the Root's history. For very large record sets, consider adding an extra tree level to keep the Root from receiving too many direct signals.
 - **Attempting external/downstream writes from Node Workflows.** Nodes may be retried. Any external write in a Node Workflow will be executed multiple times. Keep all side effects in Leaf Workflows (or Activities called by Leaves).
 
-## Related resources
+## Related patterns
 
 - [Fan-Out with Child Workflows](/design-patterns/fanout-child-workflows) — simpler flat fan-out for smaller record sets
 - [Sliding Window](/design-patterns/sliding-window) — bounded concurrency with rate limiting

--- a/docs/design-patterns/non-retryable-errors.mdx
+++ b/docs/design-patterns/non-retryable-errors.mdx
@@ -480,6 +480,10 @@ try {
 - [Resumable Activity](/design-patterns/resumable-activity): Park the Workflow and accept a corrected input via Signal when retries are exhausted.
 - [Error Handling & Retry Patterns](/design-patterns/error-handling-patterns): Overview and decision tree for all retry patterns.
 
+## Guides
+
+- [Recover business processes without restarting](/guides/recover-without-restart): Uses `ApplicationFailure.nonRetryable()` throughout a loan pipeline to distinguish permanent failures that need a human fix from transient ones the default Retry Policy already handles.
+
 ## References
 
 - [Temporal Retry Policies](/encyclopedia/retry-policies)

--- a/docs/design-patterns/resumable-activity.mdx
+++ b/docs/design-patterns/resumable-activity.mdx
@@ -560,3 +560,7 @@ stateDiagram-v2
 - [Fast/Slow Retries](/design-patterns/fast-slow-retries): Infinite patient retries when the downstream system is temporarily unavailable.
 - [Signal with Start](/design-patterns/signal-with-start): Start the Workflow and send the correction Signal atomically.
 - [Error Handling & Retry Patterns](/design-patterns/error-handling-patterns): Overview and decision tree for all retry patterns.
+
+## Guides
+
+- [Recover business processes without restarting](/guides/recover-without-restart): A `recoverableStep` implementation of this pattern in a six-step loan pipeline, with Search Attribute-based routing so operators can find and fix blocked cases.

--- a/docs/design-patterns/saga-pattern.mdx
+++ b/docs/design-patterns/saga-pattern.mdx
@@ -359,3 +359,6 @@ Some operations may not have meaningful compensations.
 - [Java Sample](https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/hello/HelloSaga.java) — Saga with the `Saga` API.
 - [TypeScript Sample](https://github.com/temporalio/samples-typescript/tree/main/saga) — Saga with array-based compensations.
 - [Python Sample](https://github.com/temporalio/samples-python) — Saga with list-based compensations.
+- [.NET Sample](https://github.com/temporalio/samples-dotnet/tree/main/src/Saga) — Saga with `try`/`catch` compensations.
+- [Ruby Sample](https://github.com/temporalio/samples-ruby/tree/main/saga) — Saga with `rescue`-based compensations.
+- [Python SDK implementation guide](/develop/python/best-practices/error-handling#implement-saga-pattern) — Full walkthrough of the compensation-list technique, including retry and rollback code.

--- a/docs/design-patterns/saga-pattern.mdx
+++ b/docs/design-patterns/saga-pattern.mdx
@@ -349,6 +349,10 @@ Some operations may not have meaningful compensations.
 - **[Long-Running Activity](/design-patterns/long-running-activity)**: Heartbeats work well with long-running compensation Activities.
 - **[Early Return](/design-patterns/early-return)**: You can combine Early Return with the Saga pattern to return initialization results before compensation runs.
 
+## Guides
+
+- [Recover business processes without restarting](/guides/recover-without-restart): Adds LIFO saga compensation to a multi-step loan pipeline, with pre-registered compensations and a recoverable rollback loop for compensations that fail.
+
 ## Sample code
 
 - [Go Sample](https://github.com/temporalio/samples-go/tree/main/saga) — Saga with `defer`-based compensations.

--- a/docs/design-patterns/saga-pattern.mdx
+++ b/docs/design-patterns/saga-pattern.mdx
@@ -344,7 +344,7 @@ Some operations may not have meaningful compensations.
 
 ## Related patterns
 
-- **Retry Policies**: Often combined with the Saga pattern to handle transient failures before compensating.
+- **[Error Handling & Retry Patterns](/design-patterns/error-handling-patterns)**: Often combined with the Saga pattern to handle transient failures before compensating.
 - **[Child Workflows](/design-patterns/child-workflows)**: You can use Child Workflows to organize complex Sagas with multiple sub-Sagas.
 - **[Long-Running Activity](/design-patterns/long-running-activity)**: Heartbeats work well with long-running compensation Activities.
 - **[Early Return](/design-patterns/early-return)**: You can combine Early Return with the Saga pattern to return initialization results before compensation runs.

--- a/docs/design-patterns/sliding-window.mdx
+++ b/docs/design-patterns/sliding-window.mdx
@@ -495,10 +495,10 @@ public interface SlidingWindowWorkflow {
 ## Common pitfalls
 
 - **Losing signals across Continue-as-New.** If a child signals before the parent's new run has registered the signal handler, the signal can be buffered and delivered correctly — Temporal buffers signals for existing Workflow IDs. However, ensure the signal handler is registered before any await, not conditionally.
-- **Race between CAN and remaining signal draining.** After `continueAsNew`, the new run must handle signals from children started by the previous run. Pass `startIndex` (the next *unstarted* record) and `active` (the live in-flight count at the moment of CAN) to the new run so it knows how many carried-over children to expect signals from, without re-starting them. The new run folds `active` in with `+=`, so a completion that arrives before `run()` executes is still counted correctly.
+- **Race between Continue-as-New and remaining signal draining.** After `continueAsNew`, the new run must handle signals from children started by the previous run. Pass `startIndex` (the next *unstarted* record) and `active` (the live in-flight count at the moment of CAN) to the new run so it knows how many carried-over children to expect signals from, without re-starting them. The new run folds `active` in with `+=`, so a completion that arrives before `run()` executes is still counted correctly.
 - **Thundering herd on startup.** Starting hundreds of children simultaneously causes a burst of Activity polls. Ramp up the window gradually or use the [Batch Iterator](/design-patterns/batch-iterator) if rate limiting is more important than throughput.
 
-## Related resources
+## Related patterns
 
 - [Continue-as-New pattern](/design-patterns/continue-as-new) — history management fundamentals
 - [Batch Iterator](/design-patterns/batch-iterator) — sequential alternative when ordered, one-at-a-time processing is acceptable

--- a/docs/design-patterns/worker-specific-taskqueue.mdx
+++ b/docs/design-patterns/worker-specific-taskqueue.mdx
@@ -779,6 +779,11 @@ You need to handle cleanup if the Workflow fails mid-process.
 
 - **[Long-Running Activity](/design-patterns/long-running-activity)**: For tracking progress and handling cancellation when the colocated Activities run for minutes or hours.
 
+## Guides
+
+- [Ensure Activity execution on the same Worker](/guides/worker-execution-affinity): A Python walkthrough of the shared-queue-discovers-unique-queue technique, with heartbeat and Schedule-to-Start timeouts for detecting a crashed Worker.
+- [Route specialized workloads](/guides/route-specialized-workloads): Routes Activities to dedicated GPU, high-memory, and CPU Worker pools by resource requirement — a related Task Queue routing technique, but by hardware capability rather than by Worker affinity.
+
 ## Sample code
 
 - [Java Sample](https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/fileprocessing) — Complete file processing implementation.

--- a/docs/develop/dotnet/best-practices/error-handling.mdx
+++ b/docs/develop/dotnet/best-practices/error-handling.mdx
@@ -76,7 +76,7 @@ One of the core design principles of Temporal is that an Activity Failure will n
 The default retry policy associated with Temporal Activities is to retry them until reaching a certain timeout threshold.
 Activities will not actually *return* a failure to your Workflow until this condition or another non-retryable condition is met.
 At this point, you can decide how to handle an error returned by your Activity the way you would in any other program.
-For example, you could implement a [Saga Pattern](https://github.com/temporalio/samples-dotnet/tree/main/src/Saga) that uses `try`/`catch` blocks to "unwind" some of the steps your Workflow has performed up to the point of Activity Failure.
+For example, you could implement a [Saga Pattern](/design-patterns/saga-pattern) — see this [.NET sample](https://github.com/temporalio/samples-dotnet/tree/main/src/Saga) — that uses `try`/`catch` blocks to "unwind" some of the steps your Workflow has performed up to the point of Activity Failure.
 
 **You will only fail a Workflow by manually raising an `ApplicationFailureException` from the Workflow code.**
 You could do this in response to an Activity Failure, if the failure of that Activity means that your Workflow should not continue:

--- a/docs/develop/python/best-practices/error-handling.mdx
+++ b/docs/develop/python/best-practices/error-handling.mdx
@@ -442,7 +442,7 @@ This lets different Workflows make different decisions about the same Activity.
 
 **How to implement the Saga pattern using the Temporal Python SDK**
 
-The Saga pattern coordinates a sequence of operations where each operation has a compensating action to undo its effects.
+The [Saga pattern](/design-patterns/saga-pattern) coordinates a sequence of operations where each operation has a compensating action to undo its effects.
 If any operation fails, execute compensating actions in reverse order to roll back previous operations.
 
 Use this for multi-step processes like:

--- a/docs/develop/ruby/best-practices/error-handling.mdx
+++ b/docs/develop/ruby/best-practices/error-handling.mdx
@@ -80,7 +80,7 @@ One of the core design principles of Temporal is that an Activity Failure will n
 The default retry policy associated with Temporal Activities is to retry them until reaching a certain timeout threshold.
 Activities will not actually *return* a failure to your Workflow until this condition or another non-retryable condition is met.
 At this point, you can decide how to handle an error returned by your Activity the way you would in any other program.
-For example, you could implement a [Saga Pattern](https://github.com/temporalio/samples-ruby/tree/main/saga) that uses `rescue` blocks to "unwind" some of the steps your Workflow has performed up to the point of Activity Failure.
+For example, you could implement a [Saga Pattern](/design-patterns/saga-pattern) — see this [Ruby sample](https://github.com/temporalio/samples-ruby/tree/main/saga) — that uses `rescue` blocks to "unwind" some of the steps your Workflow has performed up to the point of Activity Failure.
 
 **You will only fail a Workflow by manually raising an `ApplicationError` from the Workflow code.**
 You could do this in response to an Activity Failure, if the failure of that Activity means that your Workflow should not continue:

--- a/docs/guides/durable-gaming-sessions.mdx
+++ b/docs/guides/durable-gaming-sessions.mdx
@@ -1291,6 +1291,8 @@ The approach isn't limited to games. Any long-lived entity that has to take acti
 
 ## Related resources
 
+- [Entity Workflow Pattern](/design-patterns/entity-workflow) — pattern catalog reference for the underlying Entity Workflow pattern this Actor Workflow extends
+- [Continue-As-New Pattern](/design-patterns/continue-as-new) — pattern catalog reference covering common pitfalls and history-size triggers
 - [Temporal Python SDK documentation](/develop/python)
 - [Message Passing — Signals, Queries, Updates](/develop/python/workflows/message-passing)
 - [Continue-As-New](/develop/python/workflows/continue-as-new)

--- a/docs/guides/durable-gaming-sessions.mdx
+++ b/docs/guides/durable-gaming-sessions.mdx
@@ -41,10 +41,10 @@ After working through this guide, you'll have a session system where:
 
 ### What is an Actor Workflow?
 
-The Actor Workflow pattern extends the Workflow Entity pattern. An Workflow Entity is a long-running Workflow that represents a *thing*: it holds state, responds to messages, and exposes that state through Queries. An Actor Workflow is an Entity Workflow that *does things*. The distinction is behavioral:
+The Actor Workflow pattern extends the [Entity Workflow pattern](/design-patterns/entity-workflow). An Entity Workflow is a long-running Workflow that represents a *thing*: it holds state, responds to messages, and exposes that state through Queries. An Actor Workflow is an Entity Workflow that *does things*. The distinction is behavioral:
 
 - **An entity is a thing. An actor is a thing that does things.**
-- An Workflow Entity is analogous to a distributed data cache: it stores and retrieves state.
+- An Entity Workflow is analogous to a distributed data cache: it stores and retrieves state.
 - An Actor Workflow is analogous to a distributed object with operations: it stores state *and* executes side effects on behalf of the entity it represents.
 
 An Entity Workflow that takes action is an Actor Workflow. Concrete examples of actors include a Workflow that scales up a database when load increases, starts a car engine when a driver authenticates, submits an order when a customer confirms checkout, or manages a player session in a multiplayer game by joining rooms and executing combat moves.

--- a/docs/guides/entity-pattern-loyalty-points.mdx
+++ b/docs/guides/entity-pattern-loyalty-points.mdx
@@ -54,7 +54,7 @@ In the loyalty points use case, each customer has their own Entity Workflow. The
 
 ### How Entity Workflows differ from actors
 
-The Entity Workflow pattern shares characteristics with the Actor Model: both receive messages, maintain state, and can create new instances. However, there is an important distinction. An entity **represents state** and responds to interactions. It is closer to a data cache than a process orchestrator. It holds and serves state, evaluates business rules against that state, and delegates side effects to Activities. An actor, by contrast, **takes actions**. It may write to databases, call external APIs, or send emails as part of its core behavior.
+The [Entity Workflow pattern](/design-patterns/entity-workflow) shares characteristics with the Actor Model: both receive messages, maintain state, and can create new instances. However, there is an important distinction. An entity **represents state** and responds to interactions. It is closer to a data cache than a process orchestrator. It holds and serves state, evaluates business rules against that state, and delegates side effects to Activities. An actor, by contrast, **takes actions**. It may write to databases, call external APIs, or send emails as part of its core behavior.
 
 In this pattern, the loyalty Entity Workflow does not directly write to a database or send an email. When it needs a side effect, such as sending a tier upgrade notification, it delegates that work to an Activity. The Workflow itself remains a pure state container with business rules.
 

--- a/docs/guides/entity-pattern-loyalty-points.mdx
+++ b/docs/guides/entity-pattern-loyalty-points.mdx
@@ -1119,6 +1119,8 @@ You've built a loyalty account system where each customer is an independent, sel
 
 ## Related resources
 
+- [Entity Workflow Pattern](/design-patterns/entity-workflow) — pattern catalog reference for this Workflow with Go, Java, Python, and TypeScript implementations
+- [Continue-As-New Pattern](/design-patterns/continue-as-new) — pattern catalog reference covering common pitfalls and history-size triggers
 - [Temporal Python SDK documentation](/develop/python)
 - [Temporal Python SDK API Reference](https://python.temporal.io)
 - [Message Passing — Signals, Queries, Updates](/develop/python/workflows/message-passing)
@@ -1126,5 +1128,4 @@ You've built a loyalty account system where each customer is an independent, sel
 - [Worker Versioning](/production-deployment/worker-deployments/worker-versioning)
 - [Failure Detection — Timeouts, Activity Heartbeating, and Retry Policies](/develop/python/best-practices/error-handling)
 - [Temporal Python SDK samples](https://github.com/temporalio/samples-python)
-
-<!-- - [Companion article: Actor Workflow Pattern](ActorWorkflow_PlayerSessions.md) — covers the related Actor Workflow pattern for autonomous agents that take action -->
+- Companion article: [Player Sessions That Survive Anything](/guides/durable-gaming-sessions) — covers the related Actor Workflow pattern for entities that take action

--- a/docs/guides/rate-limit-downstream-apis.mdx
+++ b/docs/guides/rate-limit-downstream-apis.mdx
@@ -775,6 +775,7 @@ Your application now safely integrates with rate-limited external APIs, ensuring
 - [Python SDK Worker Configuration](https://python.temporal.io/temporalio.worker.Worker.html)
 
 ### Related patterns
+- [Downstream Rate Limiting](/design-patterns/downstream-rate-limiting) - Pattern catalog reference for this technique, covering `MaxTaskQueueActivitiesPerSecond` versus per-worker and concurrency-slot alternatives
 - [Separate Task Queues - Worker Affinity](worker-execution-affinity) - For activities on same Worker
 
 ### Community resources

--- a/docs/guides/recover-without-restart.mdx
+++ b/docs/guides/recover-without-restart.mdx
@@ -50,7 +50,7 @@ While you can use traditional architectures to implement a similar solution, the
 By completing this pattern, you will:
 
 - Pause a business process on a non-retryable failure and resume after correction without restarting from the beginning.
-- Unwind side-effecting steps through a LIFO **saga** compensation stack when forward progress is not possible — for example, a compliance block or an explicit cancellation from the applicant.
+- Unwind side-effecting steps through a LIFO **[saga](/design-patterns/saga-pattern)** compensation stack when forward progress is not possible — for example, a compliance block or an explicit cancellation from the applicant.
 - Recover from compensation failures using the same pause-and-fix loop so a stuck rollback does not leave the process in a partially unwound state.
 - Route blocked processes to the right human or automated agent using queryable Search Attributes.
 - Inspect the current state of any individual process or filter across all processes through a single API.

--- a/docs/guides/recover-without-restart.mdx
+++ b/docs/guides/recover-without-restart.mdx
@@ -536,7 +536,7 @@ This enables an operations dashboard to display aggregate statistics and filter 
 
 Not every failure can be resolved by correcting input data.
 An OFAC match, a withdrawn offer, or a regulatory hold demands that the pipeline roll back rather than pause for a fix.
-This is where the [saga pattern](https://temporal-design-patterns.fly.dev/saga-pattern.html) comes in: each forward Activity that produces an external side effect — a credit bureau inquiry, an appraiser booking, a title company fee, a reserved lending slot, a funded loan — registers a compensating Activity **before** it executes.
+This is where the [saga pattern](/design-patterns/saga-pattern) comes in: each forward Activity that produces an external side effect — a credit bureau inquiry, an appraiser booking, a title company fee, a reserved lending slot, a funded loan — registers a compensating Activity **before** it executes.
 If the forward pipeline aborts, the Workflow unwinds the registered compensations in reverse order.
 
 The pattern has three key discipline points that the implementation must honor:
@@ -1055,6 +1055,9 @@ By following this guide, you have implemented a recoverable and compensatable pi
 
 ## Related resources
 - [Source code](https://github.com/temporal-sa/validated-pattern-keep-business-moving)
+- [Saga Pattern](/design-patterns/saga-pattern) — pattern catalog reference for the LIFO compensation technique used to roll back the loan pipeline
+- [Resumable Activity](/design-patterns/resumable-activity) — pattern catalog reference for the pause-on-failure, resume-via-Signal technique behind `recoverableStep`
+- [Non-Retryable Errors](/design-patterns/non-retryable-errors) — pattern catalog reference for marking permanent failures so Temporal fails fast instead of retrying
 - [Temporal TypeScript SDK Documentation](/develop/typescript) — Complete reference for building Workflows, Activities, and Workers with the TypeScript SDK.
 - [Temporal Signals](/develop/typescript/workflows/message-passing#signals) — Guide to defining and sending Signals to running Workflow Executions.
 - [Temporal Queries](/develop/typescript/workflows/message-passing#queries) — Guide to defining and handling synchronous read-only Queries on Workflows.

--- a/docs/guides/reliable-document-approvals.mdx
+++ b/docs/guides/reliable-document-approvals.mdx
@@ -50,7 +50,7 @@ When a Workflow calls `workflow.wait_condition()`, **the Worker returns the curr
 
 ### Event History management
 
-Temporal's Event History has a hard limit of 51,200 events or 50 MB ([Workflow Execution limits](/workflow-execution/limits)). The Server emits warnings at ~10,240 events or 10 MB; hitting either hard limit terminates the Workflow. For this approval pattern:
+Temporal's Event History has a hard limit of 51,200 events or 50 MB ([Workflow Execution limits](/workflow-execution/limits)). The Server emits warnings at ~10,240 events or 10 MB; hitting either hard limit terminates the Workflow. For this [approval pattern](/design-patterns/approval):
 
 | Workflow operation | Approximate events generated |
 |--------------------|------------------------------|

--- a/docs/guides/reliable-document-approvals.mdx
+++ b/docs/guides/reliable-document-approvals.mdx
@@ -1344,6 +1344,7 @@ You've built a document approval system that holds up under real conditions — 
 
 ## Related resources
 
+- [Approval Pattern](/design-patterns/approval) — pattern catalog reference for this Workflow with Go, Java, Python, and TypeScript implementations, plus multi-level and escalating approval variants
 - [Temporal Python SDK documentation](/develop/python)
 - [Message Passing — Signals, Queries, Updates](/develop/python/workflows/message-passing)
 - [Continue-As-New](/develop/python/workflows/continue-as-new)

--- a/docs/guides/route-specialized-workloads.mdx
+++ b/docs/guides/route-specialized-workloads.mdx
@@ -673,6 +673,7 @@ Your application now intelligently routes work based on resource requirements, e
 - [Python SDK Worker Configuration](https://python.temporal.io/temporalio.worker.Worker.html)
 
 ### Related patterns
+- [Worker-Specific Task Queues](/design-patterns/worker-specific-taskqueue) - Pattern catalog reference for routing Activities to a specific Worker via a dedicated Task Queue
 - [Separate Task Queues - Worker Affinity](worker-execution-affinity) - For Activities that must run on the same Worker instance
 - [Separate Task Queues - Rate Limiting](rate-limit-downstream-apis) - For protecting downstream APIs with rate limits
 

--- a/docs/guides/worker-execution-affinity.mdx
+++ b/docs/guides/worker-execution-affinity.mdx
@@ -487,6 +487,7 @@ Your file processing Workflows now guarantee that all Activities execute on the 
 - [Temporal Documentation - Worker Sessions (Go SDK)](/develop/go/workers/sessions)
 
 ### Related patterns
+- [Worker-Specific Task Queues](/design-patterns/worker-specific-taskqueue) - Pattern catalog reference for this two-tier Task Queue technique, with Go, Java, Python, and TypeScript implementations
 - [Separate Task Queues - Priorities](/guides/route-specialized-workloads) - For priority-based routing
 - [Separate Task Queues - Rate Limiting](/guides/rate-limit-downstream-apis) - For protecting downstream APIs
 


### PR DESCRIPTION
## Summary
- Design Patterns and Guides are now sibling top-level sidebar sections with zero cross-links in either direction. Adds a "Guides" section to 8 pattern pages pointing to their matching worked example, and reciprocal links back from those guides' Related resources sections:
  - `approval` ⇄ `reliable-document-approvals`
  - `saga-pattern`, `resumable-activity`, `non-retryable-errors` ⇄ `recover-without-restart`
  - `downstream-rate-limiting` ⇄ `rate-limit-downstream-apis`
  - `worker-specific-taskqueue` ⇄ `worker-execution-affinity`, `route-specialized-workloads`
  - `entity-workflow`, `continue-as-new` ⇄ `entity-pattern-loyalty-points`, `durable-gaming-sessions`
- Fixes two stale saga-pattern links: one pointed to an external `temporal-design-patterns.fly.dev` site, the other to a thin blurb in `evaluate/use-cases-design-patterns`. Both now point to the in-depth `/design-patterns/saga-pattern` page.
- Renames "Related resources" to "Related patterns" on the four batch-processing pages (`mapreduce-tree`, `sliding-window`, `batch-iterator`, `fanout-child-workflows`) for heading consistency with the rest of the section — these pages already cross-linked each other, just under a different heading name.

## Test plan
- [x] `vale --config .vale-ci.ini docs/` on all touched files — 0 errors, 0 warnings
- [x] `yarn build` via the pre-commit hook — completed with no broken links/anchors

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217002009243264">EDU-6846 Cross-link Design Patterns and Guides</a>
