### PR TITLE
Add Langfuse Python integration card

### DIFF
--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -99,6 +99,15 @@
     "href": "/develop/python/integrations/langgraph"
   },
   {
+    "name": "Langfuse",
+    "description": "Trace and debug LLM calls in Temporal Workflows with Langfuse.",
+    "tags": [
+      "Agent observability"
+    ],
+    "sdk": "Python",
+    "href": "https://langfuse.com/integrations/frameworks/temporal"
+  },
+  {
     "name": "LangSmith",
     "description": "Trace and debug LLM calls in Temporal Workflows with LangSmith.",
     "tags": [


### PR DESCRIPTION
## What changed

Adds a Langfuse card to the AI integrations grid (`src/components/IntegrationsGrid/integrations-data.json`), linking to Langfuse's Temporal integration guide: https://langfuse.com/integrations/frameworks/temporal

- Tagged **Agent observability**, SDK **Python**, matching the existing LangSmith/Braintrust observability cards.
- Inserted alphabetically between LangGraph and LangSmith.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217352077051231">EDU-6932 Add Langfuse Python integration card</a>