### PR TITLE
Add You.com integration to the integrations grid

### DIFF
--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -278,5 +278,14 @@
       "Temporal Cloud"
     ],
     "href": "https://docs.vantage.sh/connecting_temporal/"
+  },
+  {
+    "name": "You.com",
+    "description": "Run You.com search, research, and webpage-contents calls as durable Temporal Activities with retry and error mapping.",
+    "tags": [
+      "Data source"
+    ],
+    "sdk": "Python",
+    "href": "https://github.com/youdotcom-oss/youdotcom-temporal/blob/main/README.md"
   }
 ]

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -281,7 +281,7 @@
   },
   {
     "name": "You.com",
-    "description": "Run You.com search, research, and webpage-contents calls as durable Temporal Activities with retry and error mapping.",
+    "description": "Run You.com web search, research, and webpage-contents calls as durable Temporal Activities with retry and error mapping.",
     "tags": [
       "Data source"
     ],

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -286,6 +286,6 @@
       "Data source"
     ],
     "sdk": "Python",
-    "href": "https://github.com/youdotcom-oss/youdotcom-temporal/blob/main/README.md"
+    "href": "https://github.com/youdotcom-oss/youdotcom-temporal/blob/v1.0.0/README.md"
   }
 ]

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -286,6 +286,6 @@
       "Data source"
     ],
     "sdk": "Python",
-    "href": "https://github.com/youdotcom-oss/youdotcom-temporal/blob/v1.0.0/README.md"
+    "href": "https://github.com/youdotcom-oss/youdotcom-temporal/blob/main/README.md"
   }
 ]


### PR DESCRIPTION
## What this adds

A new card in the integrations grid (`docs.temporal.io/integrations`) for **You.com**, linking to the standalone [`youdotcom-temporal`](https://github.com/youdotcom-oss/youdotcom-temporal) plugin.

The plugin exposes You.com web search, research, and webpage-contents calls as durable Temporal Activities with retry and error mapping, and ships a `SimplePlugin` for one-line worker/client setup. It is a standalone package (not in `temporalio/contrib/`), which matches how other third-party integrations are listed here (e.g., Parseable, Mastra, Pydantic AI).

## Change

One entry appended to `src/components/IntegrationsGrid/integrations-data.json`:

```json
{
  "name": "You.com",
  "description": "Run You.com web search, research, and webpage-contents calls as durable Temporal Activities with retry and error mapping.",
  "tags": ["Data source"],
  "sdk": "Python",
  "href": "https://github.com/youdotcom-oss/youdotcom-temporal/blob/main/README.md"
}
```

This JSON is the single source for both the React grid (`src/components/IntegrationsGrid`) and the markdown pipeline (`scripts/component-handlers/integrations.mjs`), so this one edit updates both renderings. No `.mdx` page is added; the card links directly to the plugin's README, consistent with the OpenAI Agents SDK (Python) and Parseable entries.

## Tag: requesting maintainer input

I used a new **`Data source`** tag. None of the existing tags (`Agent framework`, `Agent observability`, `Framework`, `Governance`, `Observability`, `Temporal Cloud`) fit a data-providing integration, and the tag list is auto-derived from this file, so the new value will appear as a filter chip with no component change.

I chose `Data source` over:

- `Tools` — too broad, and overlaps the SDK's own "tools" concept.
- `Grounding` / `Retrieval` — RAG jargon, too narrow for a public filter chip.
- `Search` — too narrow; the plugin also does research and webpage contents.

Happy to rename or drop it if you'd prefer a different category, or would rather not add a new tag for a single entry.

## Validation

- `python3 -m json.tool integrations-data.json` passes.
- No MDX/prose changes, so the Vale CI rules (`Temporal.Headings`, `Temporal.RelativeLinks`, scoped to `docs/`) do not apply to this file.
- Did not run `yarn build` locally (no Node toolchain in this environment); the change is a data-only JSON addition with no structural or code impact.

## CLA

I will sign the Temporal CLA when prompted.
