### PR TITLE
Document the PayloadsTooLarge failure_reason value

### DIFF
--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -543,6 +543,7 @@ Valid values for the `failure_reason` tag:
 
 - `NonDeterminismError`: The Workflow Task failed due to a non-determinism error.
 - `GrpcMessageTooLarge`: The Workflow Task response exceeded the gRPC message size limit and could not be delivered. The Temporal Service terminates the Workflow Execution in response. See [Troubleshoot the BlobSizeLimitError](/troubleshooting/blob-size-limit-error).
+- `PayloadsTooLarge`: A Payload or Memo in the Workflow Task response exceeded the Namespace size limit, so the Worker proactively failed the Workflow Task as retryable. See [Troubleshoot the BlobSizeLimitError](/troubleshooting/blob-size-limit-error#payload-size-limit).
 - `WorkflowError`: The Workflow Task failed for any other reason.
 
 ### `workflow_task_execution_latency`


### PR DESCRIPTION
## What does this PR do?

Adds `PayloadsTooLarge` to the list of `failure_reason` values under `workflow_task_execution_failed` in the SDK metrics reference.

This is emitted when a payload or memo in a WFT completion is over the namespace-defined error limit. The worker proactively emits a WFT failure instead of sending the completion. This behavior is already covered in [Troubleshoot the BlobSizeLimitError](https://docs.temporal.io/troubleshooting/blob-size-limit-error#payload-size-limit), which the new entry links to.

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217512101961659">EDU-6957 Document the PayloadsTooLarge failure_reason value</a>
