### PR TITLE
Clarify OpenMetrics rate limit may burst to 2x

### DIFF
--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -116,6 +116,12 @@ Rate limit scopes are subject to change.
 | ----- | ----- |
 | Account | 180 requests per hour |
 
+:::note
+Actual enforcement may allow bursts of up to 2x this limit (up to 360 requests per hour) at various times.
+Do not rely on this headroom: design production clients against the documented limit of 180 requests per hour, as the additional capacity is not guaranteed and may be withdrawn at any time.
+
+:::
+
 ### Response Completeness
 
 The `X-Completeness` header indicates whether the response contains all available data:
@@ -386,3 +392,8 @@ count({__name__=~"temporal_cloud_v1_.*"}) by (__name__)
 | ----- | ----- | ----- |
 | 30k total datapoints per scrape | Response may be truncated | Use namespace/metric filtering |
 | 180 requests per account per hour (~3 requests per minute) | HTTP 429 returned | Set scrape interval to 30s |
+
+:::note
+At various times, actual enforcement may permit up to 2x the request limit (up to 360 requests per hour). This headroom is not guaranteed. For production, design your clients around the documented limit of 180 requests per account per hour.
+
+:::

--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -116,7 +116,7 @@ Rate limit scopes are subject to change.
 | ----- | ----- |
 | Account | 180 requests per hour |
 
-:::note
+:::caution
 Practical enforcement of this limit may allow bursts of up to 2x this limit (up to 360 requests per hour) at various times.
 Do not rely on this headroom: design production clients against the documented limit of 180 requests per hour.
 

--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -117,8 +117,8 @@ Rate limit scopes are subject to change.
 | Account | 180 requests per hour |
 
 :::note
-Actual enforcement may allow bursts of up to 2x this limit (up to 360 requests per hour) at various times.
-Do not rely on this headroom: design production clients against the documented limit of 180 requests per hour, as the additional capacity is not guaranteed and may be withdrawn at any time.
+Practical enforcement of this limit may allow bursts of up to 2x this limit (up to 360 requests per hour) at various times.
+Do not rely on this headroom: design production clients against the documented limit of 180 requests per hour.
 
 :::
 
@@ -394,6 +394,7 @@ count({__name__=~"temporal_cloud_v1_.*"}) by (__name__)
 | 180 requests per account per hour (~3 requests per minute) | HTTP 429 returned | Set scrape interval to 30s |
 
 :::note
-At various times, actual enforcement may permit up to 2x the request limit (up to 360 requests per hour). This headroom is not guaranteed. For production, design your clients around the documented limit of 180 requests per account per hour.
+Practical enforcement of this limit may allow bursts of up to 2x this limit (up to 360 requests per hour) at various times.
+Do not rely on this headroom: design production clients against the documented limit of 180 requests per hour.
 
 :::


### PR DESCRIPTION
## What

Clarifies the OpenMetrics API rate limit in `docs/cloud/metrics/openmetrics/api-reference.mdx`.

Actual enforcement may permit bursts of up to 2x the documented limit (up to 360 requests/hour) at various times, but this headroom is **not guaranteed**. Production clients should be designed against the documented **180 requests per account per hour**.

## Why

Customers have observed being able to exceed 180 requests/hour and may inadvertently build production scrape configs that depend on that extra capacity. This makes explicit that 180/hour is the only limit to rely on.

## Changes

- Added a note under **Rate Limit Scopes** (Client Considerations)
- Added a matching note under **API Limits**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217340849335512">EDU-6925 Clarify OpenMetrics rate limit may burst to 2x</a>
