### PR TITLE
Generate llms-full.txt from our own transformer

### DIFF
--- a/MARKDOWN_PIPELINE.md
+++ b/MARKDOWN_PIPELINE.md
@@ -12,24 +12,39 @@ Generation happens **at build time, written directly into the build output direc
 in `static/` — the files are produced fresh on every build and deployed as-is. Vercel already
 serves `/(.*)\.md` with a `noindex` header (see `vercel.json`).
 
-Two registered Docusaurus plugins (in `docusaurus.config.js`) own the build integration:
+One registered Docusaurus plugin (in `docusaurus.config.js`) owns the build integration:
 
-1. **`plugins/markdown-pages`** — a `postBuild({ outDir })` hook that walks `docs/`, resolves
-   each page's URL path, runs the MDX through the transformer, and writes
-   `outDir/<url-path>.md`. Pages with an `llm_exclude` frontmatter field are skipped (it
-   writes the exclusion message instead).
-2. **`docusaurus-plugin-llms`** — generates `llms.txt` (page index, llmstxt.org format) and
-   `llms-full.txt` (all content concatenated). Configured with `generateMarkdownFiles: false`,
-   since `markdown-pages` produces the per-page `.md` files.
+**`plugins/markdown-pages`** — a `postBuild({ outDir })` hook that walks `docs/`, resolves each
+page's URL path, runs the MDX through the transformer, and writes `outDir/<url-path>.md`. Pages
+with an `llm_exclude` frontmatter field are skipped (it writes the exclusion message instead).
+The same pass produces three things from one transform of each page:
+
+| Output | What it is |
+| --- | --- |
+| `outDir/<url-path>.md` | Per-page clean Markdown |
+| `outDir/llms.txt` and `outDir/<section>/llms.txt` | Structured index, llmstxt.org format |
+| `outDir/llms-full.txt` | Every page's text concatenated, each with a `Source:` URL |
+
+`llms-full.txt` is for pipelines that ingest the whole corpus and chunk it themselves, so each
+entry carries its source URL and the file is ordered deterministically. Note that
+`llms-full.txt` is **not** part of the [llms.txt specification](https://llmstxt.org/) — it's a
+widely followed convention, so there's no format to conform to beyond what consumers expect.
+
+This all used to be split with `docusaurus-plugin-llms`, which ran a second, less complete MDX
+transform over the same source. That produced `llms-full.txt` with no source URLs, thousands of
+leaked `:::` and JSX artifacts, and deprecated `tctl-v1` content that `excludePaths` couldn't
+reach, since that option belongs to this plugin. Generating everything from one transform keeps
+a single exclusion list and a single definition of "clean."
 
 The **transformer** (`scripts/mdx-to-md.mjs`) is the engine `markdown-pages` calls. It is a
 standalone, **zero-dependency** ES module, separately unit-tested, so its behavior can be
 verified in isolation from a full site build.
 
 ```
-docs/**/*.mdx ──(postBuild)──▶ markdown-pages plugin ──▶ transformMdx() ──▶ outDir/<path>.md
-                                                          (scripts/mdx-to-md.mjs)
-docusaurus-plugin-llms ─────────────────────────────────▶ outDir/llms.txt, llms-full.txt
+docs/**/*.mdx ──(postBuild)──▶ markdown-pages plugin ──▶ transformMdx() ──┬─▶ outDir/<path>.md
+                                                          (mdx-to-md.mjs) ├─▶ outDir/llms.txt
+                                                                          │   outDir/<section>/llms.txt
+                                                                          └─▶ outDir/llms-full.txt
 ```
 
 > **Note: `.md` files only exist after a production build.** Generation runs in the `postBuild`

--- a/MARKDOWN_PIPELINE.md
+++ b/MARKDOWN_PIPELINE.md
@@ -18,9 +18,11 @@ Two registered Docusaurus plugins (in `docusaurus.config.js`) own the build inte
    each page's URL path, runs the MDX through the transformer, and writes
    `outDir/<url-path>.md`. Pages with an `llm_exclude` frontmatter field are skipped (it
    writes the exclusion message instead).
-2. **`docusaurus-plugin-llms`** — generates `llms.txt` (page index, llmstxt.org format) and
-   `llms-full.txt` (all content concatenated). Configured with `generateMarkdownFiles: false`,
-   since `markdown-pages` produces the per-page `.md` files.
+   Each generated `.md` opens with an agent directive blockquote under the H1 (see
+   [Agent discovery](#agent-discovery)).
+2. **`docusaurus-plugin-llms`** — generates `llms-full.txt` (all content concatenated).
+   Configured with `generateMarkdownFiles: false` and `generateLLMsTxt: false`, since
+   `markdown-pages` produces the per-page `.md` files and the structured `llms.txt` index.
 
 The **transformer** (`scripts/mdx-to-md.mjs`) is the engine `markdown-pages` calls. It is a
 standalone, **zero-dependency** ES module, separately unit-tested, so its behavior can be
@@ -29,7 +31,9 @@ verified in isolation from a full site build.
 ```
 docs/**/*.mdx ──(postBuild)──▶ markdown-pages plugin ──▶ transformMdx() ──▶ outDir/<path>.md
                                                           (scripts/mdx-to-md.mjs)
-docusaurus-plugin-llms ─────────────────────────────────▶ outDir/llms.txt, llms-full.txt
+                                                     └──▶ outDir/llms.txt
+                                                          outDir/<section>/llms.txt
+docusaurus-plugin-llms ─────────────────────────────────▶ outDir/llms-full.txt
 ```
 
 > **Note: `.md` files only exist after a production build.** Generation runs in the `postBuild`
@@ -192,6 +196,31 @@ admonitions, prose) used to keep snapshots stable as the live docs change.
 During a real build the `markdown-pages` plugin logs a count of transform warnings
 (`[markdown-pages] Generated N clean markdown files, … M transform warnings`), which surfaces
 any unknown components in the live docs.
+
+## Agent discovery
+
+An agent should be able to find `/llms.txt` and the `.md` convention from any page, no matter
+which channel it reads. Different tools read different channels, so the same two facts are
+published in four places:
+
+| Channel | Where it lives | Read by |
+| --- | --- | --- |
+| HTTP `Link` header | `vercel.json` (sitewide) | Clients that inspect response headers |
+| `<link rel="alternate" type="text/markdown">` | `MarkdownAlternateLink.tsx`, per page | Crawlers that parse `<head>` |
+| Visually hidden body text | `AgentDirective.tsx`, per page | Scrapers that read rendered body text |
+| Blockquote under the H1 | `markdown-pages` plugin, per `.md` file | Agents that fetch the `.md` directly |
+
+The last two exist because header and `<head>` metadata is invisible to anything that only
+looks at page content, which is what most agent pipelines do. Automated audits of agent
+readiness check body content specifically.
+
+`AgentDirective` is hidden with the clip-rect pattern rather than `display: none`, which some
+scrapers strip along with the text. It carries `aria-hidden="true"` to stay out of screen
+reader output and `data-nosnippet` to stay out of search result snippets.
+
+**Algolia:** the DocSearch crawler config is managed in the Algolia Crawler dashboard, not in
+this repo. If directive text ever shows up in search results, add `.agentDirective` to the
+crawler's `excludeSelectors` (or narrow the `recordExtractor` content selectors) and recrawl.
 
 ## Page actions (the buttons)
 

--- a/docs/encyclopedia/workers/worker-shutdown.mdx
+++ b/docs/encyclopedia/workers/worker-shutdown.mdx
@@ -1,3 +1,14 @@
+---
+id: worker-shutdown
+title: Worker Shutdown Behavior
+sidebar_label: Worker Shutdown
+description: Learn how a Temporal Worker shuts down, and how graceful shutdown affects in-flight Workflow Tasks and Activities.
+keywords:
+  - worker shutdown
+tags:
+  - Workers
+---
+
 # Worker Shutdown Behavior
 
 When a Worker shuts down, it stops polling for new tasks and begins the shutdown sequence.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -418,8 +418,12 @@ module.exports = async function createConfigAsync() {
             siteUrl: 'https://docs.temporal.io',
             title: 'Temporal Platform Documentation',
             description: 'This file is a structured index of Temporal\'s documentation, following the llmstxt.org standard. Temporal is an open-source platform for building crash-proof applications that resume exactly where they left off after failures.',
+            fullDescription: 'This file is the complete text of Temporal\'s documentation, intended for bulk ingestion. Temporal is an open-source platform for building crash-proof applications that resume exactly where they left off after failures.',
             rootContent:
               'To fetch any page as raw Markdown, append `.md` to its URL path (e.g., `https://docs.temporal.io/workflows.md`).\n\n' +
+              'Every page concatenated into one file is available at `https://docs.temporal.io/llms-full.txt`. ' +
+              'It is roughly 7 MB, which exceeds most context windows. Prefer the section indexes below and fetch individual `.md` pages; ' +
+              'use the full text for bulk ingestion.\n\n' +
               'This documentation reflects the latest Temporal SDK and Platform behavior. If you\'re working with an older SDK version, verify API compatibility before applying suggestions from this content.',
             excludePaths: ['tctl-v1'],
             sections: [
@@ -461,67 +465,6 @@ module.exports = async function createConfigAsync() {
           targets: [
             { docsDir: 'docs', routeBasePath: '/' },
             { docsDir: 'ai-cookbook', routeBasePath: 'ai-cookbook', footerText: 'AI COOKBOOK' },
-          ],
-        },
-      ],
-      [
-        'docusaurus-plugin-llms',
-        {
-          // Generate both llms.txt (index) and llms-full.txt (complete content)
-          generateLLMsTxt: false,
-          generateLLMsFullTxt: true,
-          generateMarkdownFiles: false,
-
-          // Exclude imported markdown partials that should not be published as standalone LLM docs.
-          ignoreFiles: ['docs/cloud/references/regions/private-service.md', 'docs/cloud/references/regions/gcpregions.md'],
-
-          // Tell agents how to fetch individual pages as raw markdown
-          rootContent:
-            'This file contains links to documentation sections following the llmstxt.org standard.\n\n' +
-            '## Fetching individual pages\n\n' +
-            'To fetch any page as raw Markdown, append `.md` to its URL path. ' +
-            'For example, `https://docs.temporal.io/encyclopedia.md` returns the raw Markdown source for the Encyclopedia page.\n\n' +
-            'Some pages (interactive demos, landing pages) are not available as Markdown. ' +
-            'Requesting `.md` for those pages returns a short explanation instead.',
-
-          // Clean up content for better LLM consumption
-          excludeImports: true,
-          removeDuplicateHeadings: true,
-
-          // Organize content in a logical order for LLMs
-          includeOrder: [
-            'quickstarts/**',
-            'evaluate/**',
-            'develop/**',
-            'production-deployment/**',
-            'cli/**',
-            'references/**',
-            'troubleshooting/**',
-            'encyclopedia/**',
-            'security*',
-            'web-ui*',
-            'glossary*',
-          ],
-
-          // Path transformation to clean URLs
-          pathTransformation: {
-            ignorePaths: ['docs'],
-          },
-
-          // Custom LLM files for specific use cases
-          customLLMFiles: [
-            {
-              filename: 'llms-quickstart.txt',
-              includePatterns: ['docs/evaluate/**/*.mdx', 'docs/develop/**/*.mdx'],
-              fullContent: true,
-              title: 'Temporal Quickstart Guide',
-            },
-            {
-              filename: 'llms-api-reference.txt',
-              includePatterns: ['docs/references/**/*.mdx', 'docs/cli/**/*.mdx'],
-              fullContent: true,
-              title: 'Temporal API and CLI Reference',
-            },
           ],
         },
       ],

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "clsx": "^2.1.1",
     "comlink": "^4.4.2",
     "concurrently": "^10.0.3",
-    "docusaurus-plugin-llms": "^0.2.0",
     "docusaurus-pushfeedback": "^1.0.3",
     "gray-matter": "^4.0.3",
     "js-yaml": "^5.2.2",

--- a/plugins/markdown-pages/index.js
+++ b/plugins/markdown-pages/index.js
@@ -20,6 +20,10 @@ module.exports = function markdownPagesPlugin(context, options = {}) {
     routeBasePath,
   }));
   const llmsTxt = options.llmsTxt || null;
+  const siteUrl = ((llmsTxt && llmsTxt.siteUrl) || context.siteConfig.url || '').replace(
+    /\/+$/,
+    ''
+  );
 
   function findSection(page, sections) {
     const urlPath = page.urlPath;
@@ -89,6 +93,25 @@ module.exports = function markdownPagesPlugin(context, options = {}) {
       }
     }
     return expanded;
+  }
+
+  // Agents that fetch a .md page directly have no way to discover the rest of
+  // the docs from it. A blockquote directive under the H1 gives them the index
+  // and the .md convention. Mirrors the visually hidden AgentDirective rendered
+  // into the HTML. See MARKDOWN_PIPELINE.md.
+  function withAgentDirective(markdown, siteUrl) {
+    const directive =
+      `> For the complete documentation index, see [llms.txt](${siteUrl}/llms.txt).\n` +
+      '> Any documentation page is available as raw Markdown by appending `.md` to its URL.';
+
+    // Keep the H1 as the first line so title extraction keeps working; the
+    // directive slots in just below it. Pages without an H1 get it up top.
+    const match = markdown.match(/^(#[^\n]*\n)/);
+    if (!match) {
+      return `${directive}\n\n${markdown}`;
+    }
+    const rest = markdown.slice(match[0].length).replace(/^\n+/, '');
+    return `${match[0]}\n${directive}\n\n${rest}`;
   }
 
   function generateLlmsTxtFiles(outDir, pages) {
@@ -292,7 +315,7 @@ module.exports = function markdownPagesPlugin(context, options = {}) {
               sourceFile: path.relative(context.siteDir, filePath),
               projectRoot: context.siteDir,
             });
-            fs.writeFileSync(outputPath, markdown + '\n');
+            fs.writeFileSync(outputPath, withAgentDirective(markdown, siteUrl) + '\n');
             totalWarnings += warnings.length;
             generated++;
 

--- a/plugins/markdown-pages/index.js
+++ b/plugins/markdown-pages/index.js
@@ -20,6 +20,10 @@ module.exports = function markdownPagesPlugin(context, options = {}) {
     routeBasePath,
   }));
   const llmsTxt = options.llmsTxt || null;
