### PR TITLE
Fix stale featureName in ReleaseNoteHeader test

### DIFF
--- a/tests/test-mdx-to-md.mjs
+++ b/tests/test-mdx-to-md.mjs
@@ -663,7 +663,7 @@ test("ReleaseNoteHeader resolves label from featureName in paired form", () => {
 });
 
 test("ReleaseNoteHeader featureName overrides explicit type when mapped", () => {
-  const input = `<ReleaseNoteHeader featureName="serverlessWorkers" type="publicPreview">\nBody.\n</ReleaseNoteHeader>`;
+  const input = `<ReleaseNoteHeader featureName="serverlessWorkersCloudRun" type="publicPreview">\nBody.\n</ReleaseNoteHeader>`;
   const { markdown } = transformMdx(input);
   assertContains(markdown, "> **Pre-release**");
 });


### PR DESCRIPTION
## Summary
- `serverlessWorkers` was split into `serverlessWorkersLambda` and `serverlessWorkersCloudRun` in `src/constants/featureReleaseTypes.js` (from the lambda worker public preview change), so the test's lookup no longer resolved and it fell back to the explicit `type` prop instead of overriding it.
- Updated the test to use `serverlessWorkersCloudRun`, which maps to `"prerelease"`, matching the existing assertion.

## Test plan
- [x] `yarn test` — 87 passed, 0 failed

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217079498783489">EDU-6863 Fix stale featureName in ReleaseNoteHeader test</a>
