### PR TITLE
pause: clarify workflow and activity unpause behavior

### DIFF
--- a/docs/encyclopedia/workflow/workflow-pause.mdx
+++ b/docs/encyclopedia/workflow/workflow-pause.mdx
@@ -194,7 +194,9 @@ Workflow Pause and [Activity Operations](/activity-operations) are separate cont
 Workflow Pause stops progress for a Workflow Execution. Activity Operations act on a specific Activity Execution.
 
 If a Workflow is Paused, Activity retries in that Workflow are blocked. If an individual Activity is also Paused, both
-the Workflow and the Activity must be Unpaused before that Activity can proceed.
+the Workflow and the Activity must be Unpaused before that Activity can proceed. If a Workflow is Unpaused, all pending
+Activities will have available retries dispatched, if the Activity is Paused it has to be Unpaused before any new
+attempts are dispatched.
 
 Workflow Pause doesn't interrupt Activity attempts that are already running. To interrupt a Heartbeating Activity
 attempt, use [Activity Pause](/activity-operations#pause).


### PR DESCRIPTION
## What does this PR do?
Clarifies the interaction of Workflow Unpause with pending activities.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217284011973968">EDU-6909 pause: clarify workflow and activity unpause behavior</a>
