### PR TITLE
Updating the site title

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,6 @@
 ---
 id: index
-title: Temporal Docs
+title: Temporal Platform Documentation
 sidebar_label: Home
 hide_table_of_contents: true
 hide_title: true

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,7 +8,7 @@ const { AEONIK_LIGHT_FILENAME, AEONIK_REGULAR_FILENAME } = require('./src/consta
 
 module.exports = async function createConfigAsync() {
   return {
-    title: 'Temporal Platform Documentation',
+    title: 'Temporal Documentation',
     tagline: 'Build invincible applications',
     url: 'https://docs.temporal.io',
     baseUrl: '/',

--- a/src/theme/ThemeProvider/TitleFormatter/index.tsx
+++ b/src/theme/ThemeProvider/TitleFormatter/index.tsx
@@ -5,14 +5,23 @@ import type {Props} from '@theme/ThemeProvider/TitleFormatter';
 type FormatterProp = ComponentProps<typeof TitleFormatterProvider>['formatter'];
 
 // Section label inserted between the page title and the site title, keyed by
-// content-docs plugin id, e.g. "Tool calling agent | AI Cookbook | Temporal Platform Documentation".
+// content-docs plugin id, e.g. "Tool calling agent | AI Cookbook | Temporal Documentation".
 const SECTION_TITLES: Record<string, string> = {
   'ai-cookbook': 'AI Cookbook',
 };
 
+// docs/index.mdx (the homepage) sets its frontmatter `title` to this exact
+// string. It's the one page that should render with no site-title suffix.
+const HOMEPAGE_TITLE = 'Temporal Platform Documentation';
+
 const formatter: FormatterProp = (params) => {
-  const sectionTitle = SECTION_TITLES[params.plugin.id];
   const trimmedTitle = params.title?.trim();
+
+  if (trimmedTitle === HOMEPAGE_TITLE) {
+    return HOMEPAGE_TITLE;
+  }
+
+  const sectionTitle = SECTION_TITLES[params.plugin.id];
 
   if (!sectionTitle || !trimmedTitle || trimmedTitle === sectionTitle) {
     return params.defaultFormatter(params);


### PR DESCRIPTION
- Change the site title from 'Temporal Platform Documentation' to 'Temporal Documentation' in docusaurus.config.js.
- Update the homepage title in docs/index.mdx to 'Temporal Platform Documentation'.
- Adjust the title formatting logic in TitleFormatter to ensure the homepage title is rendered correctly without the site-title suffix.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217425214375926">EDU-6942 Updating the site title</a>
