### PR TITLE
DO NOT MERGE: test Docs Build Check CI

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -115,14 +115,14 @@ jobs:
               core.info(`Created new build check comment (${newComment.id}).`);
             }
 
-      - name: Fail job if build failed
-        if: steps.build.outputs.exit_code != '0'
-        run: exit 1
-
       - name: Upload build log
-        if: steps.build.outputs.exit_code != '0'
+        if: always() && steps.build.outputs.exit_code != '0'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: build-output-log
           path: build-output.log
           retention-days: 7
+
+      - name: Fail job if build failed
+        if: always() && steps.build.outputs.exit_code != '0'
+        run: exit 1

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,128 @@
+name: Docs Build Check
+
+# Runs the same production build Vercel runs. Vercel's own check only shows
+# "This branch had an error being deployed" with no detail in the PR, so this
+# job re-runs `yarn build` here, parses well-known Docusaurus failure modes
+# (broken links/anchors, unresolved Markdown links, MDX syntax errors) out of
+# the log, and posts the specific page/target that needs fixing as a PR
+# comment.
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+      - "src/**"
+      - "static/**"
+      - "sidebars.js"
+      - "docusaurus.config.js"
+      - "vercel.json"
+      - "package.json"
+      - "yarn.lock"
+      - "bin/parse-build-failure.js"
+      - ".github/workflows/build-check.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  build-check:
+    name: Build site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: "yarn"
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build site
+        id: build
+        shell: bash
+        run: |
+          set +e
+          yarn build 2>&1 | tee build-output.log
+          exit_code=${PIPESTATUS[0]}
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+
+      - name: Parse build failure
+        if: steps.build.outputs.exit_code != '0'
+        run: node bin/parse-build-failure.js build-output.log > build-failure-comment.md
+
+      - name: Comment on PR
+        if: always()
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- docs-build-check -->';
+            const exitCode = '${{ steps.build.outputs.exit_code }}';
+            const buildRan = exitCode !== '';
+            const failed = buildRan && exitCode !== '0';
+
+            // buildRan is false when an earlier step (e.g. yarn install) failed
+            // before the build could even start; parse-build-failure.js has
+            // nothing to work with in that case.
+            let body;
+            if (!buildRan) {
+              body = `${marker}\n### ❌ Docs build check failed before the build ran\n\nSee the [workflow run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}) for details.`;
+            } else if (failed) {
+              body = fs.readFileSync('build-failure-comment.md', 'utf8');
+            } else {
+              body = `${marker}\n### ✅ Docs build passed`;
+            }
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              per_page: 100,
+            });
+
+            const existing = comments.find(
+              (comment) => comment.user?.login === 'github-actions[bot]' && comment.body?.includes(marker),
+            );
+
+            // Don't post a noisy "build passed" comment when there was never a failure comment to clear.
+            const cleanPass = buildRan && !failed;
+            if (cleanPass && !existing) {
+              core.info('Build passed and no previous failure comment exists; skipping comment.');
+              return;
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+              core.info(`Updated existing build check comment (${existing.id}).`);
+            } else {
+              const { data: newComment } = await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+              core.info(`Created new build check comment (${newComment.id}).`);
+            }
+
+      - name: Fail job if build failed
+        if: steps.build.outputs.exit_code != '0'
+        run: exit 1
+
+      - name: Upload build log
+        if: steps.build.outputs.exit_code != '0'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: build-output-log
+          path: build-output.log
+          retention-days: 7

--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -39,6 +39,42 @@ jobs:
           node-version: "24"
           cache: "yarn"
 
+      # A PR's own ref never has a prior run to restore from, so this exact
+      # key only ever comes from warm-build-cache.yml's runs on main via
+      # GitHub's branch fallback (current ref -> PR base branch -> default
+      # branch). That's what makes a new PR's *first* check fast instead of
+      # a fully cold install.
+      - name: Cache installed dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      # Restore-only: og-images and rspack are large (~1.7GB combined) and
+      # each save is keyed by run id so it always "changes", so restoring
+      # them here but only ever *saving* from warm-build-cache.yml (which
+      # runs once per merge, not once per PR check) avoids re-uploading
+      # multi-GB caches on every PR push.
+      - name: Restore OG image render cache
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: node_modules/.cache/og-images
+          key: og-images-${{ github.run_id }}
+          restore-keys: |
+            og-images-
+
+      - name: Restore Docusaurus build cache (rspack)
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: node_modules/.cache/rspack
+          key: rspack-${{ github.run_id }}
+          restore-keys: |
+            rspack-
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 

