### PR TITLE
Bump OpenMetric data point limit

### DIFF
--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -127,7 +127,7 @@ Do not rely on this headroom: design production clients against the documented l
 The `X-Completeness` header indicates whether the response contains all available data:
 
 * `complete`: The response contains all metrics requested  
-* `limited`: Response truncated due to size limits (30k metric data points max). Use namespace or metric filtering to reduce the response size.
+* `limited`: Response truncated due to size limits (50k metric data points max). Use namespace or metric filtering to reduce the response size.
 * `unknown`: Completeness cannot be determined (possibly due to regional issues or timeouts). Clients are encouraged to retry.
 
 ### Retry Logic
@@ -390,7 +390,7 @@ count({__name__=~"temporal_cloud_v1_.*"}) by (__name__)
 
 | Limit | Impact | Mitigation |
 | ----- | ----- | ----- |
-| 30k total datapoints per scrape | Response may be truncated | Use namespace/metric filtering |
+| 50k total datapoints per scrape | Response may be truncated | Use namespace/metric filtering |
 | 180 requests per account per hour (~3 requests per minute) | HTTP 429 returned | Set scrape interval to 30s |
 
 :::caution

--- a/docs/cloud/metrics/openmetrics/api-reference.mdx
+++ b/docs/cloud/metrics/openmetrics/api-reference.mdx
@@ -26,7 +26,7 @@ import { CaptionedImage } from '@site/src/components';
 The Temporal Cloud OpenMetrics API provides actionable operational metrics about your Temporal Cloud deployment. This is a scrapable HTTP API that returns metrics in OpenMetrics format, suitable for ingestion by Prometheus-compatible monitoring systems.
 
 
-## Available Metrics Reference
+## Available metrics reference
 
 Metrics descriptions are also available programmatically via the `/v1/descriptors` endpoint. You can see the Metrics Reference for a list of available metrics.
 
@@ -36,7 +36,7 @@ Temporal uses API keys for integrating with the OpenMetrics endpoint. Applicatio
 
 An API key is owned by a Service Account and inherits the permissions granted to the owner.
 
