### PR TITLE
Replace legacy Cloud metrics with v1 metrics

### DIFF
--- a/docs/best-practices/managing-aps-limits.mdx
+++ b/docs/best-practices/managing-aps-limits.mdx
@@ -239,7 +239,7 @@ See the documentation on [detecting resource exhaustion](/cloud/service-health#r
 If you're considering Provisioned capacity, set up monitoring to understand your usage patterns:
 
 - **Use [OpenMetrics](/cloud/metrics/openmetrics)**: For real-time visibility into APS consumption, integrate Temporal Cloud metrics with your observability stack
-- **Track APS usage vs. limits**: Monitor `temporal_cloud_v0_resource_exhausted_errors` to detect throttling events
+- **Track APS usage vs. limits**: Monitor [`temporal_cloud_v1_total_action_throttled_count`](/cloud/metrics/openmetrics/metrics-reference#temporal_cloud_v1_total_action_throttled_count) to detect throttling events
 - **Set alerts at 70-80% utilization**: This gives you time to provision TRUs before hitting limits
 - **Analyze historical patterns**: Understanding your traffic patterns helps you decide between reactive TRU provisioning and proactive automation
 

--- a/docs/best-practices/pre-production-testing.mdx
+++ b/docs/best-practices/pre-production-testing.mdx
@@ -101,7 +101,7 @@ Periodically restart a fixed or random percentage (for example, 20-30%) of your 
 
 1. Have SDK metrics accessible (not just the Cloud metrics)
 2. Understand and predict what you should see from these metrics:
-   - Rate limiting (`temporal_cloud_v1_resource_exhausted_error_count`)
+   - Rate limiting ([`temporal_cloud_v1_total_action_throttled_count`](/cloud/metrics/openmetrics/metrics-reference#temporal_cloud_v1_total_action_throttled_count) and [`temporal_cloud_v1_service_request_throttled_count`](/cloud/metrics/openmetrics/metrics-reference#temporal_cloud_v1_service_request_throttled_count))
    - Workflow failures (`temporal_cloud_v1_workflow_failed_count`)
    - Workflow execution time (`workflow_endtoend_latency`)
    - High Cloud latency (`temporal_cloud_v1_service_latency_p95`)
@@ -144,7 +144,7 @@ Start Workflows at a rate to surpass throughput limits. Example: [temporal-ratel
 **What to test**
 
 - Schedule a large number of Actions and Requests by starting many Workflows
-- Increase the number until you get rate limited (trigger metric [`temporal_cloud_v0_resource_exhausted_error_count`](/cloud/metrics/reference#temporal_cloud_v0_resource_exhausted_error_count))
+- Increase the number until you get rate limited and trigger [`temporal_cloud_v1_total_action_throttled_count`](/cloud/metrics/openmetrics/metrics-reference#temporal_cloud_v1_total_action_throttled_count) or [`temporal_cloud_v1_service_request_throttled_count`](/cloud/metrics/openmetrics/metrics-reference#temporal_cloud_v1_service_request_throttled_count)
 
 **Why it matters**
 

--- a/docs/develop/worker-tuning-reference.mdx
+++ b/docs/develop/worker-tuning-reference.mdx
@@ -168,7 +168,7 @@ Also monitor your machine's memory consumption (for example, `container_memory_u
 
 | Metric | Description |
 |--------|-------------|
-| [`poll_success_sync_count`](/cloud/metrics/reference#temporal_cloud_v0_poll_success_sync_count) | Sync match rate (Tasks immediately assigned to Workers) |
+| [`poll_success_sync_count`](/cloud/metrics/openmetrics/metrics-reference#temporal_cloud_v1_poll_success_sync_count) | Sync match rate (Tasks immediately assigned to Workers) |
 | [`approximate_backlog_count`](/cloud/metrics/openmetrics/metrics-reference#temporal_cloud_v1_approximate_backlog_count) | Approximate number of Tasks in a Task Queue |
 
 Task Queue statistics are also available via the `DescribeTaskQueue` API:


### PR DESCRIPTION
## Summary

- point Worker tuning guidance to the OpenMetrics v1 sync-match metric
- use v1 Actions and service-request throttle metrics in pre-production rate-limit testing
- use the v1 Actions throttle metric when monitoring APS limits
- remove all Temporal Cloud v0 metric references from these three pages

## Validation

- `vale --config .vale-ci.ini docs/develop/worker-tuning-reference.mdx docs/best-practices/pre-production-testing.mdx docs/best-practices/managing-aps-limits.mdx` (0 errors, 0 warnings)
- `git diff --check`
- verified the v1 metric anchors against the OpenMetrics metrics reference

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217466197944656">EDU-6950 Replace legacy Cloud metrics with v1 metrics</a>