--- a/.github/workflows/warm-build-cache.yml
+++ b/.github/workflows/warm-build-cache.yml
@@ -1,0 +1,62 @@
+name: Warm Build Cache
+
+# Runs the production build after every merge to main so the dependency and
+# build caches stay warm. "Docs Build Check" restores these on pull_request
+# runs via GitHub's cache fallback (current ref -> PR base branch -> default
+# branch), so a brand-new PR's first check doesn't do a fully cold install
+# and build.
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  warm-cache:
+    name: Warm dependency + build caches
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Cache installed dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: |
+            node_modules
+            !node_modules/.cache
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      # Rolling caches: keyed by run id so every run "changes" and re-saves,
+      # which is what keeps them incrementally warm as content changes.
+      - name: Cache OG image render cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: node_modules/.cache/og-images
+          key: og-images-${{ github.run_id }}
+          restore-keys: |
+            og-images-
+
+      - name: Cache Docusaurus build cache (rspack)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: node_modules/.cache/rspack
+          key: rspack-${{ github.run_id }}
+          restore-keys: |
+            rspack-
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build site
+        run: yarn build

--- a/bin/parse-build-failure.js
+++ b/bin/parse-build-failure.js
@@ -135,7 +135,7 @@ function tailOf(rawLog, lines) {
 
 function buildComment(findings, rawLog) {
   const marker = '<!-- docs-build-check -->';
-  const header = '### ❌ Docs build failed\n\nThis PR fails the same production build that Vercel runs, so the deployment will fail too.';
+  const header = '### ❌ Docs build failed';
 
   if (isEmpty(findings)) {
     return `${marker}

--- a/bin/parse-build-failure.js
+++ b/bin/parse-build-failure.js
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+
+// Turns a `yarn build` failure log into an actionable summary for a PR
+// comment. Docusaurus throws well-known, structured messages for the most
+// common content mistakes (broken links/anchors, unresolved Markdown links,
+// MDX syntax errors); we pull the specific page/target out of those so
+// contributors don't have to dig through the full Vercel build log.
+
+const fs = require('fs');
+
+const MAX_FINDINGS_PER_SECTION = 25;
+const RAW_TAIL_LINES = 60;
+
+function stripAnsi(text) {
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1B\[[0-9;]*[a-zA-Z]/g, '');
+}
+
+// Matches the blocks Docusaurus emits from createBrokenLinksMessage(), e.g.:
+//   - Broken anchor on source page path = /visibility:
+//      -> linking to /references/operation-list#operations
+function extractBrokenLinkFindings(log, type) {
+  const blockRegex = new RegExp(
+    `- Broken ${type} on source page path = (.+?):\\n((?:[ \\t]*-> linking to .+\\n?)+)`,
+    'g',
+  );
+  const findings = [];
+  let match;
+  while ((match = blockRegex.exec(log))) {
+    const sourcePage = match[1].trim();
+    match[2]
+      .split('-> linking to')
+      .map((s) => s.replace(/^[:\s-]+|\s+$/g, ''))
+      .filter(Boolean)
+      .forEach((target) => findings.push({ sourcePage, target }));
+  }
+  return findings;
+}
+
+// Matches mdx-loader's compileToJSX() failure:
+//   MDX compilation failed for file "docs/foo.mdx"
+//   Cause: <message>
+function findMdxCompilationErrors(log) {
+  const regex = /MDX compilation failed for file "?(.+?)"?\r?\nCause: (.+)/g;
+  const findings = [];
+  let match;
+  while ((match = regex.exec(log))) {
+    findings.push({ file: match[1].trim(), cause: match[2].trim() });
+  }
+  return findings;
+}
+
+// Matches resolveMarkdownLinks' onBrokenMarkdownLinks() report:
+//   Markdown link with URL "./foo.md" in source file path "docs/bar.mdx" ... couldn't be resolved.
+function findBrokenMarkdownLinks(log) {
+  const regex = /Markdown link with URL "(.+?)" in source file path "(.+?)"[^\n]*couldn't be resolved\./g;
+  const findings = [];
+  let match;
+  while ((match = regex.exec(log))) {
+    findings.push({ url: match[1].trim(), sourceFile: match[2].trim() });
+  }
+  return findings;
+}
+
+function parseBuildFailure(rawLog) {
+  const log = stripAnsi(rawLog);
+  return {
+    brokenLinks: extractBrokenLinkFindings(log, 'link'),
+    brokenAnchors: extractBrokenLinkFindings(log, 'anchor'),
+    mdxErrors: findMdxCompilationErrors(log),
+    brokenMarkdownLinks: findBrokenMarkdownLinks(log),
+  };
+}
+
+function isEmpty(findings) {
+  return (
+    findings.brokenLinks.length === 0 &&
+    findings.brokenAnchors.length === 0 &&
+    findings.mdxErrors.length === 0 &&
+    findings.brokenMarkdownLinks.length === 0
+  );
+}
+
+function truncatedNote(count) {
+  return count > MAX_FINDINGS_PER_SECTION
+    ? `\n_...and ${count - MAX_FINDINGS_PER_SECTION} more. See the full build log for the rest._\n`
+    : '';
+}
+
+function renderLinkSection(heading, tip, findings) {
+  if (findings.length === 0) return '';
+  const rows = findings
+    .slice(0, MAX_FINDINGS_PER_SECTION)
+    .map((f) => `| \`${f.sourcePage}\` | \`${f.target}\` |`)
+    .join('\n');
+  return `### ${heading}
+
+${tip}
+
+| Page | Broken target |
+|------|----------------|
+${rows}
+${truncatedNote(findings.length)}`;
+}
+
+function renderMdxSection(findings) {
+  if (findings.length === 0) return '';
+  const items = findings
+    .slice(0, MAX_FINDINGS_PER_SECTION)
+    .map((f) => `- \`${f.file}\`: ${f.cause}`)
+    .join('\n');
+  return `### MDX compilation errors
+
+The following file(s) have invalid MDX/JSX syntax (an unescaped \`<\`, \`{\`, or a broken component reference are common causes).
+
+${items}
+${truncatedNote(findings.length)}`;
+}
+
+function renderBrokenMarkdownLinksSection(findings) {
+  if (findings.length === 0) return '';
+  const items = findings
+    .slice(0, MAX_FINDINGS_PER_SECTION)
+    .map((f) => `- \`${f.sourceFile}\` links to \`${f.url}\`, which doesn't resolve to a real file`)
+    .join('\n');
+  return `### Unresolved Markdown links
+
+${items}
+${truncatedNote(findings.length)}`;
+}
+
+function tailOf(rawLog, lines) {
+  return stripAnsi(rawLog).trim().split('\n').slice(-lines).join('\n');
+}
+
+function buildComment(findings, rawLog) {
+  const marker = '<!-- docs-build-check -->';
+  const header = '### ❌ Docs build failed\n\nThis PR fails the same production build that Vercel runs, so the deployment will fail too.';
+
+  if (isEmpty(findings)) {
+    return `${marker}
+${header}
+
+We couldn't automatically identify the specific error from the build output. Here are the last ${RAW_TAIL_LINES} lines of the build log:
+
+<details>
+<summary>Build log tail</summary>
+
+\`\`\`
+${tailOf(rawLog, RAW_TAIL_LINES)}
+\`\`\`
+
+</details>
+
+Run \`yarn build\` locally to reproduce the full error.`;
+  }
+
+  const sections = [
+    renderLinkSection(
+      'Broken links',
+      'Update the link to point to a page that exists, or fix the typo in the path.',
+      findings.brokenLinks,
+    ),
+    renderLinkSection(
+      'Broken anchors',
+      "The target page exists, but the heading/anchor it links to doesn't. Fix the anchor, or add the missing heading to the target page.",
+      findings.brokenAnchors,
+    ),
+    renderBrokenMarkdownLinksSection(findings.brokenMarkdownLinks),
+    renderMdxSection(findings.mdxErrors),
+  ].filter(Boolean);
+
+  return `${marker}
+${header}
+
+${sections.join('\n\n')}
+
+Run \`yarn build\` locally to reproduce.`;
+}
+
+function main() {
+  const filePath = process.argv[2];
+  if (!filePath) {
+    console.error('Usage: node parse-build-failure.js <build-log-file>');
+    process.exit(1);
+  }
+  const rawLog = fs.readFileSync(filePath, 'utf8');
+  const findings = parseBuildFailure(rawLog);
+  process.stdout.write(buildComment(findings, rawLog));
+}
+
+if (require.main === module) {
+  main();
+} else {
+  module.exports = {
+    stripAnsi,
+    extractBrokenLinkFindings,
+    findMdxCompilationErrors,
+    findBrokenMarkdownLinks,
+    parseBuildFailure,
+    isEmpty,
+    buildComment,
+  };
+}

--- a/bin/parse-build-failure.test.js
+++ b/bin/parse-build-failure.test.js
@@ -1,0 +1,99 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const {
+  stripAnsi,
+  parseBuildFailure,
+  isEmpty,
+  buildComment,
+} = require('./parse-build-failure.js');
+
+describe('stripAnsi', () => {
+  it('removes color escape codes', () => {
+    assert.strictEqual(stripAnsi('\x1B[31mred text\x1B[39m'), 'red text');
+  });
+
+  it('leaves plain text untouched', () => {
+    assert.strictEqual(stripAnsi('plain text'), 'plain text');
+  });
+});
+
+describe('parseBuildFailure', () => {
+  it('extracts a broken anchor with its source page and target', () => {
+    const log = `[ERROR] Error: Unable to build website for locale en.
+  [cause]: Error: Docusaurus found broken anchors!
+
+  Exhaustive list of all broken anchors found:
+  - Broken anchor on source page path = /visibility:
+     -> linking to /references/operation-list#operations
+
+      at throwError (/vercel/path1/node_modules/@docusaurus/logger/lib/logger.js:80:11)
+`;
+    const findings = parseBuildFailure(log);
+    assert.deepStrictEqual(findings.brokenAnchors, [
+      { sourcePage: '/visibility', target: '/references/operation-list#operations' },
+    ]);
+    assert.strictEqual(findings.brokenLinks.length, 0);
+  });
+
+  it('extracts multiple broken links on the same page', () => {
+    const log = `Exhaustive list of all broken links found:
+- Broken link on source page path = /some-page:
+   -> linking to /missing-one
+   -> linking to /missing-two
+`;
+    const findings = parseBuildFailure(log);
+    assert.deepStrictEqual(findings.brokenLinks, [
+      { sourcePage: '/some-page', target: '/missing-one' },
+      { sourcePage: '/some-page', target: '/missing-two' },
+    ]);
+  });
+
+  it('extracts MDX compilation errors', () => {
+    const log = `MDX compilation failed for file "docs/foo.mdx"
+Cause: Unexpected character \`<\` before name
+Details:
+{}`;
+    const findings = parseBuildFailure(log);
+    assert.deepStrictEqual(findings.mdxErrors, [
+      { file: 'docs/foo.mdx', cause: 'Unexpected character `<` before name' },
+    ]);
+  });
+
+  it('extracts unresolved Markdown links', () => {
+    const log = `Markdown link with URL "./missing.md" in source file path "docs/bar.mdx" at line 12 couldn't be resolved.
+Make sure it references a local Markdown file that exists within the current plugin.`;
+    const findings = parseBuildFailure(log);
+    assert.deepStrictEqual(findings.brokenMarkdownLinks, [
+      { url: './missing.md', sourceFile: 'docs/bar.mdx' },
+    ]);
+  });
+
+  it('returns all-empty findings for unrecognized failures', () => {
+    const findings = parseBuildFailure('some unrelated webpack stack trace');
+    assert.ok(isEmpty(findings));
+  });
+});
+
+describe('buildComment', () => {
+  it('falls back to a log tail when nothing is recognized', () => {
+    const log = 'line one\nline two';
+    const comment = buildComment(parseBuildFailure(log), log);
+    assert.match(comment, /couldn't automatically identify/);
+    assert.match(comment, /line one/);
+  });
+
+  it('renders a table for broken anchors', () => {
+    const log = `- Broken anchor on source page path = /visibility:
+   -> linking to /references/operation-list#operations
+`;
+    const comment = buildComment(parseBuildFailure(log), log);
+    assert.match(comment, /### Broken anchors/);
+    assert.match(comment, /\/visibility/);
+    assert.match(comment, /\/references\/operation-list#operations/);
+  });
+
+  it('always includes the marker used to find/update the PR comment', () => {
+    const comment = buildComment(parseBuildFailure('anything'), 'anything');
+    assert.match(comment, /^<!-- docs-build-check -->/);
+  });
+});

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -896,6 +896,3 @@ A Workflow Type is a name that maps to a Workflow Definition.
 
 tctl is a command-line tool that you can use to interact with a Temporal Service. It is superseded by the
 [Temporal CLI utility](#cli).
-
-<!-- TEMP CI TEST: intentionally broken anchor to verify the Docs Build Check workflow. Will be reverted in a follow-up commit before this PR is closed. -->
-See [operations](#totally-made-up-anchor-that-does-not-exist-ci-test) for details.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -896,3 +896,6 @@ A Workflow Type is a name that maps to a Workflow Definition.
 
 tctl is a command-line tool that you can use to interact with a Temporal Service. It is superseded by the
 [Temporal CLI utility](#cli).
+
+<!-- TEMP CI TEST: intentionally broken anchor to verify the Docs Build Check workflow. Will be reverted in a follow-up commit before this PR is closed. -->
+See [operations](#totally-made-up-anchor-that-does-not-exist-ci-test) for details.


### PR DESCRIPTION
Test PR for the new Docs Build Check workflow (see `.github/workflows/build-check.yml`), which re-runs `yarn build` in CI and posts a PR comment parsing out the specific broken link/anchor/MDX error, instead of Vercel's opaque "This branch had an error being deployed".

This branch includes a **temporary intentional broken anchor** in `docs/glossary.md` to verify the workflow catches it and posts a useful comment. That will be reverted in a follow-up commit once confirmed, and this PR will be closed (not merged) once verified — it's a throwaway test.

## Test plan
- [ ] Confirm the workflow run fails and posts a comment identifying the broken anchor in `docs/glossary.md`
- [ ] Push a fix commit removing the broken anchor
- [ ] Confirm the workflow re-runs, passes, and updates the comment to a passing state
- [ ] Close this PR without merging

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217048982111738">EDU-6853 DO NOT MERGE: test Docs Build Check CI</a>
