### PR TITLE
Use uv commands for Braintrust setup

### DIFF
--- a/docs/develop/python/integrations/braintrust.mdx
+++ b/docs/develop/python/integrations/braintrust.mdx
@@ -56,7 +56,7 @@ Follow the steps below to configure your Worker.
 1. Install the Braintrust SDK with Temporal support.
 
    ```bash
-   uv pip install "braintrust[temporal]"
+   uv add "braintrust[temporal]"
    ```
 
 2. Initialize the Braintrust logger before creating your Worker. The logger must be initialized first so that spans are

--- a/docs/develop/python/integrations/braintrust.mdx
+++ b/docs/develop/python/integrations/braintrust.mdx
@@ -103,7 +103,7 @@ Follow the steps below to configure your Worker.
 
    ```bash
    export BRAINTRUST_API_KEY="your-api-key"
-   python worker.py
+   uv run worker.py
    ```
 
    :::tip

--- a/docs/develop/python/integrations/braintrust.mdx
+++ b/docs/develop/python/integrations/braintrust.mdx
@@ -266,8 +266,8 @@ temporal server start-dev
 export BRAINTRUST_API_KEY="your-api-key"
 export OPENAI_API_KEY="your-api-key"
 export BRAINTRUST_PROJECT="deep-research"
-uv run python -m worker
+uv run worker.py
 
 # Terminal 3: Run a research query
-uv run python -m start_workflow "What are the latest advances in quantum computing?"
+uv run start_workflow.py "What are the latest advances in quantum computing?"
 ```


### PR DESCRIPTION
## What changed

- Add the Braintrust integration dependency with `uv add`.
- Run the Worker and Workflow starter scripts directly with `uv run`.

## Why

The guide uses a uv-managed project, so dependency installation and command execution should use the project environment.

## Impact

Python developers following the guide get a reproducible dependency declaration and run the example scripts with the environment managed by uv.

## Validation

- `vale --config .vale-ci.ini docs/develop/python/integrations/braintrust.mdx` (0 errors, 0 warnings)
