### PR TITLE
Fix Python integrations list on develop landing page

### DIFF
--- a/docs/develop/python/index.mdx
+++ b/docs/develop/python/index.mdx
@@ -86,7 +86,8 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 ## [Integrations](/develop/python/integrations)
 
 - [Braintrust integration](/develop/python/integrations/braintrust)
-- [Google ADK integration](https://adk.dev/integrations/temporal/)
+- [Deep Agents integration](/develop/python/integrations/deepagents)
+- [Google ADK integration](/develop/python/integrations/google-adk)
 - [Google GenAI integration](/develop/python/integrations/google-genai)
 - [LangGraph integration](/develop/python/integrations/langgraph)
 - [LangSmith integration](/develop/python/integrations/langsmith)

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -69,7 +69,7 @@
       "Agent framework"
     ],
     "sdk": "Python",
-    "href": "https://adk.dev/integrations/temporal/"
+    "href": "/develop/python/integrations/google-adk"
   },
   {
     "name": "Google ADK",


### PR DESCRIPTION
## What changed

Two fixes to the Integrations list on `/develop/python`:

- **Google ADK** now links to the local guide at `/develop/python/integrations/google-adk` instead of `https://adk.dev/integrations/temporal/`. The external link was added in #4606, before the local guide landed in #4759, and was never updated.
- **Deep Agents** was missing from the list entirely, even though `develop/python/integrations/deepagents` is in the sidebar. Added it, alphabetized after Braintrust.

The list on this page now matches the `Integrations` entries in `sidebars.js`.

## Notes

The remaining external links in that list (OpenAI Agents SDK, OpenBox, Parseable, Pydantic AI, Tenuo) have no page under `docs/develop/python/integrations/`, so they correctly stay external. Worth a follow-up: TypeScript has an OpenAI Agents SDK guide but Python doesn't, so Python points at the `sdk-python` contrib README in both this list and `src/components/IntegrationsGrid/integrations-data.json`.

## Testing

`vale --config .vale-ci.ini docs/develop/python/index.mdx` — 0 errors, 0 warnings. The one suggestion it reports is a pre-existing heading unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

┆Attachments: <a href="https://app.asana.com/app/asana/-/get_asset?asset_id=1217608706144994">EDU-6980 Fix Python integrations list on develop landing page</a>
