### PR TITLE
Drop selectedLines from the Google GenAI snippets

### DIFF
--- a/docs/develop/python/integrations/google-genai.mdx
+++ b/docs/develop/python/integrations/google-genai.mdx
@@ -224,16 +224,15 @@ no default, and the tool call fails without one.
 
 Register the Activity on the Worker alongside the Workflow.
 
-{/* SNIPSTART python-google-genai-tools-worker {"selectedLines": ["21-26"]} */}
+{/* SNIPSTART python-google-genai-tools-worker */}
 [google_genai/tools/run_worker.py](https://github.com/temporalio/samples-python/blob/main/google_genai/tools/run_worker.py)
 ```py
-# ...
-    worker = Worker(
-        client,
-        task_queue="google-genai-tools",
-        workflows=[ToolsWorkflow],
-        activities=[get_weather],
-    )
+worker = Worker(
+    client,
+    task_queue="google-genai-tools",
+    workflows=[ToolsWorkflow],
+    activities=[get_weather],
+)
 ```
 {/* SNIPEND */}
 
@@ -315,10 +314,9 @@ the Worker and runs `list_tools` and `call_tool` as Activities against it.
 
 Register each server with a factory that yields a connected, initialized `mcp.ClientSession`.
 
-{/* SNIPSTART python-google-genai-mcp-worker {"selectedLines": ["20-32"]} */}
+{/* SNIPSTART python-google-genai-mcp-worker */}
 [google_genai/mcp/run_worker.py](https://github.com/temporalio/samples-python/blob/main/google_genai/mcp/run_worker.py)
 ```py
-# ...
 @asynccontextmanager
 async def echo_session() -> AsyncIterator[ClientSession]:
     """Yield a connected, initialized session to the stdio echo MCP server."""
@@ -419,10 +417,21 @@ class StreamingWorkflow:
 A consumer subscribes to the topic with `WorkflowStreamClient`. The published chunks are Pydantic
 `GenerateContentResponse` objects, so the subscribing Client needs `pydantic_data_converter`.
 
-{/* SNIPSTART python-google-genai-streaming-run-workflow {"selectedLines": ["29-42"]} */}
+{/* SNIPSTART python-google-genai-streaming-run-workflow */}
 [google_genai/streaming/run_workflow.py](https://github.com/temporalio/samples-python/blob/main/google_genai/streaming/run_workflow.py)
 ```py
-# ...
+async def consume(client: Client, workflow_id: str) -> None:
+    """Subscribe to the "gemini" topic and print chunks as the model produces them."""
+    stream = WorkflowStreamClient.create(client, workflow_id)
+    async for item in stream.subscribe(
+        ["gemini"],
+        from_offset=0,
+        result_type=types.GenerateContentResponse,
+        poll_cooldown=timedelta(milliseconds=50),
+    ):
+        chunk: types.GenerateContentResponse = item.data
+        if chunk.text:
+            print(chunk.text, end="", flush=True)
         if chunk.candidates and chunk.candidates[0].finish_reason:
             print()
             return
@@ -435,8 +444,6 @@ async def main() -> None:
         os.environ.get("TEMPORAL_ADDRESS", "localhost:7233"),
         data_converter=pydantic_data_converter,
     )
-    workflow_id = "google-genai-streaming"
-
 ```
 {/* SNIPEND */}
 
@@ -545,16 +552,15 @@ class VertexAIWorkflow:
 The Worker's `genai.Client` uses Application Default Credentials instead of an API key. Run
 `gcloud auth application-default login`, or set `GOOGLE_APPLICATION_CREDENTIALS` to a service account key file.
 
-{/* SNIPSTART python-google-genai-vertex-ai-worker {"selectedLines": ["13-18"]} */}
+{/* SNIPSTART python-google-genai-vertex-ai-worker */}
 [google_genai/vertex_ai/run_worker.py](https://github.com/temporalio/samples-python/blob/main/google_genai/vertex_ai/run_worker.py)
 ```py
-# ...
-    genai_client = genai.Client(
-        vertexai=True,
-        project=os.environ["GOOGLE_CLOUD_PROJECT"],
-        location=os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1"),
-    )
-    plugin = GoogleGenAIPlugin(genai_client)
+genai_client = genai.Client(
+    vertexai=True,
+    project=os.environ["GOOGLE_CLOUD_PROJECT"],
+    location=os.environ.get("GOOGLE_CLOUD_LOCATION", "us-central1"),
+)
+plugin = GoogleGenAIPlugin(genai_client)
 ```
 {/* SNIPEND */}
 


### PR DESCRIPTION
## What does this PR do?

Removes the stray `# ...` line at the top of four code samples on [the Google GenAI page](https://docs.temporal.io/develop/python/integrations/google-genai).

Each of the four used a `selectedLines` range that started partway into the file, so snipsync rendered a leading elision marker. Because that marker sits at column 0, it also zeroed out the common indent prefix and suppressed snipsync's dedenting, leaving the two worker excerpts indented under a `main()` you never see.

temporalio/samples-python#346 scopes the `SNIPSTART`/`SNIPEND` markers to exactly the code shown here, so the ranges are no longer needed. Dropping them removes both the marker and the stray indentation.

The streaming excerpt also gains the `consume()` function it was missing. Its old range began at a dangling `if` and left out the `stream.subscribe()` call the surrounding prose describes.

## Notes to reviewers

**Merge temporalio/samples-python#346 first.** The daily snipsync job pulls from samples-python `main`; if this lands alone, that job splices the whole files back in.

Verified by extracting every snippet from the updated sample sources and running snipsync's own `deindent.js` over them — all 15 blocks on the page match, so the next snipsync run is a no-op. `vale --config .vale-ci.ini` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217341426530040">EDU-6926 Drop selectedLines from the Google GenAI snippets</a>
