### PR TITLE
docs(external-storage): mark the TypeScript page as Pre-release

### DIFF
--- a/docs/develop/typescript/best-practices/data-handling/external-storage.mdx
+++ b/docs/develop/typescript/best-practices/data-handling/external-storage.mdx
@@ -12,7 +12,7 @@ description: Offload large payloads to external storage using the claim check pa
 
 import { ReleaseNoteHeader } from '@site/src/components';
 
-<ReleaseNoteHeader featureName="externalStorage">
+<ReleaseNoteHeader type="prerelease">
   APIs and configuration may change before General Availability. Join the
   [#large-payloads Slack channel](https://temporalio.slack.com/archives/C09VA2DE15Y) to provide feedback or ask for
   help.


### PR DESCRIPTION
External Storage is Public Preview overall, but the TypeScript implementation is not there yet, so the TypeScript page should not inherit the shared stage.

## The one-line change

```diff
-<ReleaseNoteHeader featureName="externalStorage">
+<ReleaseNoteHeader type="prerelease">
```

## Verified

Both renderers resolve independently, so both were checked against the build output:

| Page | Rendered HTML | Generated `.md` |
|---|---|---|
| TypeScript | `release-stages#pre-release` | `> **Pre-release**` |
| Go | `release-stages#public-preview` | `Public Preview` |
| Python | `release-stages#public-preview` | `Public Preview` |
| Encyclopedia | `release-stages#public-preview` | `Public Preview` |

`yarn build` exit 0. Vale CI-scoped: 0 errors.


┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217074952607523">EDU-6862 docs(external-storage): mark the TypeScript page as Pre-release</a>
