### PR TITLE
Move the Google GenAI Python integration to Public Preview

### DIFF
--- a/docs/develop/python/integrations/google-genai.mdx
+++ b/docs/develop/python/integrations/google-genai.mdx
@@ -33,7 +33,7 @@ History entry, and your credentials stay on the Worker.
 import { ReleaseNoteHeader } from '@site/src/components';
 
 <ReleaseNoteHeader
-  type="prerelease"
+  type="publicPreview"
 />
 
 Code snippets in this guide come from the


### PR DESCRIPTION
Updates the `ReleaseNoteHeader` on the Python Google GenAI integration page from `prerelease` to `publicPreview`, so the page shows **Currently in: Public Preview** and links to the Public Preview release stage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)