### PR TITLE
Add section title to AI Cookbook page titles

### DIFF
--- a/src/components/Cookbook/DocItem/CookbookDocItem.tsx
+++ b/src/components/Cookbook/DocItem/CookbookDocItem.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import Head from '@docusaurus/Head';
 import { DocProvider, useDoc } from '@docusaurus/plugin-content-docs/client';
 import DocItemMetadata from '@theme/DocItem/Metadata';
 import type { Props as DocItemProps } from '@theme/DocItem';
@@ -57,7 +56,6 @@ function InnerCookbookDocItem({ content, tags }: CookbookDocItemProps) {
   const { metadata, frontMatter, toc, contentTitle } = useDoc();
   const {
     title,
-    description,
     id,
     unversionedId,
     tags: metaTags = [],
@@ -258,10 +256,6 @@ function InnerCookbookDocItem({ content, tags }: CookbookDocItemProps) {
       <DocItemStructuredData />
       <MarkdownAlternateLink />
 
-      <Head>
-        <title>{title}</title>
-        {description && <meta name="description" content={description} />}
-      </Head>
       <main className={styles.main}>
         <div className={styles.wrapper} data-has-toc={hasTOC ? 'true' : undefined}>
           <article className={styles.article} data-tags={dataTags} data-doc-id={id}>

--- a/src/theme/ThemeProvider/TitleFormatter/index.tsx
+++ b/src/theme/ThemeProvider/TitleFormatter/index.tsx
@@ -1,0 +1,32 @@
+import React, {type ComponentProps, type ReactNode} from 'react';
+import {TitleFormatterProvider} from '@docusaurus/theme-common/internal';
+import type {Props} from '@theme/ThemeProvider/TitleFormatter';
+
+type FormatterProp = ComponentProps<typeof TitleFormatterProvider>['formatter'];
+
+// Section label inserted between the page title and the site title, keyed by
+// content-docs plugin id, e.g. "Tool calling agent | AI Cookbook | Temporal Platform Documentation".
+const SECTION_TITLES: Record<string, string> = {
+  'ai-cookbook': 'AI Cookbook',
+};
+
+const formatter: FormatterProp = (params) => {
+  const sectionTitle = SECTION_TITLES[params.plugin.id];
+  const trimmedTitle = params.title?.trim();
+
+  if (!sectionTitle || !trimmedTitle || trimmedTitle === sectionTitle) {
+    return params.defaultFormatter(params);
+  }
+
+  return `${trimmedTitle} ${params.titleDelimiter} ${sectionTitle} ${params.titleDelimiter} ${params.siteTitle}`;
+};
+
+export default function ThemeProviderTitleFormatter({
+  children,
+}: Props): ReactNode {
+  return (
+    <TitleFormatterProvider formatter={formatter}>
+      {children}
+    </TitleFormatterProvider>
+  );
+}


### PR DESCRIPTION
## Summary
- Inserts "AI Cookbook" between the page title and site title in `<head><title>`, so cookbook pages read e.g. "Tool calling agent | AI Cookbook | Temporal Platform Documentation" instead of the bare page title.
- Implemented via a swizzled `ThemeProvider/TitleFormatter` (`src/theme/ThemeProvider/TitleFormatter/index.tsx`), keyed by content-docs plugin id — currently just `ai-cookbook`. Auto-skips the section segment when a page's own title already matches it, so the AI Cookbook landing page renders as "AI Cookbook | Temporal Platform Documentation" with no duplication.
- Removes a redundant `<Head><title>{title}</title></Head>` in `CookbookDocItem.tsx` that was rendered after `DocItemMetadata` and silently clobbering the formatted title — this is why cookbook pages previously showed a bare title with no site suffix at all.

## Test plan
- [x] Verified via production build (`yarn build` + `yarn serve`) that ai-cookbook leaf pages, the ai-cookbook landing page, and unrelated doc pages all render the correct `<title>`
- [x] Manually tested on deployed preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217381334095550">EDU-6937 Add section title to AI Cookbook page titles</a>