+  const siteUrl = ((llmsTxt && llmsTxt.siteUrl) || context.siteConfig.url || '').replace(
+    /\/+$/,
+    ''
+  );
 
   function findSection(page, sections) {
     const urlPath = page.urlPath;
@@ -89,6 +93,50 @@ module.exports = function markdownPagesPlugin(context, options = {}) {
       }
     }
     return expanded;
+  }
+
+  // Every page's clean Markdown concatenated into one file, for pipelines that
+  // ingest the whole corpus and chunk it themselves. Each entry carries its
+  // source URL so a retrieved chunk can be cited back to a page, which is the
+  // main thing a bulk-ingestion consumer needs and the reason this is generated
+  // from the same transformer as the per-page .md files rather than a second one.
+  function generateLlmsFullTxt(outDir, pages) {
+    // The index's own description calls itself an index, which is wrong here,
+    // so llms-full.txt takes its own line.
+    const { title, fullDescription, excludePaths = [] } = llmsTxt;
+
+    const included = pages
+      .filter(
+        p => !excludePaths.some(x => p.urlPath === x || p.urlPath.startsWith(x + '/'))
+      )
+      // Stable ordering so consumers can diff builds and re-ingest only what moved.
+      .sort((a, b) => a.urlPath.localeCompare(b.urlPath));
+
+    const out = [
+      `# ${title}`,
+      '',
+      `> ${fullDescription}`,
+      '',
+      'This file contains the full text of every documentation page, in one document.',
+      'Pages are separated by a horizontal rule and each carries a `Source:` URL.',
+      'For a structured index instead, see ' + `${siteUrl}/llms.txt.`,
+      '',
+    ];
+
+    for (const page of included) {
+      // transformMdx already emits an H1 from the page title; drop it so the
+      // heading and its Source line stay adjacent and every entry looks the same.
+      const body = page.body.replace(/^#\s+.*\n+/, '').trim();
+      out.push('---', '', `# ${page.title}`, '', `Source: ${siteUrl}/${page.urlPath}`, '', body, '');
+    }
+
+    const outputPath = path.join(outDir, 'llms-full.txt');
+    const contents = out.join('\n');
+    fs.writeFileSync(outputPath, contents);
+    console.log(
+      `[markdown-pages] Generated llms-full.txt (${included.length} pages, ` +
+        `${(contents.length / 1048576).toFixed(1)} MB, ${pages.length - included.length} excluded)`
+    );
   }
 
   function generateLlmsTxtFiles(outDir, pages) {
@@ -303,6 +351,7 @@ module.exports = function markdownPagesPlugin(context, options = {}) {
                 sidebarLabel: frontmatter.sidebar_label || '',
                 description: frontmatter.description || '',
                 relPath: path.relative(docsDir, filePath).replace(/\\/g, '/'),
+                body: markdown,
               });
             }
           }
