### PR TITLE
ci: alert Slack when non-PR workflows fail

### DIFF
--- a/.github/workflows/notify-automation-failures.yml
+++ b/.github/workflows/notify-automation-failures.yml
@@ -1,0 +1,46 @@
+name: Notify Automation Failures
+
+# Posts to Slack when a non-PR workflow fails. PR CI failures are surfaced on the
+# pull request itself and are deliberately excluded here.
+#
+# The `workflows` list below uses each workflow's `name:` value, not its filename.
+# Renaming a workflow silently stops matching it, so update this list alongside
+# any rename.
+
+on:
+  workflow_run:
+    workflows:
+      - Snipsync
+      - Screenshot Capture
+      - Update Custom Role Permissions
+      - Check Metrics Against SDKs
+      - CLI Docs Update
+      - Delete Visual Tests Reports
+      - Warm Build Cache
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  notify:
+    # `Check Metrics Against SDKs` also runs on pull_request; exclude those runs so
+    # this only reports the scheduled invocation.
+    if: >-
+      github.event.workflow_run.event != 'pull_request' &&
+      contains(fromJSON('["failure", "timed_out", "startup_failure"]'), github.event.workflow_run.conclusion)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post failure to Slack
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          webhook: ${{ secrets.SLACK_AUTOMATION_ALERTS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            text: "${{ github.event.workflow_run.name }} ${{ github.event.workflow_run.conclusion }} on ${{ github.repository }}"
+            blocks:
+              - type: section
+                text:
+                  type: mrkdwn
+                  text: "*${{ github.event.workflow_run.name }}* ${{ github.event.workflow_run.conclusion }}\n<${{ github.event.workflow_run.html_url }}|Run #${{ github.event.workflow_run.run_number }}> · triggered by `${{ github.event.workflow_run.event }}` · branch `${{ github.event.workflow_run.head_branch }}`"


### PR DESCRIPTION
Adds `.github/workflows/notify-automation-failures.yml`, a `workflow_run` listener that posts to Slack when a non-PR workflow fails.

Scheduled and dispatched workflows currently fail silently. This covers the seven non-PR workflows: Snipsync, Screenshot Capture, Update Custom Role Permissions, Check Metrics Against SDKs, CLI Docs Update, Delete Visual Tests Reports, and Warm Build Cache.

- Alerts on `failure`, `timed_out`, and `startup_failure`.
- Skips `pull_request` runs, so the dual-triggered Check Metrics Against SDKs only reports its scheduled invocation.
- No changes to the monitored workflows.

The `workflows:` list matches on each workflow's `name:`, not its filename, so renaming a workflow requires updating the list.

Needs the `SLACK_AUTOMATION_ALERTS_WEBHOOK` repository secret before it can post. `workflow_run` only fires once this is on `main`, so it can't be exercised from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217135889508159">EDU-6880 ci: alert Slack when non-PR workflows fail</a>
