### PR TITLE
Add Temporal Serverless Workers Skill to Develop with AI and llms.txt

### DIFF
--- a/docs/encyclopedia/workers/serverless-workers/index.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/index.mdx
@@ -27,14 +27,6 @@ import { CaptionedImage, ReleaseNoteHeader } from '@site/src/components';
   when Cloud Run reaches Public Preview.
 </ReleaseNoteHeader>
 
-:::tip Use the Serverless Workers Skill
-
-The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) gives your AI coding
-agent the knowledge to write, package, deploy, and troubleshoot Serverless Workers. See
-[Develop with AI](/with-ai#skills) for installation instructions.
-
-:::
-
 This page covers the following:
 
 - [What is a Serverless Worker?](#serverless-worker)
@@ -62,6 +54,14 @@ Serverless Workers require [Worker Versioning](/worker-versioning). Each Serverl
 
 To deploy a Serverless Worker, see
 [Deploy a Serverless Worker](/production-deployment/worker-deployments/serverless-workers).
+
+:::tip Use the Serverless Workers Skill
+
+The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) gives your AI coding
+agent the knowledge to write, package, deploy, and troubleshoot Serverless Workers. See
+[Develop with AI](/with-ai#skills) for installation instructions.
+
+:::
 
 ### Compute providers {/* #compute-providers */}
 

--- a/docs/encyclopedia/workers/serverless-workers/index.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/index.mdx
@@ -27,6 +27,14 @@ import { CaptionedImage, ReleaseNoteHeader } from '@site/src/components';
   when Cloud Run reaches Public Preview.
 </ReleaseNoteHeader>
 
+:::tip Use the Serverless Workers Skill
+
+The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) gives your AI coding
+agent the knowledge to write, package, deploy, and troubleshoot Serverless Workers. See
+[Develop with AI](/with-ai#skills) for installation instructions.
+
+:::
+
 This page covers the following:
 
 - [What is a Serverless Worker?](#serverless-worker)

--- a/docs/evaluate/development-production-features/serverless-workers/index.mdx
+++ b/docs/evaluate/development-production-features/serverless-workers/index.mdx
@@ -30,6 +30,14 @@ import { ReleaseNoteHeader } from '@site/src/components';
   when Cloud Run reaches Public Preview.
 </ReleaseNoteHeader>
 
+:::tip Use the Serverless Workers Skill
+
+The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) gives your AI coding
+agent the knowledge to write, package, deploy, and troubleshoot Serverless Workers. See
+[Develop with AI](/with-ai#skills) for installation instructions.
+
+:::
+
 Serverless Workers let you run Temporal Workers on serverless compute platforms like AWS Lambda and GCP Cloud Run. There
 are no servers to provision, no clusters to scale, and no idle compute to pay for. Temporal starts Workers when Tasks
 arrive and stops them when the work drains.

--- a/docs/evaluate/development-production-features/serverless-workers/index.mdx
+++ b/docs/evaluate/development-production-features/serverless-workers/index.mdx
@@ -30,14 +30,6 @@ import { ReleaseNoteHeader } from '@site/src/components';
   when Cloud Run reaches Public Preview.
 </ReleaseNoteHeader>
 
-:::tip Use the Serverless Workers Skill
-
-The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) gives your AI coding
-agent the knowledge to write, package, deploy, and troubleshoot Serverless Workers. See
-[Develop with AI](/with-ai#skills) for installation instructions.
-
-:::
-
 Serverless Workers let you run Temporal Workers on serverless compute platforms like AWS Lambda and GCP Cloud Run. There
 are no servers to provision, no clusters to scale, and no idle compute to pay for. Temporal starts Workers when Tasks
 arrive and stops them when the work drains.
@@ -50,6 +42,14 @@ when there is no work.
 
 For a deeper look at how Serverless invocation works under the hood, see [Serverless Workers](/serverless-workers) in
 the encyclopedia.
+
+:::tip Use the Serverless Workers Skill
+
+The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) gives your AI coding
+agent the knowledge to write, package, deploy, and troubleshoot Serverless Workers. See
+[Develop with AI](/with-ai#skills) for installation instructions.
+
+:::
 
 ## Why use Serverless Workers?
 

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -92,6 +92,39 @@ The [Temporal Cloud Skill](https://github.com/temporalio/skill-temporal-cloud) h
 Temporal Cloud connectivity, authentication, and configuration issues.
 
 <Tabs groupId="skill-install" queryString>
+<TabItem value="claude-code" label="Claude Code Plugin">
+
+1. Add the Temporal skills marketplace to Claude Code:
+
+   ```bash
+   /plugin marketplace add temporalio/claude-temporal-plugin
+   ```
+
+2. Install the Temporal plugin, which includes the Temporal Cloud Skill:
+
+   ```bash
+   /plugin install temporal@temporal-marketplace
+   ```
+
+</TabItem>
+<TabItem value="cursor" label="Cursor">
+
+Install the Temporal plugin, which includes the Temporal Cloud Skill, from the
+[Cursor Marketplace](https://cursor.com/marketplace/temporal), or run the following command in Cursor's agent chat:
+
+```
+/add-plugin temporal
+```
+
+</TabItem>
+<TabItem value="codex" label="Codex">
+
+Install the Temporal plugin, which includes the Temporal Cloud Skill, from the Codex app or CLI:
+
+- **Codex app:** Open the plugins menu, search for **temporal**, then click **+** (or **Add to Codex**).
+- **Codex CLI:** Run `/plugin`, search for **temporal**, and mark it for installation.
+
+</TabItem>
 <TabItem value="npx" label="npx">
 
 This works with Claude Code, Codex, Cline, and other agents.
@@ -128,6 +161,39 @@ agent deploy and operate Temporal Serverless Workers on AWS Lambda. It covers Wo
 packaging, and troubleshooting Workers that aren't picking up Tasks.
 
 <Tabs groupId="skill-install" queryString>
+<TabItem value="claude-code" label="Claude Code Plugin">
+
+1. Add the Temporal skills marketplace to Claude Code:
+
+   ```bash
+   /plugin marketplace add temporalio/claude-temporal-plugin
+   ```
+
+2. Install the Temporal plugin, which includes the Temporal Serverless Workers skill:
+
+   ```bash
+   /plugin install temporal@temporal-marketplace
+   ```
+
+</TabItem>
+<TabItem value="cursor" label="Cursor">
+
+Install the Temporal plugin, which includes the Temporal Serverless Workers skill, from the
+[Cursor Marketplace](https://cursor.com/marketplace/temporal), or run the following command in Cursor's agent chat:
+
+```
+/add-plugin temporal
+```
+
+</TabItem>
+<TabItem value="codex" label="Codex">
+
+Install the Temporal plugin, which includes the Temporal Serverless Workers skill, from the Codex app or CLI:
+
+- **Codex app:** Open the plugins menu, search for **temporal**, then click **+** (or **Add to Codex**).
+- **Codex CLI:** Run `/plugin`, search for **temporal**, and mark it for installation.
+
+</TabItem>
 <TabItem value="npx" label="npx">
 
 This works with Claude Code, Codex, Cline, and other agents.

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -112,11 +112,12 @@ git clone https://github.com/temporalio/skill-temporal-cloud.git ~/.claude/skill
 
 Restart your coding agent after installing.
 
-### Temporal Serverless Workers Skill
+### Temporal Serverless Workers skill
 
 The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) helps your AI coding
-agent deploy and operate Temporal Workers on serverless compute, covering Worker code, deployment configuration,
-packaging, and troubleshooting Workers that aren't picking up Tasks.
+agent deploy and operate Temporal Serverless Workers on AWS Lambda. The skill and AWS Lambda support are in Public
+Preview. It covers Worker code, deployment configuration, packaging, and troubleshooting Workers that aren't picking up
+Tasks.
 
 <Tabs groupId="skill-install" queryString>
 <TabItem value="npx" label="npx">

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -112,6 +112,38 @@ git clone https://github.com/temporalio/skill-temporal-cloud.git ~/.claude/skill
 
 Restart your coding agent after installing.
 
+### Temporal Serverless Workers Skill
+
+The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) helps your AI coding
+agent deploy and operate Temporal Workers on serverless compute, covering Worker code, deployment configuration,
+packaging, and troubleshooting Workers that aren't picking up Tasks.
+
+<Tabs groupId="skill-install" queryString>
+<TabItem value="npx" label="npx">
+
+This works with Claude Code, Codex, Cline, and other agents.
+
+Install the skill using the `skills` CLI:
+
+```bash
+npx skills add https://github.com/temporalio/skill-temporal-serverless
+```
+
+</TabItem>
+<TabItem value="manual" label="Manual">
+
+Clone the skill repository into your Claude skills directory. Change the target directory if you are using agents other
+than Claude:
+
+```bash
+git clone https://github.com/temporalio/skill-temporal-serverless.git ~/.claude/skills/temporal-serverless
+```
+
+</TabItem>
+</Tabs>
+
+Restart your coding agent after installing.
+
 ## Temporal knowledge base MCP server
 
 Connect Temporal expertise directly to your AI assistant for accurate, up-to-date answers about Temporal. The

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -8,8 +8,8 @@ description: Give your AI coding agent Temporal expertise and real-time access t
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Give your AI coding agent Temporal expertise with Skills, real-time documentation access with the Temporal Knowledge Base
-MCP Server, or direct access to the docs as Markdown.
+Give your AI coding agent Temporal expertise with Skills, real-time documentation access with the Temporal Knowledge
+Base MCP Server, or direct access to the docs as Markdown.
 
 ## Skills
 
@@ -115,9 +115,8 @@ Restart your coding agent after installing.
 ### Temporal Serverless Workers skill
 
 The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) helps your AI coding
-agent deploy and operate Temporal Serverless Workers on AWS Lambda. The skill and AWS Lambda support are in Public
-Preview. It covers Worker code, deployment configuration, packaging, and troubleshooting Workers that aren't picking up
-Tasks.
+agent deploy and operate Temporal Serverless Workers on AWS Lambda. It covers Worker code, deployment configuration,
+packaging, and troubleshooting Workers that aren't picking up Tasks.
 
 <Tabs groupId="skill-install" queryString>
 <TabItem value="npx" label="npx">
@@ -147,14 +146,16 @@ Restart your coding agent after installing.
 
 ## Temporal knowledge base MCP server
 
-Connect Temporal expertise directly to your AI assistant for accurate, up-to-date answers about Temporal. The
-Temporal knowledge base MCP server gives AI tools real-time access to best practices compiled from our documentation, educational materials, community forum responses, and slack channels, so responses draw from current expertise
-rather than training data.
+Connect Temporal expertise directly to your AI assistant for accurate, up-to-date answers about Temporal. The Temporal
+knowledge base MCP server gives AI tools real-time access to best practices compiled from our documentation, educational
+materials, community forum responses, and slack channels, so responses draw from current expertise rather than training
+data.
 
 :::info Authentication required
 
-The Temporal Knowledge Base MCP Server is publicly available, but requires a one-time login with a Google or GitHub account to enforce rate limits and prevent abuse.
-Only an opaque user ID is used for rate limiting. Your name, email, repositories, and other personal data are not accessed or collected.
+The Temporal Knowledge Base MCP Server is publicly available, but requires a one-time login with a Google or GitHub
+account to enforce rate limits and prevent abuse. Only an opaque user ID is used for rate limiting. Your name, email,
+repositories, and other personal data are not accessed or collected.
 
 :::
 
@@ -191,11 +192,10 @@ The Temporal Knowledge Base MCP Server URL is:
 https://temporal.mcp.kapa.ai
 ```
 
-The server requires authentication through MCP OAuth.
-Not all MCP clients support this protocol.
-If your client supports MCP OAuth, it will open a browser window to verify with Google or GitHub on first connection.
-If your client does not support MCP OAuth, you may need to use a stdio proxy that handles the OAuth flow and passes credentials to the remote server.
-Check your client's documentation for details on connecting to OAuth-protected MCP servers.
+The server requires authentication through MCP OAuth. Not all MCP clients support this protocol. If your client supports
+MCP OAuth, it will open a browser window to verify with Google or GitHub on first connection. If your client does not
+support MCP OAuth, you may need to use a stdio proxy that handles the OAuth flow and passes credentials to the remote
+server. Check your client's documentation for details on connecting to OAuth-protected MCP servers.
 
 ## Markdown pages and llms.txt
 

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -7,6 +7,7 @@ description: Give your AI coding agent Temporal expertise and real-time access t
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { ReleaseNoteHeader } from '@site/src/components';
 
 Give your AI coding agent Temporal expertise with Skills, real-time documentation access with the Temporal Knowledge
 Base MCP Server, or direct access to the docs as Markdown.
@@ -83,6 +84,10 @@ Restart your coding agent after installing.
 
 ### Temporal Cloud Skill
 
+<ReleaseNoteHeader type="publicPreview">
+  The Temporal Cloud Skill is in Public Preview. Its contents and behavior may change.
+</ReleaseNoteHeader>
+
 The [Temporal Cloud Skill](https://github.com/temporalio/skill-temporal-cloud) helps your AI coding agent troubleshoot
 Temporal Cloud connectivity, authentication, and configuration issues.
 
@@ -113,6 +118,10 @@ git clone https://github.com/temporalio/skill-temporal-cloud.git ~/.claude/skill
 Restart your coding agent after installing.
 
 ### Temporal Serverless Workers skill
+
+<ReleaseNoteHeader type="publicPreview">
+  The Temporal Serverless Workers skill is in Public Preview. Its contents and behavior may change.
+</ReleaseNoteHeader>
 
 The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) helps your AI coding
 agent deploy and operate Temporal Serverless Workers on AWS Lambda. It covers Worker code, deployment configuration,

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -153,7 +153,7 @@ Restart your coding agent after installing.
 ### Temporal Serverless Workers Skill
 
 <ReleaseNoteHeader type="publicPreview">
-  The Temporal Serverless Workers skill is in Public Preview. Its contents and behavior may change.
+  The Temporal Serverless Workers Skill is in Public Preview. Its contents and behavior may change.
 </ReleaseNoteHeader>
 
 The [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) helps your AI coding
@@ -169,7 +169,7 @@ packaging, and troubleshooting Workers that aren't picking up Tasks.
    /plugin marketplace add temporalio/claude-temporal-plugin
    ```
 
-2. Install the Temporal plugin, which includes the Temporal Serverless Workers skill:
+2. Install the Temporal plugin, which includes the Temporal Serverless Workers Skill:
 
    ```bash
    /plugin install temporal@temporal-marketplace
@@ -178,7 +178,7 @@ packaging, and troubleshooting Workers that aren't picking up Tasks.
 </TabItem>
 <TabItem value="cursor" label="Cursor">
 
-Install the Temporal plugin, which includes the Temporal Serverless Workers skill, from the
+Install the Temporal plugin, which includes the Temporal Serverless Workers Skill, from the
 [Cursor Marketplace](https://cursor.com/marketplace/temporal), or run the following command in Cursor's agent chat:
 
 ```
@@ -188,7 +188,7 @@ Install the Temporal plugin, which includes the Temporal Serverless Workers skil
 </TabItem>
 <TabItem value="codex" label="Codex">
 
-Install the Temporal plugin, which includes the Temporal Serverless Workers skill, from the Codex app or CLI:
+Install the Temporal plugin, which includes the Temporal Serverless Workers Skill, from the Codex app or CLI:
 
 - **Codex app:** Open the plugins menu, search for **temporal**, then click **+** (or **Add to Codex**).
 - **Codex CLI:** Run `/plugin`, search for **temporal**, and mark it for installation.

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -117,7 +117,7 @@ git clone https://github.com/temporalio/skill-temporal-cloud.git ~/.claude/skill
 
 Restart your coding agent after installing.
 
-### Temporal Serverless Workers skill
+### Temporal Serverless Workers Skill
 
 <ReleaseNoteHeader type="publicPreview">
   The Temporal Serverless Workers skill is in Public Preview. Its contents and behavior may change.

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -234,15 +234,7 @@ module.exports = async function createConfigAsync() {
         searchPagePath: false, // Disable default search page - using custom implementation at src/pages/search.tsx
         insights: true,
         searchParameters: {
-          attributesToRetrieve: [
-            'hierarchy',
-            'content',
-            'anchor',
-            'url',
-            'url_without_anchor',
-            'type',
-            'sdk_language',
-          ],
+          attributesToRetrieve: ['hierarchy', 'content', 'anchor', 'url', 'url_without_anchor', 'type', 'sdk_language'],
         },
       },
       mermaid: {
@@ -263,12 +255,7 @@ module.exports = async function createConfigAsync() {
           docs: {
             sidebarPath: require.resolve('./sidebars.js'),
             routeBasePath: '/',
-            exclude: [
-              '**/_*.{js,jsx,ts,tsx,md,mdx}',
-              '**/_*/**',
-              '**/clusters/**',
-              '**/ai-cookbook/**',
-            ], // partials (underscore-prefixed) + context content we don't render
+            exclude: ['**/_*.{js,jsx,ts,tsx,md,mdx}', '**/_*/**', '**/clusters/**', '**/ai-cookbook/**'], // partials (underscore-prefixed) + context content we don't render
             editUrl: 'https://github.com/temporalio/documentation/blob/main/',
             /**
              * Whether to display the author who last updated the doc.
@@ -408,23 +395,26 @@ module.exports = async function createConfigAsync() {
           llmsTxt: {
             siteUrl: 'https://docs.temporal.io',
             title: 'Temporal Platform Documentation',
-            description: 'This file is a structured index of Temporal\'s documentation, following the llmstxt.org standard. Temporal is an open-source platform for building crash-proof applications that resume exactly where they left off after failures.',
-            fullDescription: 'This file is the complete text of Temporal\'s documentation, intended for bulk ingestion. Temporal is an open-source platform for building crash-proof applications that resume exactly where they left off after failures.',
+            description:
+              "This file is a structured index of Temporal's documentation, following the llmstxt.org standard. Temporal is an open-source platform for building crash-proof applications that resume exactly where they left off after failures.",
+            fullDescription:
+              "This file is the complete text of Temporal's documentation, intended for bulk ingestion. Temporal is an open-source platform for building crash-proof applications that resume exactly where they left off after failures.",
             rootContent:
               'To fetch any page as raw Markdown, append `.md` to its URL path (e.g., `https://docs.temporal.io/workflows.md`).\n\n' +
               'Every page concatenated into one file is available at `https://docs.temporal.io/llms-full.txt`. ' +
               'It is roughly 7 MB, which exceeds most context windows. Prefer the section indexes below and fetch individual `.md` pages; ' +
               'use the full text for bulk ingestion.\n\n' +
-              'This documentation reflects the latest Temporal SDK and Platform behavior. If you\'re working with an older SDK version, verify API compatibility before applying suggestions from this content.\n\n' +
+              "This documentation reflects the latest Temporal SDK and Platform behavior. If you're working with an older SDK version, verify API compatibility before applying suggestions from this content.\n\n" +
               '## Tools for agents\n\n' +
-              '- [Temporal Developer Skill](https://github.com/temporalio/skill-temporal-developer): An agent skill covering Temporal\'s programming model, including Workflow determinism rules, Activity patterns, Retry Policies, error handling, testing, Worker configuration, and versioning. Works with Claude Code, Codex, Cursor, and other agents that support Skills.\n' +
-              '- [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless): A Public Preview agent skill for deploying and operating Temporal Serverless Workers on AWS Lambda, where support is also in Public Preview. Covers Worker code, deployment configuration, packaging, and troubleshooting.\n' +
+              "- [Temporal Developer Skill](https://github.com/temporalio/skill-temporal-developer): An agent skill covering Temporal's programming model, including Workflow determinism rules, Activity patterns, Retry Policies, error handling, testing, Worker configuration, and versioning. Works with Claude Code, Codex, Cursor, and other agents that support Skills.\n" +
+              '- [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless): An agent skill for deploying and operating Temporal Serverless Workers. Covers Worker code, deployment configuration, packaging, and troubleshooting.\n' +
               '- [Temporal Docs MCP Server](https://temporal.mcp.kapa.ai): Search this documentation over MCP. Sign-in is required through MCP OAuth with Google or GitHub, which keeps the server from being used for automated bulk querying. Anonymous requests are rejected. If your client cannot complete an OAuth flow, use the `.md` URLs above instead.',
             excludePaths: ['tctl-v1'],
             sections: [
               {
                 title: 'Core Primitives',
-                description: 'Fundamental building blocks of the Temporal Platform. Read this section first for foundational concepts referenced everywhere else.',
+                description:
+                  'Fundamental building blocks of the Temporal Platform. Read this section first for foundational concepts referenced everywhere else.',
                 inline: true,
                 autoDiscoverSubsections: 'encyclopedia',
               },
@@ -432,24 +422,62 @@ module.exports = async function createConfigAsync() {
                 title: 'Concepts',
                 description: 'What Temporal is and how it works.',
                 inline: true,
-                pages: [
-                  'temporal', 'glossary',
-                ],
+                pages: ['temporal', 'glossary'],
               },
-              { autoDiscover: 'develop', title: 'SDK Development Guides', description: 'Each SDK guide is organized by topic (e.g., workflows, activities, testing). All SDKs follow the same structure, with minor differences depending on language-specific features. Use these for language-specific implementation details.' },
-              { path: 'develop', title: 'Cross-SDK Development Guides', description: 'Development guidance that applies across SDKs (worker performance, safe deployments, plugins).' },
+              {
+                autoDiscover: 'develop',
+                title: 'SDK Development Guides',
+                description:
+                  'Each SDK guide is organized by topic (e.g., workflows, activities, testing). All SDKs follow the same structure, with minor differences depending on language-specific features. Use these for language-specific implementation details.',
+              },
+              {
+                path: 'develop',
+                title: 'Cross-SDK Development Guides',
+                description:
+                  'Development guidance that applies across SDKs (worker performance, safe deployments, plugins).',
+              },
               { path: 'cloud', title: 'Temporal Cloud', description: 'Deploy and manage Temporal Cloud' },
-              { path: 'evaluate', title: 'Evaluating Temporal', description: 'Background for deciding whether and how to adopt Temporal, including feature comparisons and use cases.' },
-              { path: 'production-deployment', title: 'Production Deployment', description: 'Deploy Temporal to production' },
-              { path: 'self-hosted-guide', title: 'Self-Hosted Service Guide', description: 'Deploy, configure, and operate a self-hosted Temporal Service.' },
+              {
+                path: 'evaluate',
+                title: 'Evaluating Temporal',
+                description:
+                  'Background for deciding whether and how to adopt Temporal, including feature comparisons and use cases.',
+              },
+              {
+                path: 'production-deployment',
+                title: 'Production Deployment',
+                description: 'Deploy Temporal to production',
+              },
+              {
+                path: 'self-hosted-guide',
+                title: 'Self-Hosted Service Guide',
+                description: 'Deploy, configure, and operate a self-hosted Temporal Service.',
+              },
               { path: 'cli', title: 'CLI Reference', description: 'Temporal CLI command reference' },
               { path: 'references', title: 'References', description: 'Configuration and API references' },
               { path: 'troubleshooting', title: 'Troubleshooting', description: 'Common issues and solutions' },
               { path: 'best-practices', title: 'Best Practices', description: 'Recommended patterns for Temporal' },
-              { path: 'design-patterns', title: 'Design Patterns', description: 'Reusable Workflow and Activity patterns for common orchestration problems.' },
-              { path: 'guides', title: 'Guides', description: 'End-to-end walkthroughs that solve a specific problem with Temporal.' },
-              { path: 'ai/cookbook', title: 'AI Cookbook', description: 'Runnable examples for building AI and agent applications with Temporal.' },
-              { path: 'demos', title: 'Interactive Demos', description: 'Browser-based interactive demos. These pages are visual tools rather than prose documentation.' },
+              {
+                path: 'design-patterns',
+                title: 'Design Patterns',
+                description: 'Reusable Workflow and Activity patterns for common orchestration problems.',
+              },
+              {
+                path: 'guides',
+                title: 'Guides',
+                description: 'End-to-end walkthroughs that solve a specific problem with Temporal.',
+              },
+              {
+                path: 'ai/cookbook',
+                title: 'AI Cookbook',
+                description: 'Runnable examples for building AI and agent applications with Temporal.',
+              },
+              {
+                path: 'demos',
+                title: 'Interactive Demos',
+                description:
+                  'Browser-based interactive demos. These pages are visual tools rather than prose documentation.',
+              },
             ],
           },
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -418,7 +418,7 @@ module.exports = async function createConfigAsync() {
               'This documentation reflects the latest Temporal SDK and Platform behavior. If you\'re working with an older SDK version, verify API compatibility before applying suggestions from this content.\n\n' +
               '## Tools for agents\n\n' +
               '- [Temporal Developer Skill](https://github.com/temporalio/skill-temporal-developer): An agent skill covering Temporal\'s programming model, including Workflow determinism rules, Activity patterns, Retry Policies, error handling, testing, Worker configuration, and versioning. Works with Claude Code, Codex, Cursor, and other agents that support Skills.\n' +
-              '- [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless): An agent skill for deploying and operating Temporal Workers on serverless compute, covering Worker code, deployment configuration, packaging, and troubleshooting.\n' +
+              '- [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless): A Public Preview agent skill for deploying and operating Temporal Serverless Workers on AWS Lambda, where support is also in Public Preview. Covers Worker code, deployment configuration, packaging, and troubleshooting.\n' +
               '- [Temporal Docs MCP Server](https://temporal.mcp.kapa.ai): Search this documentation over MCP. Sign-in is required through MCP OAuth with Google or GitHub, which keeps the server from being used for automated bulk querying. Anonymous requests are rejected. If your client cannot complete an OAuth flow, use the `.md` URLs above instead.',
             excludePaths: ['tctl-v1'],
             sections: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -418,6 +418,7 @@ module.exports = async function createConfigAsync() {
               'This documentation reflects the latest Temporal SDK and Platform behavior. If you\'re working with an older SDK version, verify API compatibility before applying suggestions from this content.\n\n' +
               '## Tools for agents\n\n' +
               '- [Temporal Developer Skill](https://github.com/temporalio/skill-temporal-developer): An agent skill covering Temporal\'s programming model, including Workflow determinism rules, Activity patterns, Retry Policies, error handling, testing, Worker configuration, and versioning. Works with Claude Code, Codex, Cursor, and other agents that support Skills.\n' +
+              '- [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless): An agent skill for deploying and operating Temporal Workers on serverless compute, covering Worker code, deployment configuration, packaging, and troubleshooting.\n' +
               '- [Temporal Docs MCP Server](https://temporal.mcp.kapa.ai): Search this documentation over MCP. Sign-in is required through MCP OAuth with Google or GitHub, which keeps the server from being used for automated bulk querying. Anonymous requests are rejected. If your client cannot complete an OAuth flow, use the `.md` URLs above instead.',
             excludePaths: ['tctl-v1'],
             sections: [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -407,6 +407,7 @@ module.exports = async function createConfigAsync() {
               "This documentation reflects the latest Temporal SDK and Platform behavior. If you're working with an older SDK version, verify API compatibility before applying suggestions from this content.\n\n" +
               '## Tools for agents\n\n' +
               "- [Temporal Developer Skill](https://github.com/temporalio/skill-temporal-developer): An agent skill covering Temporal's programming model, including Workflow determinism rules, Activity patterns, Retry Policies, error handling, testing, Worker configuration, and versioning. Works with Claude Code, Codex, Cursor, and other agents that support Skills.\n" +
+              '- [Temporal Cloud Skill](https://github.com/temporalio/skill-temporal-cloud): An agent skill for troubleshooting Temporal Cloud connectivity, authentication, and configuration issues.\n' +
               '- [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless): An agent skill for deploying and operating Temporal Serverless Workers. Covers Worker code, deployment configuration, packaging, and troubleshooting.\n' +
               '- [Temporal Docs MCP Server](https://temporal.mcp.kapa.ai): Search this documentation over MCP. Sign-in is required through MCP OAuth with Google or GitHub, which keeps the server from being used for automated bulk querying. Anonymous requests are rejected. If your client cannot complete an OAuth flow, use the `.md` URLs above instead.',
             excludePaths: ['tctl-v1'],


### PR DESCRIPTION
## What

Adds the [Temporal Serverless Workers Skill](https://github.com/temporalio/skill-temporal-serverless) to the Develop with AI page (npx and manual install tabs, matching the Cloud skill) and to the "Tools for agents" list in `llms.txt`.