@@ -316,6 +365,7 @@ module.exports = function markdownPagesPlugin(context, options = {}) {
 
       if (llmsTxt) {
         generateLlmsTxtFiles(outDir, pages);
+        generateLlmsFullTxt(outDir, pages);
       }
     },
   };

--- a/scripts/mdx-to-md.mjs
+++ b/scripts/mdx-to-md.mjs
@@ -331,8 +331,9 @@ export function dedent(lines) {
 export function applyInlineTransforms(line) {
   let out = line;
 
-  // Strip single-line MDX comments: {/* ... */}
-  out = out.replace(/\{\/\*[\s\S]*?\*\/\}/g, "");
+  // Strip single-line MDX comments: {/* ... */}, tolerating a space before the
+  // closing brace ({/* #anchor */ }), which authors write inconsistently.
+  out = out.replace(/\{\/\*[\s\S]*?\*\/\s*\}/g, "");
 
   // Inline <ToolTipTerm term="x" /> → x  (self-closing or paired)
   out = out.replace(/<ToolTipTerm\b[^>]*\/>/g, (m) => extractProp(m, "term") || "");
@@ -530,6 +531,8 @@ export function transformMdx(mdxContent, options = {}) {
 
   // --- Admonition state ---
   let admonitionType = null;
+  let admonitionTitle = "";
+  let admonitionFence = 3;
   let admonitionLines = [];
 
   // --- Details state ---
@@ -655,6 +658,23 @@ export function transformMdx(mdxContent, options = {}) {
         codeBlockFence = null;
       }
       continue;
+    }
+
+    // ------------------------------------------------------------------
+    // Multi-line MDX comments  {/* ... \n ... */}
+    // ------------------------------------------------------------------
+    // applyInlineTransforms strips comments that open and close on one line;
+    // it works per line, so it can't see a block that spans several. Runs after
+    // code-fence detection so a `{/*` inside a code sample is left alone.
+    if (trimmed.includes('{/*') && !/\*\/\s*\}/.test(trimmed)) {
+      let j = i + 1;
+      while (j < lines.length && !/\*\/\s*\}/.test(lines[j])) j++;
+      if (j < lines.length) {
+        i = j;
+        continue;
+      }
+      // Unterminated: fall through and let the line be handled normally rather
+      // than swallowing the rest of the page.
     }
 
     // ==================================================================
