### PR TITLE
Add SigNoz as an OpenMetrics metrics integration

### DIFF
--- a/docs/cloud/metrics/openmetrics/index.mdx
+++ b/docs/cloud/metrics/openmetrics/index.mdx
@@ -72,6 +72,7 @@ Stream metrics from Temporal Cloud into your observability tool in about 5 minut
    - [Grafana Cloud](/cloud/metrics/openmetrics/metrics-integrations#grafana-cloud)
    - [New Relic](/cloud/metrics/openmetrics/metrics-integrations#new-relic)
    - [ClickStack](/cloud/metrics/openmetrics/metrics-integrations#clickstack)
+   - [SigNoz](/cloud/metrics/openmetrics/metrics-integrations#signoz)
    - [Self-hosted Prometheus or OpenTelemetry Collector](/cloud/metrics/openmetrics/metrics-integrations#prometheus-grafana)
 
 Metrics begin populating in your tool within a few minutes.

--- a/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
@@ -109,6 +109,16 @@ The integration runs on a host (Linux, Windows, or Kubernetes) with the New Reli
 
 For New Relic-side details, see the [New Relic integration page](https://docs.newrelic.com/docs/infrastructure/host-integrations/host-integrations-list/temporal-cloud-integration/).
 
+### SigNoz
+
+SigNoz is an OpenTelemetry-native observability platform, available as a cloud service or self-hosted. The integration runs an OpenTelemetry Collector that scrapes the OpenMetrics endpoint and forwards metrics to SigNoz over OTLP.
+
+1. Configure an OpenTelemetry Collector with a Prometheus receiver against `metrics.temporal.io` using Bearer token auth with your Temporal Cloud API key, and an OTLP exporter that sends to your SigNoz ingestion endpoint (using your SigNoz ingestion key and region). Copy the full template - including the Kubernetes Secret-based variant - from the [SigNoz integration page](https://signoz.io/docs/integrations/temporal-cloud-metrics/).
+2. Deploy the collector (VM/binary or Kubernetes) and confirm `temporal_cloud_v1_*` metrics arrive in the SigNoz **Metrics Explorer**, typically within a few minutes.
+3. Import the pre-built dashboard JSON from the [SigNoz integration page](https://signoz.io/docs/integrations/temporal-cloud-metrics/) to visualize Temporal Cloud metrics.
+
+For SigNoz-side details, see the [SigNoz integration page](https://signoz.io/docs/integrations/temporal-cloud-metrics/).
+
 ### Prometheus \+ Grafana {/* #prometheus-grafana */}
 
 Self hosted Prometheus can be used to scrape the OpenMetrics endpoint.

--- a/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
+++ b/docs/cloud/metrics/openmetrics/metrics-integrations.mdx
@@ -14,6 +14,10 @@ keywords:
   - observability tools integration
   - openmetrics api
   - datadog temporal integration
+  - signoz temporal integration
+  - new relic temporal integration
+  - clickstack temporal integration
+  - opentelemetry collector metrics
 tags:
   - Metrics
   - OpenMetrics

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -208,6 +208,15 @@
     "href": "/develop/ruby/integrations/rails-integration"
   },
   {
+    "name": "SigNoz",
+    "description": "Export Temporal Cloud metrics to SigNoz via an OpenTelemetry Collector with a pre-built dashboard.",
+    "tags": [
+      "Observability",
+      "Temporal Cloud"
+    ],
+    "href": "https://signoz.io/docs/integrations/temporal-cloud-metrics/"
+  },
+  {
     "name": "Spring AI",
     "description": "Build AI-powered Java applications with durable Spring AI tool calls.",
     "tags": [


### PR DESCRIPTION
## What

Adds SigNoz as a third-party OpenMetrics integration for Temporal Cloud metrics.

## Why

SigNoz publishes a [Temporal Cloud metrics integration guide](https://signoz.io/docs/integrations/temporal-cloud-metrics/). It belongs alongside the other vendor integrations (Datadog, Grafana Cloud, New Relic, ClickStack) on our metrics integrations page.

## Changes

- **`docs/cloud/metrics/openmetrics/metrics-integrations.mdx`** - New `### SigNoz` section following the established vendor pattern: high-level description, basic setup steps, and a link out to the SigNoz partner docs for the full config template.
- **`docs/cloud/metrics/openmetrics/index.mdx`** - Added SigNoz to the quickstart "Configure your observability tool" link list for consistency with the other tool-specific entries.
- **`src/components/IntegrationsGrid/integrations-data.json`** - Added a SigNoz card (Observability / Temporal Cloud tags) so it surfaces on the [Integrations](https://docs.temporal.io/integrations) page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217031902636008">EDU-6852 Add SigNoz as an OpenMetrics metrics integration</a>
