### PR TITLE
Modernize GitHub links pinned to commit SHAs

### DIFF
--- a/docs/cloud/get-started/api-keys.mdx
+++ b/docs/cloud/get-started/api-keys.mdx
@@ -427,7 +427,7 @@ Do not confuse environment variables, set with your shell, with temporal env opt
 
 To use an API key with the [Cloud Ops API](/ops), securely pass the API key in your API client. For a complete example,
 see
-[Cloud Samples in Go](https://github.com/temporalio/cloud-samples-go/blob/1dd4254b6ed1937e361005c0144410e72b8a5542/client/api/apikey.go).
+[Cloud Samples in Go](https://github.com/temporalio/cloud-samples-go/blob/main/client/api/client.go).
 
 ### Terraform Provider
 

--- a/docs/develop/go/client/namespaces.mdx
+++ b/docs/develop/go/client/namespaces.mdx
@@ -142,7 +142,7 @@ Note that these APIs and Temporal CLI commands will not work with Temporal Cloud
 - Get details for all registered Namespaces on your Temporal Service:
 
   - With the Temporal CLI: [`temporal operator namespace list`](/cli/command-reference/operator#list)
-  - Use the [`ListNamespace` API](https://github.com/temporalio/api/blob/f0350f8032ad2f0c60c539b3b61ea37f412f1cf7/temporal/api/operatorservice/v1/service.proto) to return information and configuration details for all registered Namespaces on your Temporal Service.
+  - Use the [`ListNamespace` API](https://github.com/temporalio/api/blob/main/temporal/api/operatorservice/v1/service.proto) to return information and configuration details for all registered Namespaces on your Temporal Service.
     Example
 
   ```go
@@ -155,7 +155,7 @@ Note that these APIs and Temporal CLI commands will not work with Temporal Cloud
   //...
   ```
 
-- Delete a Namespace: The [`DeleteNamespace` API](https://github.com/temporalio/api/blob/f0350f8032ad2f0c60c539b3b61ea37f412f1cf7/temporal/api/operatorservice/v1/service.proto) deletes a Namespace. Deleting a Namespace deletes all running and completed Workflow Executions on the Namespace, and removes them from the persistence store and the visibility store.
+- Delete a Namespace: The [`DeleteNamespace` API](https://github.com/temporalio/api/blob/main/temporal/api/operatorservice/v1/service.proto) deletes a Namespace. Deleting a Namespace deletes all running and completed Workflow Executions on the Namespace, and removes them from the persistence store and the visibility store.
   Example:
 
   ```go

--- a/docs/develop/go/workflows/selectors.mdx
+++ b/docs/develop/go/workflows/selectors.mdx
@@ -154,7 +154,7 @@ You can use the `selector.HasPending` API to ensure that signals are not lost wh
 
 Usage of Selectors is best learned by example:
 
-- Setting up a race condition between an Activity and a Timer, and conditionally execute ([Timer example](https://github.com/temporalio/samples-go/blob/14980b3792cc3a8447318fefe9a73fe0a580d4b9/timer/workflow.go))
-- Receiving information in a Channel ([Mutex example](https://github.com/temporalio/samples-go/blob/14980b3792cc3a8447318fefe9a73fe0a580d4b9/mutex/mutex_workflow.go))
-- Looping through a list of work and scheduling them all in parallel ([DSL example](https://github.com/temporalio/samples-go/blob/14980b3792cc3a8447318fefe9a73fe0a580d4b9/dsl/workflow.go))
-- Executing activities in parallel, pick the first result, cancel remainder ([Pick First example](https://github.com/temporalio/samples-go/blob/14980b3792cc3a8447318fefe9a73fe0a580d4b9/pickfirst/pickfirst_workflow.go))
+- Setting up a race condition between an Activity and a Timer, and conditionally execute ([Timer example](https://github.com/temporalio/samples-go/blob/main/timer/workflow.go))
+- Receiving information in a Channel ([Mutex example](https://github.com/temporalio/samples-go/blob/main/mutex/mutex_workflow.go))
+- Looping through a list of work and scheduling them all in parallel ([DSL example](https://github.com/temporalio/samples-go/blob/main/dsl/workflow.go))
+- Executing activities in parallel, pick the first result, cancel remainder ([Pick First example](https://github.com/temporalio/samples-go/blob/main/pickfirst/pickfirst_workflow.go))

--- a/docs/develop/java/client/namespaces.mdx
+++ b/docs/develop/java/client/namespaces.mdx
@@ -43,7 +43,7 @@ Note that these APIs and Temporal CLI commands will not work with Temporal Cloud
 
 Use a custom [Authorizer](/self-hosted-guide/security#authorizer-plugin) on your Frontend Service in the Temporal Service to set restrictions on who can create, update, or deprecate Namespaces.
 
-Use the [`RegisterNamespace` API](https://github.com/temporalio/api/blob/f0350f8032ad2f0c60c539b3b61ea37f412f1cf7/temporal/api/workflowservice/v1/service.proto) to register a [Namespace](/namespaces) and set the [Retention Period](/temporal-service/temporal-server#retention-period) for the Workflow Execution Event History for the Namespace.
+Use the [`RegisterNamespace` API](https://github.com/temporalio/api/blob/main/temporal/api/workflowservice/v1/service.proto) to register a [Namespace](/namespaces) and set the [Retention Period](/temporal-service/temporal-server#retention-period) for the Workflow Execution Event History for the Namespace.
 
 ```java
 //...
@@ -94,7 +94,7 @@ Note that these APIs and Temporal CLI commands will not work with Temporal Cloud
 
   - With the Temporal CLI: [`temporal operator namespace update`](/cli/command-reference/operator#update)
     Example
-  - Use the [`UpdateNamespace` API](https://github.com/temporalio/api/blob/e5cf521c6fdc71c69353f3d2ac5506dd6e827af8/temporal/api/workflowservice/v1/service.proto) to update configuration on a Namespace.
+  - Use the [`UpdateNamespace` API](https://github.com/temporalio/api/blob/main/temporal/api/workflowservice/v1/service.proto) to update configuration on a Namespace.
     Example
 
   ```java
@@ -116,7 +116,7 @@ Note that these APIs and Temporal CLI commands will not work with Temporal Cloud
 - Get details for a registered Namespace on your Temporal Service:
 
   - With the Temporal CLI: [`temporal operator namespace describe`](/cli/command-reference/operator#describe)
-  - Use the [`DescribeNamespace` API](https://github.com/temporalio/api/blob/e5cf521c6fdc71c69353f3d2ac5506dd6e827af8/temporal/api/workflowservice/v1/service.proto) to return information and configuration details for a registered Namespace.
+  - Use the [`DescribeNamespace` API](https://github.com/temporalio/api/blob/main/temporal/api/workflowservice/v1/service.proto) to return information and configuration details for a registered Namespace.
     Example
 
   ```java
@@ -133,7 +133,7 @@ Note that these APIs and Temporal CLI commands will not work with Temporal Cloud
 - Get details for all registered Namespaces on your Temporal Service:
 
   - With the Temporal CLI: [`temporal operator namespace list`](/cli/command-reference/operator#list)
-  - Use the [`ListNamespace` API](https://github.com/temporalio/api/blob/e5cf521c6fdc71c69353f3d2ac5506dd6e827af8/temporal/api/workflowservice/v1/service.proto) to return information and configuration details for all registered Namespaces on your Temporal Service.
+  - Use the [`ListNamespace` API](https://github.com/temporalio/api/blob/main/temporal/api/workflowservice/v1/service.proto) to return information and configuration details for all registered Namespaces on your Temporal Service.
     Example
 
   ```java
@@ -144,7 +144,7 @@ Note that these APIs and Temporal CLI commands will not work with Temporal Cloud
   //...
   ```
 
-- Deprecate a Namespace: The [`DeprecateNamespace` API](https://github.com/temporalio/api/blob/e5cf521c6fdc71c69353f3d2ac5506dd6e827af8/temporal/api/workflowservice/v1/service.proto) updates the state of a registered Namespace to "DEPRECATED". Once a Namespace is deprecated, you cannot start new Workflow Executions on it. All existing and running Workflow Executions on a deprecated Namespace will continue to run.
+- Deprecate a Namespace: The [`DeprecateNamespace` API](https://github.com/temporalio/api/blob/main/temporal/api/workflowservice/v1/service.proto) updates the state of a registered Namespace to "DEPRECATED". Once a Namespace is deprecated, you cannot start new Workflow Executions on it. All existing and running Workflow Executions on a deprecated Namespace will continue to run.
   Example:
 
   ```java
@@ -157,7 +157,7 @@ Note that these APIs and Temporal CLI commands will not work with Temporal Cloud
   //...
   ```
 
-- Delete a Namespace: The [`DeleteNamespace` API](https://github.com/temporalio/api/blob/e5cf521c6fdc71c69353f3d2ac5506dd6e827af8/temporal/api/workflowservice/v1/service.proto) deletes a Namespace. Deleting a Namespace deletes all running and completed Workflow Executions on the Namespace, and removes them from the persistence store and the visibility store.
+- Delete a Namespace: The [`DeleteNamespace` API](https://github.com/temporalio/api/blob/main/temporal/api/workflowservice/v1/service.proto) deletes a Namespace. Deleting a Namespace deletes all running and completed Workflow Executions on the Namespace, and removes them from the persistence store and the visibility store.
 
   Example:
 

--- a/docs/develop/java/platform/observability.mdx
+++ b/docs/develop/java/platform/observability.mdx
@@ -46,7 +46,7 @@ For a complete list of metrics capable of being emitted, see the [SDK metrics re
 - For a list of metrics, see the [SDK metrics reference](/references/sdk-metrics).
 - For an end-to-end example that exposes metrics with the Java SDK, refer to the [samples-java](https://github.com/temporalio/samples-java/tree/main/core/src/main/java/io/temporal/samples/metrics) repo.
 
-To emit metrics with the Java SDK, use the [`MicrometerClientStatsReporter`](https://github.com/temporalio/sdk-java/blob/55ee7894aec427d7e384c3519732bdd61119961a/src/main/java/io/temporal/common/reporter/MicrometerClientStatsReporter.java#L34) class to integrate with Micrometer MeterRegistry configured for your metrics backend.
+To emit metrics with the Java SDK, use the [`MicrometerClientStatsReporter`](https://github.com/temporalio/sdk-java/blob/69a5d3fa44da4043697b7e57d7ef6691c24287cd/temporal-sdk/src/main/java/io/temporal/common/reporter/MicrometerClientStatsReporter.java#L18) class to integrate with Micrometer MeterRegistry configured for your metrics backend.
 [Micrometer](https://micrometer.io/docs) is a popular Java framework that provides integration with Prometheus and other backends.
 
 The following example shows how to use `MicrometerClientStatsReporter` to define the metrics scope and set it with the `WorkflowServiceStubsOptions`.

--- a/docs/develop/plugins-guide.mdx
+++ b/docs/develop/plugins-guide.mdx
@@ -44,7 +44,7 @@ If you prefer to learn by getting hands-on with code, check out some existing pl
   [OpenAI Agents SDK](https://github.com/temporalio/sdk-python/tree/main/temporalio/contrib/openai_agents) plugin
 - Temporal's Python SDK ships with a
   [LangGraph](https://github.com/temporalio/sdk-python/tree/main/temporalio/contrib/langgraph) plugin
-- [Temporal client and Worker plugin for Pydantic AI](https://github.com/pydantic/pydantic-ai/blob/757d40932ebb8ef00f25cc469ff44e9b267b1aa3/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py#L83)
+- [Temporal client and Worker plugin for Pydantic AI](https://github.com/pydantic/pydantic-ai/blob/d9b4b2540183a4426669b2824c87cdfc36144780/pydantic_ai_slim/pydantic_ai/durable_exec/temporal/__init__.py#L142)
 - Temporal's TypeScript SDK ships with an
   [OpenTelemetry Plugin](https://github.com/temporalio/sdk-typescript/blob/main/packages/interceptors-opentelemetry/src/plugin.ts)
 

--- a/docs/develop/ruby/workflows/continue-as-new.mdx
+++ b/docs/develop/ruby/workflows/continue-as-new.mdx
@@ -21,7 +21,7 @@ The Workflow Execution spawned from the use of Continue-As-New has the same Work
 
 :::caution
 
-As a precautionary measure, the Workflow Execution's Event History is limited to [51,200 Events](https://github.com/temporalio/temporal/blob/e3496b1c51bfaaae8142b78e4032cc791de8a76f/service/history/configs/config.go#L382) or [50 MB](https://github.com/temporalio/temporal/blob/e3496b1c51bfaaae8142b78e4032cc791de8a76f/service/history/configs/config.go#L380) and will warn you after 10,240 Events or 10 MB.
+As a precautionary measure, the Workflow Execution's Event History is limited to [51,200 Events](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/common/dynamicconfig/constants.go#L441) or [50 MB](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/common/dynamicconfig/constants.go#L425) and will warn you after 10,240 Events or 10 MB.
 
 :::
 

--- a/docs/develop/typescript/best-practices/debugging.mdx
+++ b/docs/develop/typescript/best-practices/debugging.mdx
@@ -87,7 +87,7 @@ When you pass a `workflowsPath`, our Webpack config expects to find `node_module
 }
 ```
 
-Temporal Workflow Bundles need to [export a set of methods that fit the compiled `worker-interface.ts` from `@temporalio/workflow`](https://github.com/temporalio/sdk-typescript/blob/eaa2d205c9bc5ff4a3b17c0b34f2dcf6b1e0264a/packages/worker/src/workflow/bundler.ts#L81) as an entry point.
+Temporal Workflow Bundles need to [export a set of methods that fit the compiled `worker-interface.ts` from `@temporalio/workflow`](https://github.com/temporalio/sdk-typescript/blob/803d95ada755736c17c5af719fa6c447e4cd75ac/packages/worker/src/workflow/bundler.ts#L180) as an entry point.
 We do offer a `bundleWorkflowCode` method to assist you with this, though it uses our Webpack settings.
 For more information, see the [Register types](/develop/typescript/workers/run-worker-process#register-types) section.
 

--- a/docs/develop/typescript/platform/observability.mdx
+++ b/docs/develop/typescript/platform/observability.mdx
@@ -59,7 +59,7 @@ Temporal Web's tracing capabilities mainly track Activity Execution within a Tem
 
 The [`interceptors-opentelemetry`](https://github.com/temporalio/samples-typescript/tree/main/interceptors-opentelemetry) sample shows how to use the SDK's built-in OpenTelemetry tracing to trace everything from starting a Workflow to Workflow Execution to running an Activity from that Workflow.
 
-The built-in tracing uses protobuf message headers (like [this one](https://github.com/temporalio/api/blob/b2b8ae6592a8730dd5be6d90569d1aea84e1712f/temporal/api/workflowservice/v1/request_response.proto#L161) when starting a Workflow) to propagate the tracing information from the client to the Workflow and from the Workflow to its successors (when Continued As New), children, and Activities.
+The built-in tracing uses protobuf message headers (like [this one](https://github.com/temporalio/api/blob/70cec27214ec2173974fb045667df324b45e705c/temporal/api/workflowservice/v1/request_response.proto#L180) when starting a Workflow) to propagate the tracing information from the client to the Workflow and from the Workflow to its successors (when Continued As New), children, and Activities.
 All of these executions are linked with a single trace identifier and have the proper `parent -> child` span relation.
 
 Tracing is compatible between different Temporal SDKs as long as compatible [context propagators](https://opentelemetry.io/docs/concepts/context-propagation/) are used.

--- a/docs/develop/typescript/workers/run-process.mdx
+++ b/docs/develop/typescript/workers/run-process.mdx
@@ -188,7 +188,7 @@ Workers shut down if they receive any of the Signals enumerated in
 `'SIGTERM'`, `'SIGQUIT'`, and `'SIGUSR2'`.
 
 In development, shut down Workers with `Ctrl+C` (`SIGINT`) or
-[nodemon](https://github.com/temporalio/samples-typescript/blob/c37bae3ea235d1b6956fcbe805478aa46af973ce/hello-world/package.json#L10)
+[nodemon](https://github.com/temporalio/samples-typescript/blob/277ce0e858cd74a582c83991aaf4430a53653aab/hello-world/package.json#L12)
 (`SIGUSR2`). In production, give Workers time to finish in-progress Activities by setting
 [shutdownGraceTime](https://typescript.temporal.io/api/interfaces/worker.WorkerOptions#shutdowngracetime):
 

--- a/docs/develop/typescript/workflows/message-passing.mdx
+++ b/docs/develop/typescript/workflows/message-passing.mdx
@@ -772,7 +772,7 @@ inlineSignal(`task-${taskBId}`, (payload) => {
 
 The semantic of `defineSignal` and `defineQuery` is intentional.
 They return Signal and Query **definitions**, not unique instances of Signals and Queries themselves
-The following is their [entire source code](https://github.com/temporalio/sdk-typescript/blob/fc658d3760e6653aec47732ab17a0062b7dd23fc/packages/workflow/src/workflow.ts#L883-L907):
+The following is their [entire source code](https://github.com/temporalio/sdk-typescript/blob/803d95ada755736c17c5af719fa6c447e4cd75ac/packages/workflow/src/workflow.ts#L1268-L1296):
 
 ```ts
 /**

--- a/docs/develop/worker-performance.mdx
+++ b/docs/develop/worker-performance.mdx
@@ -689,7 +689,7 @@ The `maxWorkflowThreadCount` and `workflow_active_thread_count` parameters are f
 
 :::info
 
-The information listed in this section is readable using the `DescribeTaskQueueEnhanced` method in the [Go SDK](https://github.com/temporalio/sdk-go/blob/74320648ab0e4178b1fedde01672f9b5b9f6c898/client/client.go), with the [Temporal CLI](https://github.com/temporalio/cli/releases/tag/v1.1.0) `task-queue describe` command, and using `DescribeTaskQueue` through RPC.
+The information listed in this section is readable using the `DescribeTaskQueueEnhanced` method in the [Go SDK](https://github.com/temporalio/sdk-go/blob/main/client/client.go), with the [Temporal CLI](https://github.com/temporalio/cli/releases/tag/v1.1.0) `task-queue describe` command, and using `DescribeTaskQueue` through RPC.
 
 :::
 

--- a/docs/encyclopedia/child-workflows/parent-close-policy.mdx
+++ b/docs/encyclopedia/child-workflows/parent-close-policy.mdx
@@ -49,7 +49,7 @@ There are three possible values:
 - **Request Cancel:** a Cancellation request is sent to the Child Workflow Execution.
 - **Terminate** (default): the Child Workflow Execution is forcefully Terminated.
 
-[`ParentClosePolicy`](https://github.com/temporalio/api/blob/c1f04d0856a3ba2995e92717607f83536b5a44f5/temporal/api/enums/v1/workflow.proto#L44) proto definition.
+[`ParentClosePolicy`](https://github.com/temporalio/api/blob/70cec27214ec2173974fb045667df324b45e705c/temporal/api/enums/v1/workflow.proto#L50) proto definition.
 
 Each Child Workflow Execution may have its own Parent Close Policy.
 This policy applies only to Child Workflow Executions and has no effect otherwise.

--- a/docs/encyclopedia/nexus/nexus-endpoints.mdx
+++ b/docs/encyclopedia/nexus/nexus-endpoints.mdx
@@ -29,7 +29,7 @@ The Endpoint description field supports markdown for documenting available Opera
 A Nexus Endpoint acts as a reverse proxy for a single Nexus Service, routing requests to one target Namespace and Task Queue.
 
 Unlike general-purpose proxies, it does not route to multiple backends. Instead, it provides a secure, managed connection to a specific upstream target, which can be in any region or cloud.
-The [EndpointSpec](https://github.com/temporalio/api/blob/2a5b3951e71565e28628edea1b3d88d69ed26607/temporal/api/nexus/v1/message.proto#L170) support the following [target type](https://github.com/temporalio/api/blob/2a5b3951e71565e28628edea1b3d88d69ed26607/temporal/api/nexus/v1/message.proto#L185):
+The [EndpointSpec](https://github.com/temporalio/api/blob/70cec27214ec2173974fb045667df324b45e705c/temporal/api/nexus/v1/message.proto#L182) support the following [target type](https://github.com/temporalio/api/blob/70cec27214ec2173974fb045667df324b45e705c/temporal/api/nexus/v1/message.proto#L197):
 
 - **Worker**: Route to a target Namespace and Task Queue.
 

--- a/docs/encyclopedia/nexus/nexus-operations.mdx
+++ b/docs/encyclopedia/nexus/nexus-operations.mdx
@@ -170,7 +170,7 @@ At a high level, when a caller Workflow executes a Nexus Operation:
 Once the caller Workflow schedules an Operation with the caller's Temporal Service, the caller's Nexus Machinery keeps trying to start the Operation.
 If a [retryable Nexus error](/references/failures#nexus-errors) is returned the Nexus Machinery will retry until the Nexus Operation's [Schedule-to-Start timeout](#schedule-to-start-timeout) or [Schedule-to-close timeout](#schedule-to-close-timeout) is exceeded.
 
-For example, if a Nexus handler returns a [retryable error](/references/failures#nexus-errors), or an [upstream timeout](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors) is encountered by the caller, the Nexus request will be retried up to the [default Retry Policy's](https://github.com/temporalio/temporal/blob/de7c8879e103be666a7b067cc1b247f0ac63c25c/components/nexusoperations/config.go#L111) max attempts and expiration interval.
+For example, if a Nexus handler returns a [retryable error](/references/failures#nexus-errors), or an [upstream timeout](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors) is encountered by the caller, the Nexus request will be retried up to the [default Retry Policy's](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/components/nexusoperations/config.go#L204) max attempts and expiration interval.
 
 :::note
 This differs from Activity and Workflow error handling.

--- a/docs/encyclopedia/workflow/workflow-execution/limits.mdx
+++ b/docs/encyclopedia/workflow/workflow-execution/limits.mdx
@@ -22,7 +22,7 @@ There is no limit to the number of concurrent Workflow Executions, albeit you mu
 
 :::caution
 
-As a precautionary measure, the Workflow Execution's Event History is limited to [51,200 Events](https://github.com/temporalio/temporal/blob/e3496b1c51bfaaae8142b78e4032cc791de8a76f/service/history/configs/config.go#L382) or [50 MB](https://github.com/temporalio/temporal/blob/e3496b1c51bfaaae8142b78e4032cc791de8a76f/service/history/configs/config.go#L380) and will warn you after 10,240 Events or 10 MB.
+As a precautionary measure, the Workflow Execution's Event History is limited to [51,200 Events](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/common/dynamicconfig/constants.go#L441) or [50 MB](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/common/dynamicconfig/constants.go#L425) and will warn you after 10,240 Events or 10 MB.
 
 :::
 
@@ -46,7 +46,9 @@ There is a limit to the total number of Workflow Callbacks that may be attached 
 Attaching [multiple Nexus callers to a handler Workflow](/nexus/operations#attaching-multiple-nexus-callers) may exceed these limits.
 
 These limits can be set with the following dynamic configuration keys:
-- [MaxCallbacksPerWorkflow](https://github.com/temporalio/temporal/blob/3b626075691c483871630d4a4df266e783f86328/common/dynamicconfig/constants.go#L998)
+- [MaxCallbacksPerWorkflow](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/common/dynamicconfig/constants.go#L1082)
+{/* TODO: MaxCHASMCallbacksPerWorkflow has been removed from temporalio/temporal (it was marked temporary,
+pending full CHASM rollout). Decide whether to drop this bullet or replace it with the current equivalent. */}
 - [MaxCHASMCallbacksPerWorkflow](https://github.com/temporalio/temporal/blob/3b626075691c483871630d4a4df266e783f86328/common/dynamicconfig/constants.go#L1005)
 
 ## Workflow Execution Nexus Operation Limits {/* #workflow-execution-nexus-operation-limits */}
@@ -57,6 +59,6 @@ Too many entries in a single Workflow Execution's mutable state causes unstable 
 To protect the system, Temporal enforces a maximum number of incomplete Nexus Operation requests per Workflow Execution (by default, 30 Nexus Operations).
 Once the limit is reached for a type of operation, if the Workflow Execution attempts to start another Nexus operation (by producing a ScheduleNexusOperation), it will be unable to do so (the Workflow Task Execution will fail and get retried).
 
-These limits are set with the following [dynamic configuration keys](https://github.com/temporalio/temporal/blob/de7c8879e103be666a7b067cc1b247f0ac63c25c/components/nexusoperations/config.go#L38):
+These limits are set with the following [dynamic configuration keys](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/components/nexusoperations/config.go#L36):
 
 - MaxConcurrentOperations

--- a/docs/production-deployment/self-hosted-guide/monitoring.mdx
+++ b/docs/production-deployment/self-hosted-guide/monitoring.mdx
@@ -184,7 +184,7 @@ Refer to the [Cluster metrics](/references/cluster-metrics) and [SDK metrics](/r
 
 ## Configuring Temporal Service health checks {/* #health-checks */}
 
-The [Frontend Service](/temporal-service/temporal-server#frontend-service) supports TCP or [gRPC](https://github.com/grpc/grpc/blob/875066b61e3b57af4bb1d6e36aabe95a4f6ba4f7/src/proto/grpc/health/v1/health.proto#L45) health checks on port 7233.
+The [Frontend Service](/temporal-service/temporal-server#frontend-service) supports TCP or [gRPC](https://github.com/grpc/grpc/blob/ee389ed222de898ae419c8c5ef8c213573ce5c55/src/proto/grpc/health/v1/health.proto#L45) health checks on port 7233.
 
 If you use [Nomad](https://www.nomadproject.io/) to manage your containers, the [check stanza](https://developer.hashicorp.com/nomad/docs/job-specification/check) would look like this for TCP:
 

--- a/docs/production-deployment/self-hosted-guide/security.mdx
+++ b/docs/production-deployment/self-hosted-guide/security.mdx
@@ -144,7 +144,7 @@ temporal-ui:
 ```
 
 For more general guidance for configuration, refer to the [Temporal UI README](https://github.com/temporalio/ui?tab=readme-ov-file#configuration).
-For more details on configuration with Docker, refer to [Temporal UI Config](https://github.com/temporalio/ui/blob/c95265ee6431fd0f6cf78ae06373885d66a8ee0c/server/docker/config-template.yaml).
+For more details on configuration with Docker, refer to [Temporal UI Config](https://github.com/temporalio/ui/blob/main/server/config/docker.yaml).
 
 ## Temporal Service plugins {/* #plugins */}
 

--- a/docs/production-deployment/self-hosted-guide/visibility.mdx
+++ b/docs/production-deployment/self-hosted-guide/visibility.mdx
@@ -163,7 +163,7 @@ echo 'MySQL schema setup complete'
 {/* SNIPEND */}
 
 Note that the script uses
-[temporal-sql-tool](https://github.com/temporalio/temporal/blob/3b982585bf0124839e697952df4bba01fe4d9543/tools/sql/main.go)
+[temporal-sql-tool](https://github.com/temporalio/temporal/blob/main/tools/sql/main.go)
 to run the setup.
 
 ## How to set up PostgreSQL Visibility store {/* #postgresql */}
@@ -258,7 +258,7 @@ echo 'PostgreSQL schema setup complete'
 {/* SNIPEND */}
 
 Note that the script uses
-[temporal-sql-tool](https://github.com/temporalio/temporal/blob/3b982585bf0124839e697952df4bba01fe4d9543/tools/sql/main.go)
+[temporal-sql-tool](https://github.com/temporalio/temporal/blob/main/tools/sql/main.go)
 to run the setup.
 
 ### Maintaining Visibility index health {/* #postgresql-index-maintenance */}

--- a/docs/production-deployment/worker-deployments/worker-versioning.mdx
+++ b/docs/production-deployment/worker-deployments/worker-versioning.mdx
@@ -927,7 +927,7 @@ Worker Deployments are never garbage collected, but _Worker Deployment Versions_
 Versions, Deployment Versions) are.
 
 Versions are deleted to keep the total number of versions in one Worker Deployment less than or equal to
-[`matching.maxVersionsInDeployment`](https://github.com/temporalio/temporal/blob/a3a53266c002ae33b630a41977274f8b5b587031/common/dynamicconfig/constants.go#L1317-L1321),
+[`matching.maxVersionsInDeployment`](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/common/dynamicconfig/constants.go#L1501-L1505),
 which is currently set to 100 in Temporal Cloud, but that's a conservative number and it could be increased if needed.
 
 For example, when you deploy your 101st Worker Version in a Worker Deployment, the server looks at the oldest drained

--- a/docs/references/cluster-metrics.mdx
+++ b/docs/references/cluster-metrics.mdx
@@ -39,7 +39,7 @@ Temporal emits metrics for each gRPC service request.
 These metrics are emitted with `type`, `operation`, and `namespace` tags, which provide visibility into Service usage and show the request rates across Services, Namespaces, and Operations.
 
 - Use the `operation` tag in your query to get request rates, error rates, or latencies per operation.
-- Use the `service_name` tag with the [service role tag values](https://github.com/temporalio/temporal/blob/bba148cf1e1642fd39fa0174423b183d5fc62d95/common/metrics/defs.go#L108) to get details for the specific service.
+- Use the `service_name` tag with the [service role tag values](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/common/metrics/metric_defs.go#L40) to get details for the specific service.
 
 All common tags that you can add in your query are defined in the [metric_defs.go](https://github.com/temporalio/temporal/blob/main/common/metrics/metric_defs.go) file.
 
@@ -270,7 +270,7 @@ These metrics pertain to Nexus Operations.
 
 ### Nexus Machinery in the History Service
 
-See [architecture document](https://github.com/temporalio/temporal/blob/5d55d6c707bd68d8f3274c57ae702331adf05e6e/docs/architecture/nexus.md#scheduler)
+See [architecture document](https://github.com/temporalio/temporal/blob/main/docs/architecture/nexus.md#scheduler)
 for more info.
 
 #### In-Memory Buffer

--- a/docs/references/dynamic-configuration.mdx
+++ b/docs/references/dynamic-configuration.mdx
@@ -20,10 +20,10 @@ Ensure that you check server release notes for any changes to these keys and val
 
 For the default values of dynamic configuration keys, check the following links:
 
-- [Frontend Service](https://github.com/temporalio/temporal/blob/5783e781504d8ffac59f9848b830868f3139b980/service/frontend/service.go#L176)
-- [History Service](https://github.com/temporalio/temporal/blob/5783e781504d8ffac59f9848b830868f3139b980/service/history/configs/config.go#L309)
-- [Matching Service](https://github.com/temporalio/temporal/blob/5783e781504d8ffac59f9848b830868f3139b980/service/matching/config.go#L125)
-- [Worker Service](https://github.com/temporalio/temporal/blob/5783e781504d8ffac59f9848b830868f3139b980/service/worker/service.go#L193)
+- [Frontend Service](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/service/frontend/service.go#L271)
+- [History Service](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/service/history/configs/config.go#L451)
+- [Matching Service](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/service/matching/config.go#L276)
+- [Worker Service](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/service/worker/service.go#L185)
 
 Setting dynamic configuration is optional.
 Change these values only if you need to override the default values to achieve better performance on your Temporal Cluster.
@@ -241,7 +241,7 @@ The Temporal server reports the server version and the version of the SDK that i
 
 Settings related to the management of Nexus.
 
-For more detailed explanation of these configs see the [in-repo Nexus architecture doc](https://github.com/temporalio/temporal/blob/6cb70c0785fd7ba4574ed91d772fe17dff4981b4/docs/architecture/nexus.md).
+For more detailed explanation of these configs see the [in-repo Nexus architecture doc](https://github.com/temporalio/temporal/blob/main/docs/architecture/nexus.md).
 
 | Dynamic configuration key                              | Type    | Description                                                                                                                                                                                                                                      | Default value       |
 | ------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |

--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -50,7 +50,7 @@ Metrics are defined in the following locations.
 - [Core SDK Client metrics](https://github.com/temporalio/sdk-rust/blob/main/crates/client/src/metrics.rs)
 - [Java SDK Worker metrics](https://github.com/temporalio/sdk-java/blob/master/temporal-sdk/src/main/java/io/temporal/worker/MetricsType.java)
 - [Java SDK Client metrics](https://github.com/temporalio/sdk-java/blob/master/temporal-serviceclient/src/main/java/io/temporal/serviceclient/MetricsType.java)
-- [Go SDK Worker and Client metrics](https://github.com/temporalio/sdk-go/blob/c32b04729cc7691f80c16f80eed7f323ee5ce24f/internal/common/metrics/constants.go)
+- [Go SDK Worker and Client metrics](https://github.com/temporalio/sdk-go/blob/main/internal/common/metrics/constants.go)
 
 :::note Metric units across SDKs
 


### PR DESCRIPTION
## Summary

Follow-up to an earlier GitHub link sweep that intentionally skipped ~40 links pinned to commit SHAs, since many carry line anchors (`#L108`) that drift and would silently point at the wrong line if just moved to `main`.

- **Links without a line anchor** (20): repointed to the repo's default branch (`main`, or `master` for `grpc/grpc`). Two of these had moved to a new path along the way, so the link target was updated accordingly:
  - `cloud-samples-go`'s `client/api/apikey.go` was merged into `client/api/client.go`.
  - `ui`'s `server/docker/config-template.yaml` moved to `server/config/docker.yaml`.
- **Links with a line anchor** (20): fetched the original pinned snapshot to identify exactly what each anchor pointed at, located that same declaration in the current default-branch HEAD, and re-pinned to today's commit SHA with the corrected line number. Several had moved files entirely, e.g. `temporal`'s history size/count limit defaults moved from `service/history/configs/config.go` into `common/dynamicconfig/constants.go`, and `common/metrics/defs.go` → `metric_defs.go`.

## Test plan
- [x] Verified every re-pinned line by diffing the old pinned snapshot against the new HEAD content for each file
- [x] `vale --config .vale-ci.ini docs/` on all touched files — 0 errors/warnings (pre-existing heading-style suggestions only, unrelated to this change)
- [x] Confirmed no remaining commit-SHA-pinned links in `docs/` outside the one flagged item

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217080204065919">EDU-6866 Modernize GitHub links pinned to commit SHAs</a>
