### PR TITLE
fix(snipsync): drop duplicate origins and all non-main refs

### DIFF
--- a/snipsync.config.yaml
+++ b/snipsync.config.yaml
@@ -22,12 +22,8 @@ origins:
     repo: samples-ruby
   - owner: temporalio
     repo: samples-dotnet
-  # Pinned until temporalio/samples-java#784 merges the lambda-worker sample to
-  # main. A ref here pins every snippet from this repo, not just one page's, so
-  # remove it as soon as that PR lands.
   - owner: temporalio
     repo: samples-java
-    ref: ea/aws-lambda
   - files:
       pattern: './sample-apps/**/*.go'
       owner: 'temporalio'

--- a/snipsync.config.yaml
+++ b/snipsync.config.yaml
@@ -22,14 +22,12 @@ origins:
     repo: samples-ruby
   - owner: temporalio
     repo: samples-dotnet
-    ref: ea/aws-lambda
+  # Pinned until temporalio/samples-java#784 merges the lambda-worker sample to
+  # main. A ref here pins every snippet from this repo, not just one page's, so
+  # remove it as soon as that PR lands.
   - owner: temporalio
     repo: samples-java
     ref: ea/aws-lambda
-  - owner: temporalio
-    repo: features
-  - owner: temporalio
-    repo: reference-app-orders-go
   - files:
       pattern: './sample-apps/**/*.go'
       owner: 'temporalio'


### PR DESCRIPTION
Snipsync has been failing intermittently since 2026-07-20 and on **every run since 2026-07-30**, so no snippet has synced in five days. Two independent causes.

## 1. Duplicate origins race the same zip filename

`features` and `reference-app-orders-go` were each listed twice.

`Sync.js:277` names every download `` `${repo}.zip` `` — from the repo alone, no owner or ref — and `getRepos` fans all origins out through a single `Promise.all`. `unzip()` then **unlinks the archive** when it finishes (`Sync.js:297`). Two tasks sharing a filename race, and the loser reads a partially written or already deleted archive:

```
Error: unexpected EOF
    at node_modules/yauzl/index.js:629:23
    at node_modules/fd-slicer/index.js:32:7
    at FSReqCallback.wrapper [as oncomplete] (node:fs:670:5)
```

That throw originates in an fs callback, so it escapes `getRepos`'s try/catch and hard-kills the process — which is why the logs never show the handler's own `Failed downloading ...` message. Being a race, it explains the intermittency. The duplicates are old: `reference-app-orders-go` since #3932 (Nov 2025), `features` since #4247 (Mar 2026).

## 2. Branch pins, one of them dead

#4663 pinned both `samples-dotnet` and `samples-java` to `ea/aws-lambda` on 07-30.

`samples-dotnet`'s branch no longer exists — that sample merged in temporalio/samples-dotnet#152 (07-21) and the branch was deleted — so every run since has 404'd on the archive download and burned five retries. That's the `Operation failed - Retrying in 1000 ms...` line.

Separating the two causes: the 07-20 and 07-27 failures show `unexpected EOF` with **no** retry line, i.e. the race alone, before the pin existed. 08-03 shows both. The pin is why occasional failures became five in a row.

This PR removes every non-main `ref`. `samples-server` keeps `ref: main`, which is already main.

## Known consequence for the Java lambda page

temporalio/samples-java#784 has **not** merged, so `lambda-worker/` exists only on `ea/aws-lambda`. Unpinning means the java lambda page's three snippets (`java-lambda-worker`, `java-lambda-worker-workflow`, `java-lambda-worker-otel-collector-config`) have no source on main and stop tracking upstream.

They keep their current content rather than breaking: snipsync only splices IDs it finds in a source, and leaves unmatched markers untouched. Re-pin or merge #784 when the snippets need to move again.

The tradeoff being made deliberately: a `ref:` pins *every* snippet from that repo, not one page's, so carrying a feature-branch pin in shared config to serve a single page is the more expensive side.

## Testing

Ran `yarn snipsync` locally against the final config:

- Completes in 88s, no crash — previously a hard exit.
- `712/716 target file(s) unchanged`.
- Both lambda pages untouched, confirming unmatched markers are left alone.
- The 4 files it did want to rewrite are legitimate upstream drift held back by five days of failures, e.g. `golang:1.24.1` → `golang:1.25.4` in `docs/best-practices/worker.mdx`. Discarded to keep this PR config-only; the next scheduled run picks them up.

## Follow-ups, not in this PR

- **The .NET lambda page also stops tracking its source, permanently.** temporalio/samples-dotnet#152 merged that sample to `main` *without* snipsync markers — `samples-dotnet@main` has zero `SNIPSTART` markers anywhere, so the page's three IDs resolve nowhere on any ref. Content is correct today but frozen until markers are added upstream.
- **`${repo}.zip` should include owner and ref** so this class of collision is impossible. Belongs upstream in [snipsync](https://github.com/temporalio/snipsync).
- **Pre-existing marker mismatches** in `docs/develop/java/best-practices/testing-suite.mdx` — four `java-nexus-*-mock` snippets warn `mismatched end marker ... Skipping splice` and are silently not syncing. Unrelated to this failure, and invisible because the warning scrolls past in an exit-0 run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)