@@ -879,19 +899,28 @@ export function transformMdx(mdxContent, options = {}) {
     // Admonitions  :::note / :::tip / :::caution / :::danger / :::info / :::warning
     // ------------------------------------------------------------------
     if (state === State.NORMAL) {
-      const admonitionOpen = trimmed.match(/^:::(note|tip|caution|danger|info|warning)(\s.*)?$/i);
+      // Docusaurus allows any fence of three or more colons, an optional
+      // `[Custom title]` immediately after the type, and closing on a fence at
+      // least as long as the opener. Authors use `::::` when the body itself
+      // contains a `:::` block.
+      const admonitionOpen = trimmed.match(
+        /^(:{3,})(note|tip|caution|danger|info|warning|important)(\[([^\]]*)\])?(\s.*)?$/i
+      );
       if (admonitionOpen) {
         state = State.ADMONITION;
-        admonitionType = admonitionOpen[1].toLowerCase();
+        admonitionFence = admonitionOpen[1].length;
+        admonitionType = admonitionOpen[2].toLowerCase();
+        admonitionTitle = (admonitionOpen[4] || '').trim();
         admonitionLines = [];
-        if (admonitionOpen[2] && admonitionOpen[2].trim()) {
-          admonitionLines.push(admonitionOpen[2].trim());
+        if (admonitionOpen[5] && admonitionOpen[5].trim()) {
+          admonitionLines.push(admonitionOpen[5].trim());
         }
         continue;
       }
     }
     if (state === State.ADMONITION) {
-      if (trimmed === ":::") {
+      const closes = /^:{3,}$/.test(trimmed) && trimmed.length >= admonitionFence;
+      if (closes) {
         const typeLabels = {
           note: "📝 Note",
           tip: "💡 Tip",
@@ -899,9 +928,13 @@ export function transformMdx(mdxContent, options = {}) {
           danger: "🚨 Danger",
           info: "ℹ️ Info",
           warning: "⚠️ Warning",
+          important: "❗ Important",
         };
         const label = typeLabels[admonitionType] || admonitionType.toUpperCase();
-        outputLines.push(`> **${label}:**`);
+        // A custom `[title]` replaces the generic type word but keeps the icon,
+        // since the title is what the rendered page shows.
+        const icon = label.split(' ')[0];
+        outputLines.push(admonitionTitle ? `> **${icon} ${admonitionTitle}:**` : `> **${label}:**`);
         for (const al of admonitionLines) {
           outputLines.push(al.trim() === "" ? ">" : `> ${applyInlineTransforms(al)}`);
         }
@@ -909,6 +942,7 @@ export function transformMdx(mdxContent, options = {}) {
         state = State.NORMAL;
         admonitionLines = [];
         admonitionType = null;
+        admonitionTitle = "";
       } else {
         // Drop YouTube/HTML embeds inside tips; keep the markdown Watch link.
         const embedEnd = findHtmlEmbedEnd(lines, i);

--- a/src/components/Cookbook/DocItem/CookbookDocItem.tsx
+++ b/src/components/Cookbook/DocItem/CookbookDocItem.tsx
@@ -14,6 +14,7 @@ import { usePluginData } from '@docusaurus/useGlobalData';
 import DocItemStructuredData from '@site/src/theme/DocItem/StructuredData';
 import LLMActions from '@site/src/components/LLMActions/LLMActions';
 import MarkdownAlternateLink from '@site/src/components/LLMActions/MarkdownAlternateLink';
+import AgentDirective from '@site/src/components/LLMActions/AgentDirective';
 
 import styles from './CookbookDocItem.module.css';
 
@@ -264,6 +265,7 @@ function InnerCookbookDocItem({ content, tags }: CookbookDocItemProps) {
       <main className={styles.main}>
         <div className={styles.wrapper} data-has-toc={hasTOC ? 'true' : undefined}>
           <article className={styles.article} data-tags={dataTags} data-doc-id={id}>
+            <AgentDirective />
             {syntheticTitle && (
               <header className={styles.syntheticHeader}>
                 {renderActions()}

--- a/src/components/LLMActions/AgentDirective.module.css
+++ b/src/components/LLMActions/AgentDirective.module.css
@@ -1,0 +1,20 @@
+/**
+ * Visually hidden, but present in the rendered HTML and in the DOM text.
+ *
+ * Deliberately not `display: none` or `visibility: hidden`: some scrapers drop
+ * those subtrees, and the whole point of this element is to be readable by
+ * agents that parse body content. The clip-rect pattern keeps it in the layout
+ * tree while making it invisible to sighted users.
+ */
+.agentDirective {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+  border: 0;
+}

--- a/src/components/LLMActions/AgentDirective.tsx
+++ b/src/components/LLMActions/AgentDirective.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useDoc } from '@docusaurus/plugin-content-docs/client';
+import { getMarkdownPath } from './markdownPath';
+import styles from './AgentDirective.module.css';
+
+/**
+ * Emits a visually hidden directive near the top of each page body, pointing
+ * agents at /llms.txt and the raw Markdown rendition of the current page.
+ *
+ * This duplicates information already carried by the sitewide `Link` header
+ * (vercel.json) and the per-page <link rel="alternate"> tag
+ * (MarkdownAlternateLink). Those live in the response headers and <head>, which
+ * most agent pipelines never parse. Scrapers read rendered body text, so the
+ * directive has to appear there too.
+ *
+ * Hidden with the clip-rect technique rather than `display: none`, which some
+ * scrapers strip. `aria-hidden` keeps it out of screen reader output, and
+ * `data-nosnippet` keeps it out of search result snippets. Algolia excludes it
+ * via the crawler's `excludeSelectors` (see MARKDOWN_PIPELINE.md).
+ */
+export default function AgentDirective(): JSX.Element | null {
+  const { metadata, frontMatter } = useDoc();
+
+  if (!metadata.permalink) {
+    return null;
+  }
+
+  // Pages with no Markdown counterpart still get the index pointer, just
+  // without the .md claim, which would 404 for them.
+  const markdownPath = frontMatter.llm_exclude ? null : getMarkdownPath(metadata.permalink);
+
+  return (
+    <div className={styles.agentDirective} aria-hidden="true" data-nosnippet>
+      For the complete documentation index, see <a href="/llms.txt">/llms.txt</a>.
+      {markdownPath && (
+        <>
+          {' '}
+          This page is also available as raw Markdown at <a href={markdownPath}>{markdownPath}</a>. Append{' '}
+          <code>.md</code> to any page URL to fetch its Markdown.
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/theme/DocItem/Content/index.tsx
+++ b/src/theme/DocItem/Content/index.tsx
@@ -8,6 +8,7 @@ import type { Props } from '@theme/DocItem/Content';
 
 import LLMActions from '@site/src/components/LLMActions/LLMActions';
 import MarkdownAlternateLink from '@site/src/components/LLMActions/MarkdownAlternateLink';
+import AgentDirective from '@site/src/components/LLMActions/AgentDirective';
 import styles from './styles.module.css';
 
 /**
@@ -30,6 +31,7 @@ export default function DocItemContent({ children }: Props): JSX.Element {
   return (
     <div className={clsx(ThemeClassNames.docs.docMarkdown, 'markdown')}>
       <MarkdownAlternateLink />
+      <AgentDirective />
       {syntheticTitle && (
         <header className={styles.header}>
           <Heading as="h1">{syntheticTitle}</Heading>

--- a/tests/test-mdx-to-md.mjs
+++ b/tests/test-mdx-to-md.mjs
@@ -316,6 +316,55 @@ test("converts :::tip to blockquote with tip label", () => {
   assertContains(markdown, "> **💡 Tip:**");
 });
 
+test("uses a custom [title] in place of the type word, keeping the icon", () => {
+  const { markdown } = transformMdx(":::info[TLDR]\nShort version.\n:::");
+  assertContains(markdown, "> **ℹ️ TLDR:**");
+  assertContains(markdown, "> Short version.");
+  assertNotContains(markdown, ":::");
+});
+
+test("converts :::important", () => {
+  const { markdown } = transformMdx(":::important\nRead this.\n:::");
+  assertContains(markdown, "> **❗ Important:**");
+  assertNotContains(markdown, ":::");
+});
+
+test("handles a four-colon fence", () => {
+  const { markdown } = transformMdx("::::note\nNested-capable body.\n::::");
+  assertContains(markdown, "> **📝 Note:**");
+  assertContains(markdown, "> Nested-capable body.");
+  assertNotContains(markdown, "::::");
+});
+
+test("a shorter inner fence does not close a longer outer one", () => {
+  const { markdown } = transformMdx("::::note\nOuter\n\n:::tip\nInner\n:::\n\nStill outer\n::::");
+  assertContains(markdown, "> **📝 Note:**");
+  assertContains(markdown, "> Still outer");
+  assertNotContains(markdown, "::::");
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests: transformMdx — MDX comments
+// ---------------------------------------------------------------------------
+
+test("strips an MDX comment spanning multiple lines", () => {
+  const { markdown } = transformMdx("{/* NOTE: auto-generated.\nDo not edit. */}\n\nReal content.");
+  assertContains(markdown, "Real content.");
+  assertNotContains(markdown, "{/*");
+  assertNotContains(markdown, "auto-generated");
+});
+
+test("strips an MDX comment with a space before the closing brace", () => {
+  const { markdown } = transformMdx("Before {/* #patching */ } after");
+  assertNotContains(markdown, "{/*");
+  assertContains(markdown, "Before");
+});
+
+test("leaves a {/* inside a code fence alone", () => {
+  const { markdown } = transformMdx("```jsx\n{/* keep me */}\n```");
+  assertContains(markdown, "{/* keep me */}");
+});
+
 test("admonition does not bleed into surrounding content", () => {
   const input = `Before\n\n:::note\nNote content\n:::\n\nAfter`;
   const { markdown } = transformMdx(input);

--- a/vercel.json
+++ b/vercel.json
@@ -40,6 +40,16 @@
   ],
   "redirects": [
     {
+      "source": "/llms-quickstart.txt",
+      "destination": "/llms.txt",
+      "permanent": true
+    },
+    {
+      "source": "/llms-api-reference.txt",
+      "destination": "/llms.txt",
+      "permanent": true
+    },
+    {
       "source": "/production-deployment/worker-deployments/serverless-workers/self-hosted-setup",
       "destination": "/production-deployment/worker-deployments/serverless-workers/aws-lambda/self-hosted-setup",
       "permanent": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -5165,13 +5165,6 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
-  dependencies:
-    balanced-match "^1.0.0"
-
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
@@ -6655,15 +6648,6 @@ doctrine@^2.1.0:
   integrity sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==
   dependencies:
     esutils "^2.0.2"
-
-docusaurus-plugin-llms@^0.2.0:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/docusaurus-plugin-llms/-/docusaurus-plugin-llms-0.2.2.tgz#3461e8295d18d4057cf0fbcf5e3feac561ea6fd1"
-  integrity sha512-DZlZ6cv9p5poFE00Qg78aurBNWhLa4o0VhH4kI33DUT0y4ydlFEJJbf8Bks9BuuGPFbY/Guebn+hRc2QymMImg==
-  dependencies:
-    gray-matter "^4.0.3"
-    minimatch "^9.0.3"
-    yaml "^2.8.1"
 
 docusaurus-pushfeedback@^1.0.3:
   version "1.0.9"
@@ -10364,13 +10348,6 @@ minimatch@3.1.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^3.1.5:
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
-
-minimatch@^9.0.3:
-  version "9.0.5"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz"
-  integrity sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==
-  dependencies:
-    brace-expansion "^2.0.1"
 
 minimist@^1.2.0, minimist@^1.2.6, minimist@^1.2.8:
   version "1.2.8"
@@ -14659,7 +14636,7 @@ yaml@^1.10.2:
   resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
 
-yaml@^2.8.1, yaml@^2.9.0:
+yaml@^2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.9.0.tgz#78274afd93598a1dfdd6130df6a566defcbf9aa4"
   integrity sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==


### PR DESCRIPTION
`llms-full.txt` was generated by `docusaurus-plugin-llms`, a second MDX transform running over the same source as `plugins/markdown-pages`. Generate it from the markdown we already transform for the per-page `.md` files, and drop the plugin.

Same 6.8 MB, but:

| | Before | After |
|---|---|---|
| Pages with a `Source:` URL | 0 | 720 |
| `:::` admonition markers | 1,383 | 0 |
| `{/* */}` comments | 1,963 | 0 |
| Stray JSX closing tags | 1,167 | 0 |
| Deprecated `tctl-v1` commands | 369 | 0 |

`tctl-v1` was included because `excludePaths` belongs to `markdown-pages`, so the other plugin never saw it. Entries are sorted by URL and separated by `---` so consumers can diff builds and chunk cleanly.

## Also here

- **Deletes `llms-quickstart.txt` and `llms-api-reference.txt`.** The first was 2.9 MB of every SDK and evaluate page under the title "Temporal Quickstart Guide"; the second duplicated `references` and `cli`. Neither was linked anywhere and both show negligible traffic. Redirects point them at `llms.txt`.
- **Transformer fixes** for the leaks above: 4+ colon fences, `:::info[Custom title]`, `:::important`, multi-line MDX comments, and `{/* … */ }` with a space before the brace. Six new tests.
- **Frontmatter for `encyclopedia/workers/worker-shutdown.mdx`**, which had none and was therefore missing from `llms.txt` entirely. It's in the sidebar and linked from five SDK pages. No `slug`, so the URL is unchanged.

## Test plan

- [x] `yarn build` from a clean tree; 99 transformer tests pass
- [x] Zero `:::`, `{/* */}`, and JSX artifacts across all 749 generated `.md` files
- [x] 720 `Source:` lines; the 30 omitted pages are `tctl-v1` (10), `terms/*` fragments (12), imported partials (4), `llm_exclude` pages (2), and generated indexes (2)
- [x] `worker-shutdown` URL and rendered H1 unchanged
- [ ] Confirm `/llms-full.txt` and both redirects on the Vercel preview

Conflicts with #5042 on `MARKDOWN_PIPELINE.md`; trivial to resolve whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217247371495209">EDU-6901 Generate llms-full.txt from our own transformer</a>
