### PR TITLE
ci: scope the role-permissions token to saas-proto

### DIFF
--- a/.github/workflows/update-custom-role-permissions.yml
+++ b/.github/workflows/update-custom-role-permissions.yml
@@ -20,6 +20,15 @@ jobs:
         with:
           app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
           private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+          # Without owner/repositories the token is scoped to this repo only, so
+          # reading custom_role_permissions.json from the private saas-proto repo
+          # returns 404 (GitHub hides private repos a token cannot see rather
+          # than returning 403). documentation must stay in the list because the
+          # later steps push a branch and open the PR with this same token.
+          owner: temporalio
+          repositories: |
+            documentation
+            saas-proto
 
       - name: Checkout docs repo
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Problem

The **Update Custom Role Permissions** workflow has failed on **every run since it was added** in #4293. All six scheduled runs, starting 2026-06-29:

| Date | Result |
|---|---|
| 2026-08-03 | failure |
| 2026-07-27 | failure |
| 2026-07-20 | failure |
| 2026-07-13 | failure |
| 2026-07-06 | failure |
| 2026-06-29 | failure |

Every run dies in the `Fetch permissions and generate table` step ([latest run](https://github.com/temporalio/documentation/actions/runs/30805058092/job/91658375816)):

```
Fetching permissions from GitHub...
Error: HTTP 404: {"message":"Not Found","documentation_url":"...","status":"404"}
    at bin/generate-custom-role-permissions-table.js:102:18
```

Because nothing notifies on scheduled-workflow failure, this went unnoticed for five weeks. `docs/cloud/manage-access/_custom_role_permissions_table.mdx` has not been regenerated since it was hand-committed in #4293, so the published table has that much drift behind it.

## Cause

The 404 is misleading — the file is there. `protogen/custom_role_permissions.json` reads back fine from `temporalio/saas-proto` with a token that has access to that repo (50,243 bytes, sha `ec36aef`).

The actual problem is token scope. The workflow called `create-github-app-token` with neither `owner` nor `repositories`, and [per the action](https://github.com/actions/create-github-app-token) the token is then scoped to the current repository only. `saas-proto` is private, and GitHub returns **404 rather than 403** for private repos a token cannot see — so a permissions problem presents as a missing file.

## Fix

Set `owner` and `repositories` so the token covers both repos. `documentation` has to stay in the list: the later steps push a branch and open the PR with this same token.

This mirrors what `temporalio/cli` already does in `trigger-docs.yml` when it dispatches into this repo.

## Before merging

The `temporal-cicd` app must be installed on `saas-proto` with **Contents: read**. I could not verify that from outside the app. If it is not installed, this change at least converts the failure into an honest one — token generation fails with an explicit "app not installed" error instead of a phantom 404.

Once this lands, the first successful run will likely open a real PR with five weeks of accumulated permission changes.

## Testing

- `js-yaml` parses the workflow; the step resolves to `owner: temporalio`, `repositories: "documentation\nsaas-proto\n"`.
- End-to-end can only be confirmed by dispatching the workflow after merge, since the token is minted from repo secrets.

## Not in this PR

The run log also warns `Input 'app-id' has been deprecated with message: Use 'client-id' instead.` That affects all four workflows using this action and belongs in its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217128546930261">EDU-6874 ci: scope the role-permissions token to saas-proto</a>
