### PR TITLE
Mention AI agents on the homepage

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -4,7 +4,7 @@ title: Temporal Platform Documentation
 sidebar_label: Home
 hide_table_of_contents: true
 hide_title: true
-description: Official docs for Temporal, the open source Durable Execution platform for crash-proof applications. Guides, SDKs, and references for reliable workflows.
+description: Official docs for Temporal, the open source Durable Execution platform for crash-proof applications and AI agents. Guides, SDKs, and references for reliable workflows.
 ---
 
 import {
@@ -32,7 +32,7 @@ import {
 
 Temporal is an open-source platform for building reliable applications. Temporal delivers crash-proof execution by guaranteeing that applications resume exactly where they left off after crashes, network failures, or infrastructure outages, whether that happens seconds, days, or even years later.
 
-Temporal enables developers to focus on building features that drive the business while ensuring that mission-critical processes such as order fulfillment, customer onboarding, and payment processing never fail or disappear, regardless of what goes wrong.
+Temporal enables developers to focus on building features that drive the business while ensuring that mission-critical processes such as order fulfillment, customer onboarding, payment processing, and AI agents never fail or disappear, regardless of what goes wrong.
 
 <HeroCta href="/quickstarts">Quickstart</HeroCta>
 


### PR DESCRIPTION
## Summary
- Folds "AI agents" into the existing list of mission-critical process examples in the homepage hero paragraph
- Adds "AI agents" to the homepage's SEO `description`, so it also surfaces in search snippets and social previews

Both changes are subtle by design — no new section, card, or link (the not-yet-live Durable AI landing page isn't linked here). Terminology matches the existing "AI Agents" heading on [use-cases-design-patterns.mdx](https://github.com/temporalio/documentation/blob/main/docs/evaluate/use-cases-design-patterns.mdx).

Opened as draft to revisit later.

## Test plan
- [x] `vale --config .vale-ci.ini docs/index.mdx` passes clean
- [x] `yarn build` succeeds with no MDX/build errors
- [x] Verified in dev server: hero paragraph renders correctly, `<meta name="description">` reflects the new text
- [x] Verified generated Markdown mirror (`build/index.md`) includes both changes