### PR TITLE
Add scheduled check comparing the SDK metrics reference with the SDK sources

### DIFF
--- a/.github/workflows/check-metrics-against-sdks.yml
+++ b/.github/workflows/check-metrics-against-sdks.yml
@@ -1,0 +1,119 @@
+name: Check Metrics Against SDKs
+
+# Compares docs/references/sdk-metrics.mdx with the metric definitions on the
+# default branches of the SDK repositories. This is advisory: it opens a
+# tracking issue rather than failing, because the SDK default branches run
+# ahead of released versions and extracting metric names from three languages
+# is approximate. The merge gate is Check Metrics Reference, which checks the
+# page against itself.
+
+on:
+  schedule:
+    - cron: '0 10 * * 1'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'docs/references/sdk-metrics.mdx'
+      - 'bin/check-metrics-against-sdks.js'
+      - 'bin/check-metrics-against-sdks.test.js'
+      - 'bin/metrics-baseline.json'
+      - '.github/workflows/check-metrics-against-sdks.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: check-metrics-against-sdks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compare:
+    name: Compare the reference with the SDK sources
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '24'
+
+      - name: Test the comparison
+        run: node --test bin/check-metrics-against-sdks.test.js
+
+      - name: Compare against the SDK sources
+        id: compare
+        run: |
+          set +e
+          node bin/check-metrics-against-sdks.js > report.txt 2>&1
+          status=$?
+          set -e
+
+          cat report.txt
+
+          # 0 is clean and 2 is drift. Anything else means the comparison could
+          # not run, usually because a definition file was renamed upstream.
+          if [ "$status" -ne 0 ] && [ "$status" -ne 2 ]; then
+            echo "::error::The comparison could not run. A definition file was probably renamed upstream; update SDKS in bin/check-metrics-against-sdks.js."
+            exit "$status"
+          fi
+
+          if [ "$status" -eq 2 ]; then
+            echo "drift=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "drift=false" >> "$GITHUB_OUTPUT"
+          fi
+
+          {
+            echo "### SDK metrics comparison"
+            echo
+            echo '```'
+            cat report.txt
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Open or update the tracking issue
+        if: github.event_name != 'pull_request' && steps.compare.outputs.drift == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: 'SDK metrics reference has drifted from the SDK sources'
+        run: |
+          {
+            echo "\`docs/references/sdk-metrics.mdx\` no longer matches the metric"
+            echo "definitions on the SDK default branches."
+            echo
+            echo '```'
+            cat report.txt
+            echo '```'
+            echo
+            echo "To resolve, either update the page, or record the metric as"
+            echo "intentionally undocumented in \`bin/metrics-baseline.json\`."
+            echo "Reproduce locally with \`yarn check:metrics:sdks\`."
+            echo
+            echo "_Updated by [${GITHUB_WORKFLOW}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})._"
+          } > issue-body.md
+
+          number=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')
+
+          if [ -n "$number" ]; then
+            gh issue edit "$number" --body-file issue-body.md
+            echo "Updated issue #$number."
+          else
+            gh issue create --title "$TITLE" --body-file issue-body.md
+          fi
+
+      - name: Close the tracking issue
+        if: github.event_name != 'pull_request' && steps.compare.outputs.drift == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TITLE: 'SDK metrics reference has drifted from the SDK sources'
+        run: |
+          number=$(gh issue list --state open --search "in:title \"$TITLE\"" --json number --jq '.[0].number // empty')
+
+          if [ -n "$number" ]; then
+            gh issue close "$number" --comment "The page and the SDK sources agree again."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,17 @@
 # AGENTS.md
 
-Guidance for AI coding agents working in the [Temporal documentation](https://github.com/temporalio/documentation) repository.
+Guidance for AI coding agents working in the [Temporal documentation](https://github.com/temporalio/documentation)
+repository.
 
 ## Read these first
 
-| Topic | File |
-|-------|------|
-| Where content belongs | [INFORMATION-ARCHITECTURE.md](./INFORMATION-ARCHITECTURE.md) |
-| React components in MDX | [COMPONENTS.md](./COMPONENTS.md) |
-| Mermaid diagrams | [MERMAID.md](./readme/MERMAID.md) |
-| LLM Markdown pipeline | [MARKDOWN_PIPELINE.md](./MARKDOWN_PIPELINE.md) |
-| Component → Markdown mapping | [COMPONENT_REGISTRY.md](./COMPONENT_REGISTRY.md) |
+| Topic                        | File                                                         |
+| ---------------------------- | ------------------------------------------------------------ |
+| Where content belongs        | [INFORMATION-ARCHITECTURE.md](./INFORMATION-ARCHITECTURE.md) |
+| React components in MDX      | [COMPONENTS.md](./COMPONENTS.md)                             |
+| Mermaid diagrams             | [MERMAID.md](./readme/MERMAID.md)                            |
+| LLM Markdown pipeline        | [MARKDOWN_PIPELINE.md](./MARKDOWN_PIPELINE.md)               |
+| Component → Markdown mapping | [COMPONENT_REGISTRY.md](./COMPONENT_REGISTRY.md)             |
 
 ## Repository overview
 
@@ -21,7 +22,7 @@ Guidance for AI coding agents working in the [Temporal documentation](https://gi
 
 ## Where to put content
 
-Use [INFORMATION-ARCHITECTURE.md](./INFORMATION-ARCHITECTURE.md) to choose the section. 
+Use [INFORMATION-ARCHITECTURE.md](./INFORMATION-ARCHITECTURE.md) to choose the section.
 
 ## Style Guide
 
@@ -62,30 +63,34 @@ In code blocks, follow each language's conventions.
 
 ### Writing style
 
-Follow [STYLE.md](./STYLE.md) and the [Google developer documentation style guide](https://developers.google.com/style) for tone (conversational, second person, active voice) and structure (short paragraphs, one idea per sentence). A few additions specific to model output:
+Follow [STYLE.md](./STYLE.md) and the [Google developer documentation style guide](https://developers.google.com/style)
+for tone (conversational, second person, active voice) and structure (short paragraphs, one idea per sentence). A few
+additions specific to model output:
 
-- Cut filler that adds no information: "it's worth noting that," "in order to," "simply," "easily," "just." 
-- Avoid vague intensifiers doing the work a specific fact should do: "powerful," "robust," "seamless," "cutting-edge," "leverage" (use "use"), "unlock," "elevate," "streamline." Replace with what the thing actually does.
-- Don't pad a page to look thorough. Prefer brevity over overly-verbose paragraphs. 
-- Do not add emojis to documentation prose and use em-dashes sparingly. 
+- Cut filler that adds no information: "it's worth noting that," "in order to," "simply," "easily," "just."
+- Avoid vague intensifiers doing the work a specific fact should do: "powerful," "robust," "seamless," "cutting-edge,"
+  "leverage" (use "use"), "unlock," "elevate," "streamline." Replace with what the thing actually does.
+- Don't pad a page to look thorough. Prefer brevity over overly-verbose paragraphs.
+- Do not add emojis to documentation prose and use em-dashes sparingly.
 
 ### Word choice
 
 Prefer common, concrete verbs and nouns.
 
-| Prefer | Instead of |
-|--------|------------|
-| use | utilize, leverage |
-| help | facilitate |
-| to | in order to |
-| many | numerous, various (when you can be specific, be specific) |
+| Prefer | Instead of                                                |
+| ------ | --------------------------------------------------------- |
+| use    | utilize, leverage                                         |
+| help   | facilitate                                                |
+| to     | in order to                                               |
+| many   | numerous, various (when you can be specific, be specific) |
 
 ### Tense and time
 
-Document current behavior. Don't make future promises. Tie claims to a version, release note, or release stage when that matters.
+Document current behavior. Don't make future promises. Tie claims to a version, release note, or release stage when that
+matters.
 
-| Prefer | Instead of |
-|--------|------------|
+| Prefer                                                                | Instead of                                 |
+| --------------------------------------------------------------------- | ------------------------------------------ |
 | Temporal Server v1.31.0 and later supports Cassandra 5.0.4 and later. | A future release will support Cassandra 5. |
 
 ## Frontmatter
@@ -113,11 +118,14 @@ tags:
 ## MDX and components
 
 - Pages are `.mdx` with YAML frontmatter (see [Frontmatter](#frontmatter) above).
-- Import shared components from `@site/src/components` unless a page uses a one-off import path already established nearby.
-- Before adding a component, check [COMPONENTS.md](./COMPONENTS.md) and [COMPONENT_REGISTRY.md](./COMPONENT_REGISTRY.md).
-- Reuse existing components (`Tabs`, `SdkTabs`, `CaptionedImage`, `ViewSourceCodeNotice`, etc.) instead of inventing inline HTML patterns.
-- Interactive demos live in `src/components/elements/`. Export new public components from `src/components/index.js` when needed.
-
+- Import shared components from `@site/src/components` unless a page uses a one-off import path already established
+  nearby.
+- Before adding a component, check [COMPONENTS.md](./COMPONENTS.md) and
+  [COMPONENT_REGISTRY.md](./COMPONENT_REGISTRY.md).
+- Reuse existing components (`Tabs`, `SdkTabs`, `CaptionedImage`, `ViewSourceCodeNotice`, etc.) instead of inventing
+  inline HTML patterns.
+- Interactive demos live in `src/components/elements/`. Export new public components from `src/components/index.js` when
+  needed.
 
 ## URLs and navigation
 
@@ -130,7 +138,8 @@ Adding or moving pages usually requires:
 ## Code samples and Snipsync
 
 - Prefer code extracted from CI-enabled sample repos via [Snipsync](https://github.com/temporalio/snipsync).
-- Snippets are wrapped in `<!--SNIPSTART id-->` / `<!--SNIPEND-->`. Edit the **source repo** named inside the wrapper, then run `yarn snipsync`.
+- Snippets are wrapped in `<!--SNIPSTART id-->` / `<!--SNIPEND-->`. Edit the **source repo** named inside the wrapper,
+  then run `yarn snipsync`.
 
 ## Commands
 
@@ -144,6 +153,16 @@ yarn check-links  # Broken link check (run after build)
 yarn snipsync     # Refresh Snipsync code snippets
 ```
 
+Reference page checks:
+
+```bash
+yarn check:metrics       # SDK metrics reference against itself; runs in CI on PRs
+yarn check:metrics:sdks  # SDK metrics reference against the SDK sources; advisory, clones the SDK repos
+```
+
+`yarn check:metrics:sdks` reports metrics an SDK defines but the page omits. When one is deliberately left undocumented,
+record it in `bin/metrics-baseline.json` rather than suppressing the check.
+
 Vale linting (style):
 
 ```bash
@@ -152,8 +171,15 @@ vale --config .vale-ci.ini docs/      # CI-scoped rules only (what PR checks run
 vale docs/                            # Full Vale style set
 ```
 
-Before finishing any docs change, run the CI-scoped command (`vale --config .vale-ci.ini docs/`) against the files you touched and resolve every result it reports, unless it's a genuine false positive (e.g. a heading that's a literal command/metric name, or a bare URL that must stay absolute for autolinking). `.vale-ci.ini` enables only the small set of high-confidence rules (`Temporal.Headings`, `Temporal.RelativeLinks`) that gate PRs in `.github/workflows/vale-ci.yml` — treat that as the bar to hit.
+Before finishing any docs change, run the CI-scoped command (`vale --config .vale-ci.ini docs/`) against the files you
+touched and resolve every result it reports, unless it's a genuine false positive (e.g. a heading that's a literal
+command/metric name, or a bare URL that must stay absolute for autolinking). `.vale-ci.ini` enables only the small set
+of high-confidence rules (`Temporal.Headings`, `Temporal.RelativeLinks`) that gate PRs in
+`.github/workflows/vale-ci.yml` — treat that as the bar to hit.
 
-Do not use the full Vale style set (plain `vale docs/`, no `--config`) to judge whether a change is done. It runs many noisier suggestion-level rules that are not enforced in CI and are not a requirement for this repo.
+Do not use the full Vale style set (plain `vale docs/`, no `--config`) to judge whether a change is done. It runs many
+noisier suggestion-level rules that are not enforced in CI and are not a requirement for this repo.
 
-`.vale-ci.ini` enables only the small set of high-confidence rules (`Temporal.Headings`, `Temporal.RelativeLinks`) used as a CI gate in `.github/workflows/vale-ci.yml`. `.vale.ini` (the default config) runs the full style set, which includes noisier suggestion-level rules not enforced in CI.
+`.vale-ci.ini` enables only the small set of high-confidence rules (`Temporal.Headings`, `Temporal.RelativeLinks`) used
+as a CI gate in `.github/workflows/vale-ci.yml`. `.vale.ini` (the default config) runs the full style set, which
+includes noisier suggestion-level rules not enforced in CI.

--- a/bin/check-metrics-against-sdks.js
+++ b/bin/check-metrics-against-sdks.js
@@ -1,0 +1,484 @@
+#!/usr/bin/env node
+
+// Compares the SDK metrics reference against the metric definitions in the
+// SDK repositories, and reports where they disagree.
+//
+// This is the companion to bin/check-metrics-reference.js. That check only
+// proves the page does not contradict itself; this one proves the page matches
+// the SDKs. It is advisory rather than a merge gate, because extracting metric
+// names from three languages is inherently approximate and the SDK default
+// branches move ahead of released versions.
+//
+//   node bin/check-metrics-against-sdks.js                    # report
+//   node bin/check-metrics-against-sdks.js --json             # machine-readable
+//   node bin/check-metrics-against-sdks.js --update-baseline  # accept current gaps
+//   node bin/check-metrics-against-sdks.js --cache-dir /tmp/sdks
+//
+// Exit codes: 0 clean, 2 drift found, 1 the comparison could not run at all,
+// which is what happens when a definition file is renamed upstream.
+
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { parseTable } = require('./check-metrics-reference.js');
+
+const PAGE = path.join('docs', 'references', 'sdk-metrics.mdx');
+const BASELINE = path.join('bin', 'metrics-baseline.json');
+
+// Names are stored on the page without the temporal_ prefix that SDKs add on
+// export, so everything is normalized to the bare name for comparison.
+const PREFIX = 'temporal_';
+
+const METRIC_NAME = /^[a-z][a-z0-9_]*$/;
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+// Rust keeps unit tests in the same file behind a #[cfg(test)] mod, and those
+// register throwaway instruments named "ctr", "histo" and so on.
+function stripRustTestModule(source) {
+  const lines = source.split('\n');
+  for (let i = 0; i < lines.length - 1; i++) {
+    if (lines[i] === '#[cfg(test)]' && /^mod \w+/.test(lines[i + 1])) {
+      return lines.slice(0, i).join('\n');
+    }
+  }
+  return source;
+}
+
+const RUST_CONST = /(?:const|static)\s+([A-Z][A-Z0-9_]*)\s*:\s*&(?:'static\s+)?str\s*=\s*"([a-z0-9_]+)"/g;
+// Instruments are registered either as MetricParameters { name: <expr>.into() }
+// or via a direct meter call such as meter.gauge_f64("...".into()).
+const RUST_REGISTRATION = /(?:name:\s*|meter\.[a-z0-9_]+\(\s*)(?:"([a-z0-9_]+)"|([A-Z][A-Z0-9_]*))\s*\.into\(\)/g;
+
+function extractRust(files) {
+  const constants = new Map();
+  const found = [];
+
+  for (const { source } of files) {
+    const body = stripRustTestModule(source);
+    for (const m of body.matchAll(RUST_CONST)) {
+      constants.set(m[1], m[2]);
+    }
+  }
+
+  for (const { source } of files) {
+    const body = stripRustTestModule(source);
+    for (const m of body.matchAll(RUST_REGISTRATION)) {
+      const name = m[1] ?? constants.get(m[2]);
+      if (name && METRIC_NAME.test(name)) {
+        found.push({ name, identifier: m[2] ?? null, annotations: [] });
+      }
+    }
+  }
+  return found;
+}
+
+// Metric names are always built from the prefix constant. A bare literal that
+// happens to start with temporal_ is something else, such as the Go client tag
+// value "temporal_go".
+function referencesConstant(expression) {
+  return /[A-Za-z_]/.test(expression.replace(/"[^"]*"/g, ''));
+}
+
+// Go and Java both build metric names by concatenating a prefix constant with
+// a literal, sometimes chaining off another metric constant
+// (TemporalRequestFailure = TemporalRequest + "_failure").
+function resolveConcatenations(assignments) {
+  const values = new Map();
+
+  const resolve = (expr, depth = 0) => {
+    if (depth > 10) return null;
+    let out = '';
+    for (const part of expr.split('+').map((p) => p.trim())) {
+      const literal = part.match(/^"([^"]*)"$/);
+      if (literal) {
+        out += literal[1];
+        continue;
+      }
+      if (values.has(part)) {
+        out += values.get(part);
+        continue;
+      }
+      const pending = assignments.find((a) => a.identifier === part);
+      if (!pending) return null;
+      const resolved = resolve(pending.expression, depth + 1);
+      if (resolved === null) return null;
+      values.set(part, resolved);
+      out += resolved;
+    }
+    return out;
+  };
+
+  for (const assignment of assignments) {
+    const value = resolve(assignment.expression);
+    if (value !== null) values.set(assignment.identifier, value);
+  }
+  return values;
+}
+
+const GO_ASSIGNMENT = /^\s*([A-Z][A-Za-z0-9_]*)\s*=\s*(.+?)\s*(?:\/\/(.*))?$/;
+
+function extractGo(files) {
+  const assignments = [];
+
+  for (const { source } of files) {
+    // sdk-go marks deprecations with a trailing comment, but the Go convention
+    // is a preceding one, so accept either.
+    let preceding = '';
+    for (const line of source.split('\n')) {
+      const m = line.match(GO_ASSIGNMENT);
+      if (!m || !m[2].includes('"')) {
+        preceding = line.trim().startsWith('//') ? line : '';
+        continue;
+      }
+      assignments.push({
+        identifier: m[1],
+        expression: m[2],
+        annotations: /^\s*(?:\/\/\s*)?deprecated/i.test(m[3] ?? preceding.replace('//', '')) ? ['Deprecated'] : [],
+      });
+      preceding = '';
+    }
+  }
+
+  const values = resolveConcatenations(assignments);
+  return assignments
+    .filter((a) => (values.get(a.identifier) ?? '').startsWith(PREFIX) && referencesConstant(a.expression))
+    .map((a) => ({
+      name: values.get(a.identifier).slice(PREFIX.length),
+      identifier: a.identifier,
+      annotations: a.annotations,
+    }))
+    .filter((m) => METRIC_NAME.test(m.name));
+}
+
+const JAVA_ASSIGNMENT = /((?:@\w+\s+)*)public static final String ([A-Z][A-Z0-9_]*)\s*=\s*([^;]+);/g;
+
+function extractJava(files) {
+  const assignments = [];
+
+  for (const { source } of files) {
+    // Comments can contain @Deprecated prose and stray semicolons.
+    const body = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/.*$/gm, '');
+    for (const m of body.matchAll(JAVA_ASSIGNMENT)) {
+      assignments.push({
+        identifier: m[2],
+        expression: m[3].replace(/\s+/g, ' ').trim(),
+        annotations: [...m[1].matchAll(/@(\w+)/g)].map((a) => a[1]),
+      });
+    }
+  }
+
+  const values = resolveConcatenations(assignments);
+  return assignments
+    .filter((a) => (values.get(a.identifier) ?? '').startsWith(PREFIX) && referencesConstant(a.expression))
+    .map((a) => ({
+      name: values.get(a.identifier).slice(PREFIX.length),
+      identifier: a.identifier,
+      annotations: a.annotations,
+    }))
+    .filter((m) => METRIC_NAME.test(m.name));
+}
+
+// ---------------------------------------------------------------------------
+// SDK configuration
+// ---------------------------------------------------------------------------
+
+// Definition files are listed explicitly rather than discovered. If one is
+// renamed upstream the check fails loudly instead of quietly reporting that a
+// whole SDK stopped emitting metrics.
+const SDKS = [
+  {
+    name: 'Core',
+    repo: 'temporalio/sdk-rust',
+    files: [
+      'crates/sdk-core/src/telemetry/metrics.rs',
+      'crates/common/src/telemetry/metrics.rs',
+      'crates/client/src/metrics.rs',
+      'crates/sdk-core/src/worker/tuner/resource_based.rs',
+    ],
+    extract: extractRust,
+    // Rust registers the instrument at the definition site, so appearing there
+    // already means the metric is created.
+    checkUsage: false,
+  },
+  {
+    name: 'Go',
+    repo: 'temporalio/sdk-go',
+    files: ['internal/common/metrics/constants.go'],
+    extract: extractGo,
+    checkUsage: true,
+    testPaths: [':(exclude)*_test.go'],
+  },
+  {
+    name: 'Java',
+    repo: 'temporalio/sdk-java',
+    files: [
+      'temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java',
+      'temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsType.java',
+    ],
+    extract: extractJava,
+    checkUsage: true,
+    testPaths: [':(exclude)*/src/test/*', ':(exclude)*/src/testFixtures/*'],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Repository access
+// ---------------------------------------------------------------------------
+
+function ensureRepo(repo, dir) {
+  if (fs.existsSync(path.join(dir, '.git'))) return dir;
+  fs.mkdirSync(path.dirname(dir), { recursive: true });
+  execFileSync('git', ['clone', '--depth', '1', '--quiet', `https://github.com/${repo}.git`, dir], {
+    stdio: ['ignore', 'ignore', 'inherit'],
+  });
+  return dir;
+}
+
+function headSha(dir) {
+  return execFileSync('git', ['-C', dir, 'rev-parse', '--short', 'HEAD'], {
+    encoding: 'utf8',
+  }).trim();
+}
+
+// A constant declared in the metrics file but referenced nowhere else is not
+// actually emitted. sdk-go declares WorkflowActiveThreadCount and never uses
+// it, and trusting the declaration would wrongly credit Go with that metric.
+function findUnusedIdentifiers(dir, identifiers, definitionFiles, testPaths) {
+  if (identifiers.length === 0) return new Set();
+
+  const pathspec = ['.', ...definitionFiles.map((f) => `:(exclude)${f}`), ...testPaths];
+
+  let output = '';
+  try {
+    output = execFileSync(
+      'git',
+      ['-C', dir, 'grep', '--no-color', '-how', '-E', identifiers.join('|'), '--', ...pathspec],
+      { encoding: 'utf8', maxBuffer: 1024 * 1024 * 64 }
+    );
+  } catch (error) {
+    // git grep exits 1 when nothing matches, which is a valid result.
+    if (error.status !== 1) throw error;
+  }
+
+  const used = new Set(output.split('\n').filter(Boolean));
+  return new Set(identifiers.filter((id) => !used.has(id)));
+}
+
+function collectSdk(sdk, cacheDir) {
+  const dir = ensureRepo(sdk.repo, path.join(cacheDir, path.basename(sdk.repo)));
+
+  const files = sdk.files.map((file) => {
+    const full = path.join(dir, file);
+    if (!fs.existsSync(full)) {
+      throw new Error(
+        `${sdk.repo}: definition file not found: ${file}\n` +
+          'It was probably renamed upstream. Update SDKS in this script.'
+      );
+    }
+    return { file, source: fs.readFileSync(full, 'utf8') };
+  });
+
+  let metrics = sdk.extract(files);
+  let unused = [];
+
+  if (sdk.checkUsage) {
+    const identifiers = [...new Set(metrics.map((m) => m.identifier).filter(Boolean))];
+    const dead = findUnusedIdentifiers(dir, identifiers, sdk.files, sdk.testPaths);
+    unused = metrics.filter((m) => dead.has(m.identifier)).map((m) => ({ name: m.name, identifier: m.identifier }));
+    metrics = metrics.filter((m) => !dead.has(m.identifier));
+  }
+
+  const byName = new Map();
+  for (const metric of metrics) {
+    byName.set(metric.name, metric);
+  }
+
+  return { name: sdk.name, repo: sdk.repo, sha: headSha(dir), metrics: byName, unused };
+}
+
+// ---------------------------------------------------------------------------
+// Comparison
+// ---------------------------------------------------------------------------
+
+function compare(rows, sdks) {
+  const documented = new Map(rows.map((r) => [r.name, r]));
+  const everyName = new Set(sdks.flatMap((s) => [...s.metrics.keys()]));
+
+  const unknown = [];
+  const mismatched = [];
+  const undocumented = [];
+
+  for (const [name, row] of documented) {
+    const actual = sdks.filter((s) => s.metrics.has(name)).map((s) => s.name);
+
+    if (actual.length === 0) {
+      unknown.push({ name, documented: row.availability });
+      continue;
+    }
+    const expected = actual.join(', ');
+    if (expected !== row.availability) {
+      mismatched.push({ name, documented: row.availability, actual: expected });
+    }
+  }
+
+  for (const name of [...everyName].sort()) {
+    if (documented.has(name)) continue;
+    const found = sdks.filter((s) => s.metrics.has(name));
+    undocumented.push({
+      name,
+      sdks: found.map((s) => s.name).join(', '),
+      annotations: [...new Set(found.flatMap((s) => s.metrics.get(name).annotations))],
+    });
+  }
+
+  return { unknown, mismatched, undocumented };
+}
+
+// Not every metric an SDK defines belongs on the page: some are deprecated
+// aliases, some are internals. Those are recorded in a baseline so the check
+// reports only new drift. An entry with no note has not been reviewed yet.
+function applyBaseline(result, baseline) {
+  const known = new Map(baseline.undocumented.map((e) => [e.name, e]));
+
+  const undocumented = result.undocumented.filter((u) => !known.has(u.name));
+  const stale = baseline.undocumented
+    .filter((e) => !result.undocumented.some((u) => u.name === e.name))
+    .map((e) => e.name);
+
+  return { ...result, undocumented, stale };
+}
+
+function report({ unknown, mismatched, undocumented, stale }, sdks) {
+  const lines = [];
+
+  lines.push('Sources:');
+  for (const sdk of sdks) {
+    lines.push(`  ${sdk.name.padEnd(5)} ${sdk.repo}@${sdk.sha} — ${sdk.metrics.size} metrics`);
+    for (const u of sdk.unused) {
+      lines.push(`      excluded ${u.name} (${u.identifier} is never referenced)`);
+    }
+  }
+  lines.push('');
+
+  if (unknown.length) {
+    lines.push('Documented but not found in any SDK (likely a wrong name):');
+    for (const u of unknown) {
+      lines.push(`  ${u.name} — page says ${u.documented}`);
+    }
+    lines.push('');
+  }
+
+  if (mismatched.length) {
+    lines.push('Availability disagrees with the SDK sources:');
+    for (const m of mismatched) {
+      lines.push(`  ${m.name}\n      page:   ${m.documented}\n      source: ${m.actual}`);
+    }
+    lines.push('');
+  }
+
+  if (undocumented.length) {
+    lines.push('Emitted by an SDK but not documented, and not in the baseline:');
+    for (const u of undocumented) {
+      const notes = u.annotations.length ? ` [${u.annotations.join(', ')}]` : '';
+      lines.push(`  ${u.name} — ${u.sdks}${notes}`);
+    }
+    lines.push('');
+  }
+
+  if (stale?.length) {
+    lines.push('Baseline entries the SDKs no longer define (remove them):');
+    for (const name of stale) lines.push(`  ${name}`);
+    lines.push('');
+  }
+
+  const total = unknown.length + mismatched.length + undocumented.length + (stale?.length ?? 0);
+  lines.push(total === 0 ? 'No drift found.' : `${total} difference(s) between the page and the SDK sources.`);
+
+  return lines.join('\n');
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const json = args.includes('--json');
+  const cacheIndex = args.indexOf('--cache-dir');
+  const cacheDir = cacheIndex === -1 ? path.join(os.tmpdir(), 'temporal-sdk-sources') : args[cacheIndex + 1];
+
+  const rows = parseTable(fs.readFileSync(path.join(process.cwd(), PAGE), 'utf8')).filter((r) => r.name);
+
+  if (rows.length === 0) {
+    console.error(`No metrics found in ${PAGE}.`);
+    process.exit(1);
+  }
+
+  const sdks = SDKS.map((sdk) => collectSdk(sdk, cacheDir));
+  const baseline = JSON.parse(fs.readFileSync(BASELINE, 'utf8'));
+  const raw = compare(rows, sdks);
+  const result = applyBaseline(raw, baseline);
+
+  if (args.includes('--update-baseline')) {
+    const notes = new Map(baseline.undocumented.map((e) => [e.name, e.note]));
+    const updated = {
+      comment: baseline.comment,
+      undocumented: raw.undocumented.map((u) => ({
+        name: u.name,
+        sdks: u.sdks,
+        note: notes.get(u.name) ?? '',
+      })),
+    };
+    fs.writeFileSync(BASELINE, `${JSON.stringify(updated, null, 2)}\n`);
+    console.log(
+      `Wrote ${BASELINE} with ${updated.undocumented.length} entries. ` + 'Add a note for any entry that has none.'
+    );
+    return;
+  }
+
+  if (json) {
+    console.log(
+      JSON.stringify(
+        {
+          page: PAGE,
+          documented: rows.length,
+          sources: sdks.map((s) => ({
+            sdk: s.name,
+            repo: s.repo,
+            sha: s.sha,
+            metrics: s.metrics.size,
+          })),
+          ...result,
+        },
+        null,
+        2
+      )
+    );
+  } else {
+    console.log(report(result, sdks));
+  }
+
+  return result.unknown.length + result.mismatched.length + result.undocumented.length + result.stale.length;
+}
+
+module.exports = {
+  SDKS,
+  BASELINE,
+  applyBaseline,
+  stripRustTestModule,
+  extractRust,
+  extractGo,
+  extractJava,
+  resolveConcatenations,
+  compare,
+};
+
+if (require.main === module) {
+  try {
+    if (main() > 0) process.exit(2);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/bin/check-metrics-against-sdks.test.js
+++ b/bin/check-metrics-against-sdks.test.js
@@ -1,0 +1,371 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const {
+  SDKS,
+  BASELINE,
+  applyBaseline,
+  stripRustTestModule,
+  extractRust,
+  extractGo,
+  extractJava,
+  resolveConcatenations,
+  compare,
+} = require('./check-metrics-against-sdks.js');
+
+// Snippets in the shape each SDK actually writes, trimmed to the cases the
+// extractors have to get right. Anything exercised here was a real bug or a
+// real trap in the sources at the time it was written.
+
+const RUST = `
+const NUM_POLLERS_NAME: &str = "num_pollers";
+pub const WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME: &str = "workflow_endtoend_latency";
+const KEY_NAMESPACE: &str = "namespace";
+
+fn workflow_completed(meter: &Meter) -> Counter {
+    meter.counter(MetricParameters {
+        name: "workflow_completed".into(),
+        description: "Count of workflows completed".into(),
+    })
+}
+
+fn pollers(meter: &Meter) -> Gauge {
+    meter.gauge(MetricParameters {
+        name: NUM_POLLERS_NAME.into(),
+        description: "Current number of pollers".into(),
+    })
+}
+
+fn e2e(meter: &Meter) -> Histogram {
+    meter.histogram_duration(MetricParameters {
+        name: WORKFLOW_E2E_LATENCY_HISTOGRAM_NAME.into(),
+        unit: "duration".into(),
+    })
+}
+
+fn slots(meter: &Meter) {
+    let mem_usage = meter.gauge_f64("resource_slots_mem_usage".into());
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fake(meter: &Meter) {
+        meter.counter(MetricParameters {
+            name: "ctr".into(),
+        });
+    }
+}
+`;
+
+const GO = `
+const (
+	TemporalMetricsPrefix = "temporal_"
+
+	WorkflowCompletedCounter = TemporalMetricsPrefix + "workflow_completed"
+	TemporalRequest          = TemporalMetricsPrefix + "request"
+	TemporalRequestFailure   = TemporalRequest + "_failure"
+	LocalActivityFailedCounter = TemporalMetricsPrefix + "local_activity_failed" // Deprecated: use LocalActivityExecutionFailedCounter instead.
+	// Deprecated: use WorkflowCompletedCounter instead.
+	LocalActivityCanceledCounter = TemporalMetricsPrefix + "local_activity_canceled"
+	WorkflowActiveThreadCount    = TemporalMetricsPrefix + "workflow_active_thread_count"
+)
+
+const (
+	ClientTagValue = "temporal_go"
+	NamespaceTagName = "namespace"
+)
+`;
+
+const JAVA = `
+public class MetricsType {
+  public static final String TEMPORAL_METRICS_PREFIX = "temporal_";
+
+  public static final String WORKFLOW_COMPLETED_COUNTER =
+      TEMPORAL_METRICS_PREFIX + "workflow_completed";
+
+  /** Emitted when a Workflow Task heartbeats; see @Deprecated docs elsewhere. */
+  public static final String WORKFLOW_TASK_HEARTBEAT_COUNTER =
+      TEMPORAL_METRICS_PREFIX + "workflow_task_heartbeat";
+
+  @Deprecated
+  public static final String ACTIVITY_CANCELED_COUNTER =
+      TEMPORAL_METRICS_PREFIX + "activity_canceled";
+
+  @Experimental
+  public static final String NEXUS_POLL_NO_TASK_COUNTER =
+      TEMPORAL_METRICS_PREFIX + "nexus_poll_no_task";
+}
+`;
+
+describe('stripRustTestModule', () => {
+  it('drops the inline test module', () => {
+    const body = stripRustTestModule(RUST);
+    assert.ok(!body.includes('"ctr"'));
+    assert.ok(body.includes('"workflow_completed"'));
+  });
+
+  it('leaves a file with no test module alone', () => {
+    const source = 'const A: &str = "a";\n';
+    assert.strictEqual(stripRustTestModule(source), source);
+  });
+
+  it('keeps a #[cfg(test)] that is not a module', () => {
+    const source = '#[cfg(test)]\nuse crate::TelemetryInstance;\nconst A: &str = "a";';
+    assert.ok(stripRustTestModule(source).includes('const A'));
+  });
+});
+
+describe('extractRust', () => {
+  const names = extractRust([{ source: RUST }]).map((m) => m.name);
+
+  it('reads names given as literals', () => {
+    assert.ok(names.includes('workflow_completed'));
+  });
+
+  it('resolves names given as constants', () => {
+    assert.ok(names.includes('num_pollers'));
+    assert.ok(names.includes('workflow_endtoend_latency'));
+  });
+
+  it('reads names from direct meter calls', () => {
+    assert.ok(names.includes('resource_slots_mem_usage'));
+  });
+
+  it('ignores constants that are never registered as metrics', () => {
+    assert.ok(!names.includes('namespace'));
+  });
+
+  it('ignores instruments registered only in tests', () => {
+    assert.ok(!names.includes('ctr'));
+  });
+
+  it('resolves constants defined in a different file of the same SDK', () => {
+    const found = extractRust([
+      { source: 'pub const SHARED_NAME: &str = "shared_metric";' },
+      { source: 'meter.counter(MetricParameters { name: SHARED_NAME.into() });' },
+    ]);
+    assert.deepStrictEqual(
+      found.map((m) => m.name),
+      ['shared_metric']
+    );
+  });
+});
+
+describe('extractGo', () => {
+  const found = extractGo([{ source: GO }]);
+  const names = found.map((m) => m.name);
+
+  it('strips the prefix constant', () => {
+    assert.ok(names.includes('workflow_completed'));
+  });
+
+  it('resolves a name chained off another metric constant', () => {
+    assert.ok(names.includes('request_failure'));
+  });
+
+  it('ignores tag values that merely start with temporal_', () => {
+    assert.ok(!names.includes('go'));
+  });
+
+  it('ignores constants that are not metric names', () => {
+    assert.ok(!names.includes('namespace'));
+  });
+
+  it('records the identifier so usage can be checked', () => {
+    const metric = found.find((m) => m.name === 'workflow_active_thread_count');
+    assert.strictEqual(metric.identifier, 'WorkflowActiveThreadCount');
+  });
+
+  it('picks up a trailing deprecation comment', () => {
+    const metric = found.find((m) => m.name === 'local_activity_failed');
+    assert.deepStrictEqual(metric.annotations, ['Deprecated']);
+  });
+
+  it('picks up a preceding deprecation comment', () => {
+    const metric = found.find((m) => m.name === 'local_activity_canceled');
+    assert.deepStrictEqual(metric.annotations, ['Deprecated']);
+  });
+
+  it('does not carry a deprecation onto the next constant', () => {
+    const metric = found.find((m) => m.name === 'workflow_active_thread_count');
+    assert.deepStrictEqual(metric.annotations, []);
+  });
+});
+
+describe('extractJava', () => {
+  const found = extractJava([{ source: JAVA }]);
+  const names = found.map((m) => m.name);
+
+  it('reads names split across lines', () => {
+    assert.ok(names.includes('workflow_completed'));
+  });
+
+  it('records annotations', () => {
+    assert.deepStrictEqual(found.find((m) => m.name === 'activity_canceled').annotations, ['Deprecated']);
+    assert.deepStrictEqual(found.find((m) => m.name === 'nexus_poll_no_task').annotations, ['Experimental']);
+  });
+
+  it('does not read an annotation out of a comment', () => {
+    assert.deepStrictEqual(found.find((m) => m.name === 'workflow_task_heartbeat').annotations, []);
+  });
+
+  it('ignores the prefix constant itself', () => {
+    assert.ok(!names.includes(''));
+  });
+});
+
+describe('resolveConcatenations', () => {
+  it('resolves in any declaration order', () => {
+    const values = resolveConcatenations([
+      { identifier: 'B', expression: 'A + "_failure"' },
+      { identifier: 'A', expression: 'PREFIX + "request"' },
+      { identifier: 'PREFIX', expression: '"temporal_"' },
+    ]);
+    assert.strictEqual(values.get('B'), 'temporal_request_failure');
+  });
+
+  it('gives up on an unresolvable reference instead of guessing', () => {
+    const values = resolveConcatenations([{ identifier: 'A', expression: 'someFunc() + "x"' }]);
+    assert.strictEqual(values.get('A'), undefined);
+  });
+
+  it('does not hang on a cycle', () => {
+    const values = resolveConcatenations([
+      { identifier: 'A', expression: 'B + "a"' },
+      { identifier: 'B', expression: 'A + "b"' },
+    ]);
+    assert.strictEqual(values.get('A'), undefined);
+  });
+});
+
+describe('compare', () => {
+  const sdk = (name, metrics) => ({
+    name,
+    metrics: new Map(metrics.map((m) => [m, { name: m, identifier: null, annotations: [] }])),
+  });
+
+  it('reports nothing when the page matches the sources', () => {
+    const result = compare(
+      [{ name: 'worker_start', availability: 'Core, Go' }],
+      [sdk('Core', ['worker_start']), sdk('Go', ['worker_start'])]
+    );
+    assert.deepStrictEqual(result, {
+      unknown: [],
+      mismatched: [],
+      undocumented: [],
+    });
+  });
+
+  it('flags a documented metric no SDK defines', () => {
+    const result = compare([{ name: 'invented_metric', availability: 'Go' }], [sdk('Go', ['worker_start'])]);
+    assert.deepStrictEqual(result.unknown, [{ name: 'invented_metric', documented: 'Go' }]);
+  });
+
+  it('flags an availability list that is missing an SDK', () => {
+    const result = compare(
+      [{ name: 'worker_start', availability: 'Go' }],
+      [sdk('Core', ['worker_start']), sdk('Go', ['worker_start'])]
+    );
+    assert.deepStrictEqual(result.mismatched, [{ name: 'worker_start', documented: 'Go', actual: 'Core, Go' }]);
+  });
+
+  it('flags an availability list claiming an SDK that lacks the metric', () => {
+    const result = compare(
+      [{ name: 'worker_start', availability: 'Core, Go' }],
+      [sdk('Core', ['worker_start']), sdk('Go', [])]
+    );
+    assert.deepStrictEqual(result.mismatched, [{ name: 'worker_start', documented: 'Core, Go', actual: 'Core' }]);
+  });
+
+  it('flags a metric the SDKs define but the page omits', () => {
+    const result = compare(
+      [{ name: 'worker_start', availability: 'Go' }],
+      [sdk('Go', ['worker_start', 'secret_metric'])]
+    );
+    assert.deepStrictEqual(result.undocumented, [{ name: 'secret_metric', sdks: 'Go', annotations: [] }]);
+  });
+
+  it('orders availability the way the page does', () => {
+    const result = compare(
+      [{ name: 'worker_start', availability: 'Core, Go, Java' }],
+      [sdk('Core', ['worker_start']), sdk('Go', ['worker_start']), sdk('Java', ['worker_start'])]
+    );
+    assert.deepStrictEqual(result.mismatched, []);
+  });
+});
+
+describe('applyBaseline', () => {
+  const result = {
+    unknown: [],
+    mismatched: [],
+    undocumented: [
+      { name: 'known_alias', sdks: 'Go', annotations: [] },
+      { name: 'brand_new', sdks: 'Java', annotations: [] },
+    ],
+  };
+  const baseline = {
+    undocumented: [{ name: 'known_alias', sdks: 'Go', note: 'Deprecated.' }],
+  };
+
+  it('suppresses metrics we have decided not to document', () => {
+    assert.deepStrictEqual(
+      applyBaseline(result, baseline).undocumented.map((u) => u.name),
+      ['brand_new']
+    );
+  });
+
+  it('reports a baseline entry the SDKs no longer define', () => {
+    const gone = { ...result, undocumented: [] };
+    assert.deepStrictEqual(applyBaseline(gone, baseline).stale, ['known_alias']);
+  });
+
+  it('never suppresses a wrong name or a wrong availability', () => {
+    const wrong = {
+      unknown: [{ name: 'known_alias', documented: 'Go' }],
+      mismatched: [{ name: 'known_alias', documented: 'Go', actual: 'Java' }],
+      undocumented: [],
+    };
+    const applied = applyBaseline(wrong, baseline);
+    assert.strictEqual(applied.unknown.length, 1);
+    assert.strictEqual(applied.mismatched.length, 1);
+  });
+});
+
+describe('the checked-in baseline', () => {
+  const baseline = JSON.parse(fs.readFileSync(path.join(__dirname, '..', BASELINE), 'utf8'));
+
+  it('lists each entry once', () => {
+    const names = baseline.undocumented.map((e) => e.name);
+    assert.deepStrictEqual(names, [...new Set(names)]);
+  });
+
+  it('stays sorted so regenerating it produces a readable diff', () => {
+    const names = baseline.undocumented.map((e) => e.name);
+    assert.deepStrictEqual(names, [...names].sort());
+  });
+
+  it('gives every entry a name and the SDKs that define it', () => {
+    for (const entry of baseline.undocumented) {
+      assert.match(entry.name, /^[a-z][a-z0-9_]*$/);
+      assert.ok(entry.sdks, `${entry.name} is missing its sdks`);
+      assert.strictEqual(typeof entry.note, 'string');
+    }
+  });
+});
+
+describe('SDK configuration', () => {
+  it('names the SDKs the page uses in its availability column', () => {
+    assert.deepStrictEqual(
+      SDKS.map((s) => s.name),
+      ['Core', 'Go', 'Java']
+    );
+  });
+
+  it('checks usage for the SDKs that declare names away from the emit site', () => {
+    const usage = Object.fromEntries(SDKS.map((s) => [s.name, s.checkUsage]));
+    assert.deepStrictEqual(usage, { Core: false, Go: true, Java: true });
+  });
+});

--- a/bin/metrics-baseline.json
+++ b/bin/metrics-baseline.json
@@ -1,0 +1,70 @@
+{
+  "comment": "Metrics the SDKs define but docs/references/sdk-metrics.mdx does not document. bin/check-metrics-against-sdks.js reports anything not listed here, so this file is the record of what we have decided not to document. An empty note means the entry has not been reviewed yet; fill it in or document the metric and remove the entry. Regenerate with: yarn check:metrics:sdks --update-baseline",
+  "undocumented": [
+    {
+      "name": "activity_canceled",
+      "sdks": "Java",
+      "note": "Deprecated in the SDK. Superseded by activity_execution_cancelled."
+    },
+    {
+      "name": "activity_task_received",
+      "sdks": "Core",
+      "note": ""
+    },
+    {
+      "name": "local_activity_canceled",
+      "sdks": "Go, Java",
+      "note": "Deprecated in both SDKs. Superseded by local_activity_execution_cancelled."
+    },
+    {
+      "name": "local_activity_error",
+      "sdks": "Go",
+      "note": ""
+    },
+    {
+      "name": "local_activity_failed",
+      "sdks": "Go, Java",
+      "note": "Deprecated in both SDKs. Superseded by local_activity_execution_failed."
+    },
+    {
+      "name": "long_request_resource_exhausted",
+      "sdks": "Go",
+      "note": ""
+    },
+    {
+      "name": "request_resource_exhausted",
+      "sdks": "Go",
+      "note": ""
+    },
+    {
+      "name": "resource_slots_cpu_pid_output",
+      "sdks": "Core, Java",
+      "note": ""
+    },
+    {
+      "name": "resource_slots_mem_pid_output",
+      "sdks": "Core, Java",
+      "note": ""
+    },
+    {
+      "name": "sticky_cache_thread_forced_eviction",
+      "sdks": "Java",
+      "note": ""
+    },
+    {
+      "name": "workflow_task_execution_total_latency",
+      "sdks": "Java",
+      "note": ""
+    },
+    {
+      "name": "workflow_task_heartbeat",
+      "sdks": "Java",
+      "note": ""
+    },
+    {
+      "name": "workflow_task_no_completion",
+      "sdks": "Java",
+      "note": "Go declares WorkflowTaskNoCompletionCounter but never references it, so it is Java only."
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "validate:og-images": "node ./bin/validate-og-images.js",
     "check:og-budget": "node ./bin/check-og-build-budget.js",
     "check:metrics": "node ./bin/check-metrics-reference.js",
+    "check:metrics:sdks": "node ./bin/check-metrics-against-sdks.js",
     "test": "node --test",
     "lint": "vale --output=JSON docs/**/**/*.mdx > vale-output.json; vale --output=JSON docs/**/**/*.md > vale-md-output.json",
     "lint:go": "vale docs/develop/go/*.mdx",


### PR DESCRIPTION
Follow-up to #4985 (content fixes) and #4986 (internal consistency check).

#4986 proves `docs/references/sdk-metrics.mdx` doesn't contradict itself. It can't tell you the page is *wrong* — a metric that never existed, or an availability list missing an SDK, passes it happily. Those were the errors the manual audit in #4985 actually found. This check closes that gap by comparing the page against the metric definitions in `sdk-rust`, `sdk-go`, and `sdk-java`.

## What it reports

- Documented metrics that no SDK defines (a wrong name).
- Availability lists that disagree with the sources, in either direction.
- Metrics an SDK defines that the page omits, unless they're in the baseline.
- Baseline entries the SDKs no longer define.

## Validation

Run against the page as merged, it reports **zero wrong names and zero availability mismatches** across all 48 metrics. That independently reproduces the availability table I verified by hand for #4985, which is the main evidence the extractors are trustworthy.

## Design notes

**Advisory, not a merge gate.** The SDK default branches run ahead of released versions, so drift here is often "the SDK changed," not "the docs are wrong." A weekly job opens (and updates, and later closes) a single tracking issue. Exit codes are 0 clean, 2 drift, 1 the comparison couldn't run.

**A constant that's declared but never referenced isn't emitted.** `sdk-go` declares `WorkflowActiveThreadCount` and never uses it; trusting the declaration would wrongly credit Go with that metric. The check greps each repo for the identifier and drops unreferenced ones. This caught a second case: `WorkflowTaskNoCompletionCounter` is also dead in `sdk-go`, so `workflow_task_no_completion` is Java-only. **My review packet on #4985 listed it under Go — that was wrong.**

**Definition files are listed explicitly, not discovered.** If one is renamed upstream the check fails loudly with exit 1 rather than quietly reporting that an SDK stopped emitting metrics.

**The baseline is the record of what we chose not to document.** `bin/metrics-baseline.json` holds the 13 metrics the SDKs define but the page omits, so the job only alerts on *new* drift. Three are confirmed deprecated aliases. **The nine with an empty `note` are the open questions** — I didn't want to invent justifications for metrics I haven't confirmed with the SDK team:

| Metric | SDKs |
|---|---|
| `activity_task_received` | Core |
| `local_activity_error` | Go |
| `request_resource_exhausted`, `long_request_resource_exhausted` | Go |
| `resource_slots_cpu_pid_output`, `resource_slots_mem_pid_output` | Core, Java |
| `sticky_cache_thread_forced_eviction` | Java |
| `workflow_task_execution_total_latency` | Java |
| `workflow_task_heartbeat` | Java |
| `workflow_task_no_completion` | Java |

The two `resource_slots_*_pid_output` gauges look like tuner internals, and the two `*_resource_exhausted` counters look like genuine gaps in the page. Both are worth a second opinion before I either document them or write a note.

## Test plan

- [x] `node --test bin/check-metrics-against-sdks.test.js` — 38 tests, offline, over fixture snippets in each language
- [x] Clean run exits 0; a removed baseline entry and a stale one both surface and exit 2
- [x] Deleting a definition file produces the "renamed upstream" error and exit 1
- [x] Fresh clone into an empty cache dir works; three shallow clones total 37MB and take ~6s
- [x] `yarn check:metrics` still passes and its 22 tests still pass
- [ ] Confirm the scheduled run opens the tracking issue as expected (needs a `workflow_dispatch` after merge)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217077419657186">EDU-6859 Add scheduled check comparing the SDK metrics reference with the SDK sources</a>