-### Creating API Keys
+### Creating API keys
 
 API keys can be created using the [Temporal Cloud UI](https://cloud.temporal.io):
 
@@ -50,7 +50,7 @@ See the [docs](/cloud/api-keys#serviceaccount-api-keys) for more details on gene
 
 :::
 
-### Using API Keys
+### Using API keys
 
 All API requests must be made over HTTPS. Calls made over plain HTTP will fail. API requests without authentication will also fail.
 
@@ -58,7 +58,7 @@ All API requests must be made over HTTPS. Calls made over plain HTTP will fail. 
 curl -H "Authorization: Bearer <API_KEY>" https://metrics.temporal.io/v1/metrics
 ```
 
-## Object Model
+## Object model
 
 The object model for the Metrics API follows the [OpenMetrics](https://openmetrics.io/) standard.
 
@@ -66,7 +66,7 @@ The object model for the Metrics API follows the [OpenMetrics](https://openmetri
 
 A metric is a numeric attribute measured at a specific point in time, labeled with contextual metadata gathered at the point of instrumentation.
 
-### Metric Types
+### Metric types
 
 All Temporal Cloud metrics are exposed as *gauges* in OpenMetrics format, but represent different measurement types:
 
@@ -94,9 +94,9 @@ Each metric has its own set of applicable labels. See the Metrics Reference for 
 
 A [Metric Family](https://github.com/prometheus/OpenMetrics/blob/main/specification/OpenMetrics.md#metricfamily) may have zero or more metrics.  The set of metrics returned will vary based on actual system activity.  Metrics only appear in a Metric Family if they were reported during the aggregation window.
 
-## Client Considerations
+## Client considerations
 
-### Rate Limiting
+### Rate limiting
 
 To protect the stability of the API and keep it available to all users, Temporal employs multiple safeguards.
 
@@ -106,7 +106,7 @@ When a rate limit is breached, an HTTP `429 Too Many Requests` error is returned
 | ----- | ----- |
 | `Retry-After` | The time in seconds until the rate limit window resets |
 
-#### Rate Limit Scopes
+#### Rate limit scopes
 :::note
 Rate limit scopes are subject to change.
 
@@ -122,7 +122,7 @@ Do not rely on this headroom: design production clients against the documented l
 
 :::
 
-### Response Completeness
+### Response completeness
 
 The `X-Completeness` header indicates whether the response contains all available data:
 
@@ -130,11 +130,11 @@ The `X-Completeness` header indicates whether the response contains all availabl
 * `limited`: Response truncated due to size limits (50k metric data points max). Use namespace or metric filtering to reduce the response size.
 * `unknown`: Completeness cannot be determined (possibly due to regional issues or timeouts). Clients are encouraged to retry.
 
-### Retry Logic
+### Retry logic
 
 Implement retry logic in your client to gracefully handle transient API failures. Use exponential backoff with jitter to avoid retry storms with reasonable retry intervals to avoid reaching rate limits.
 
-### Data Latency
+### Data latency
 
 Metric data points are available for query within 3 minutes of their origination. This is in line with the freshest metrics [available from any major service provider](https://docs.datadoghq.com/integrations/guide/cloud-metric-delay/). This latency should be accounted for when setting up monitoring alerts.
 
@@ -150,17 +150,17 @@ All endpoints are served from: `metrics.temporal.io`
 
 :::
 
-### Get Metrics
+### Get metrics
 
 `GET /v1/metrics`
 
 Returns metrics in OpenMetrics format suitable for scraping by Prometheus-compatible systems.
 
-#### Timestamp Offset
+#### Timestamp offset
 
 To account for metric data latency, this endpoint returns metrics from the current timestamp minus a fixed offset.  The current offset is 3 minutes rounded down to the start of the minute. To accommodate this offset, the timestamps in the response should be honored when importing the metrics. For example, in Prometheus this can be controlled using the `honor\_timestamps` flag.
 
-#### Query Parameters
+#### Query parameters
 
 | Parameter | Type | Description |
 | ----- | ----- | ----- |
@@ -179,7 +179,7 @@ The `namespaces` and `metrics` parameters can be combined, and each may be repea
 /v1/metrics?namespaces=prod-payments&namespaces=prod-orders&metrics=temporal_cloud_v1_workflow_success_count&metrics=temporal_cloud_v1_approximate_backlog_count
 ```
 
-#### Response Headers
+#### Response headers
 
 | Header | Description |
 | ----- | ----- |
@@ -209,20 +209,20 @@ temporal_cloud_v1_approximate_backlog_count{temporal_namespace="production",temp
 
 :::
 
-#### Summary of Best Practices
+#### Summary of best practices
 
 * *Honor timestamps*: Set `honor_timestamps: true` in Prometheus  
 * *Scrape interval*: Use 30s. Intervals longer than 60s may skip datapoints because metrics update once per minute.  
 * *Timeout*: Set scrape timeout to 10 seconds for large responses  
 * *Filtering*: Use query parameters to reduce response size
 
-### List Metric Descriptors
+### List metric descriptors
 
 `GET /v1/descriptors`
 
 Lists all metric descriptors including metadata, data types, and available dimensions (a.k.a. labels).
 
-#### Query Parameters
+#### Query parameters
 
 | Parameter | Type | Description |
 | ----- | ----- | ----- |
@@ -266,7 +266,7 @@ Response:
 
 :::
 
-## Managing High Cardinality
+## Managing high cardinality
 
 :::caution
 
@@ -274,7 +274,7 @@ High-cardinality labels like `temporal_task_queue` and `temporal_workflow_type` 
 
 :::
 
-### Cardinality Estimation
+### Cardinality estimation
 
 To estimate your metric cardinality and see if this is an issue:
 
@@ -298,7 +298,7 @@ Example:
 
 If the cardinality is too high or you are hitting API limits, consider the following strategies.
 
-### Filtering at Scrape Time
+### Filtering at scrape time
 
 You can isolate only the metrics/namespaces you need.  For example, the following shows examples of filtering by modifying the `metrics_path.`
 
@@ -336,7 +336,7 @@ scrape_configs:
 :::
 
 
-### Label Management
+### Label management
 
 #### Prometheus
 
@@ -359,7 +359,7 @@ metric_relabel_configs:
   action: labeldrop
 ```
 
-#### OpenTelemetry Collector
+#### OpenTelemetry collector
 
 To accomplish the same as Prometheus, a filter can be used in the collector along with any other processors.
 
@@ -374,7 +374,7 @@ processors:
           - Label("temporal_task_queue") == nil or IsMatch(Label("temporal_task_queue"), "^(critical-queue|payment-queue)$")
 ```
 
-### Monitoring Cardinality
+### Monitoring cardinality
 
 Cardinality can be monitored using this PromQL query.
 
@@ -386,7 +386,7 @@ count({__name__=~"temporal_cloud_v1_.*"})
 count({__name__=~"temporal_cloud_v1_.*"}) by (__name__)
 ```
 
-## API Limits
+## API limits
 
 | Limit | Impact | Mitigation |
 | ----- | ----- | ----- |


### PR DESCRIPTION
## What does this PR do?
We bumped the OpenMetrics data point return limit from 30k to 50k. Updating the docs to reflect reality.

## Notes to reviewers

<!-- delete if n/a -->

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217423457692792">EDU-6938 Bump OpenMetric data point limit</a>
