### PR TITLE
Recommend setting a Worker Identity on Cloud Run

### DIFF
--- a/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
@@ -239,6 +239,16 @@ For the TypeScript Worker setup specific to Cloud Run, see
 </SdkTabs.TypeScript>
 </SdkTabs>
 
+:::tip
+
+Workers on Cloud Run use the same code as a traditional long-lived Worker, so the SDK defaults the
+[Worker Identity](/workers#worker-identity) to the process ID and hostname. On Cloud Run that resolves to
+`1@localhost`, which makes a Worker harder to identify in the Temporal UI. Set your own Worker Identity, built from the
+[Cloud Run environment variables](https://cloud.google.com/run/docs/container-contract#worker-pools-env-vars), to help
+identify your Serverless Workers.
+
+:::
+
 ## 2. Deploy to a Cloud Run Worker Pool {/* #deploy-worker-pool */}
 
 Containerize the Worker, push the image to Artifact Registry, and create the Worker Pool.


### PR DESCRIPTION
Fast-follow for Serverless Workers on GCP Cloud Run.

Cloud Run instances have no meaningful hostname, so the SDK default Worker Identity of process ID plus hostname resolves to `1@localhost` on every instance. That makes Workers hard to tell apart in the Temporal UI.

Adds a tip to the end of **1. Write Worker code** in the Cloud Run deploy guide, linking to [Worker Identity](https://docs.temporal.io/workers#worker-identity) and to the Cloud Run environment variables a Worker can build an identity from.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217039130006614">EDU-6855 Recommend setting a Worker Identity on Cloud Run</a>
