### PR TITLE
Enable Google.Latin rule in Vale CI

### DIFF
--- a/.vale-ci.ini
+++ b/.vale-ci.ini
@@ -7,8 +7,7 @@ BasedOnStyles = Temporal
 
 ; Explicitly enable a single Google rule without pulling in the whole Google
 ; style. Google.Latin flags Latin abbreviations (e.g., i.e.) in favor of
-; "for example" / "that is". The Google styles are checked into vale/styles/,
-; so no Packages sync is needed for this to resolve.
+; "for example" / "that is". 
 Google.Latin = YES
 
 ; Only enable the high-confidence rules we want in CI.

--- a/.vale-ci.ini
+++ b/.vale-ci.ini
@@ -5,6 +5,12 @@ MinAlertLevel = suggestion
 [*.{md,mdx}]
 BasedOnStyles = Temporal
 
+; Explicitly enable a single Google rule without pulling in the whole Google
+; style. Google.Latin flags Latin abbreviations (e.g., i.e.) in favor of
+; "for example" / "that is". The Google styles are checked into vale/styles/,
+; so no Packages sync is needed for this to resolve.
+Google.Latin = YES
+
 ; Only enable the high-confidence rules we want in CI.
 ; Temporal.terms (term-capitalization substitution) is disabled here because
 ; it produces too many false positives to be useful as a CI gate.


### PR DESCRIPTION
## What

Enables the `Google.Latin` rule in the Vale CI config (`.vale-ci.ini`). The rule flags Latin abbreviations (`e.g.`, `i.e.`) and suggests the plain-English forms "for example" / "that is", per the [Google style guide on abbreviations](https://developers.google.com/style/abbreviations).

## How

Added a single line to the `[*.{md,mdx}]` section:

```ini
Google.Latin = YES
```

- Enables just this one rule without adding the entire `Google` style to `BasedOnStyles`.
- Resolves against `vale/styles/Google/Latin.yml`, which is already checked into the repo — no `Packages` sync needed.

## Behavior

Stays advisory, consistent with the other rules in this CI gate:

- The rule is `level: suggestion` and the workflow keeps `fail_on_error: false`, so it surfaces as `github-pr-review` comments, not a hard failure.
- The job runs with `filter_mode: diff_context`, so only `e.g.`/`i.e.` on **changed** lines get flagged. There are ~216 existing hits across `docs/`; those won't all appear — they'll only be commented as contributors touch those lines.

To make it blocking later would be a separate change: bump the rule's `level` to `error` and set `fail_on_error: true` in the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217444683585193">EDU-6945 Enable Google.Latin rule in Vale CI</a>
