### PR TITLE
Document the Ops, Serverless, and Cloud Setup skills

### DIFF
--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -7,6 +7,7 @@ description: Give your AI coding agent Temporal expertise and real-time access t
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { ReleaseNoteHeader } from '@site/src/components';
 
 Give your AI coding agent Temporal expertise with Skills, real-time documentation access with the Temporal Knowledge Base
 MCP Server, or direct access to the docs as Markdown.
@@ -88,6 +89,10 @@ error handling, testing strategies, Worker configuration, versioning, and common
 
 ### Temporal Ops skill
 
+<ReleaseNoteHeader type="publicPreview">
+  The skill's coverage and structure may change before the stable release.
+</ReleaseNoteHeader>
+
 The [Temporal Ops skill](https://github.com/temporalio/skill-temporal-ops) administers and diagnoses running Temporal
 Cloud and self-hosted environments through the `temporal` and `tcld` CLIs: Namespace management, API key and mTLS
 certificate rotation, Cloud capacity, batch cancel, terminate, and reset operations, Export, and Search Attributes. It
@@ -96,16 +101,16 @@ backlog, or a missed Schedule — until it reaches a root cause.
 
 Trigger the skill with a slash command: `/temporal:temporal-ops`.
 
-This skill is in Public Preview.
-
 ### Temporal Serverless skill
+
+<ReleaseNoteHeader type="publicPreview">
+  The skill's coverage and structure may change before the stable release.
+</ReleaseNoteHeader>
 
 The [Temporal Serverless skill](https://github.com/temporalio/skill-temporal-serverless) guides your AI coding agent
 through configuring and deploying Temporal Workers on serverless compute, and troubleshooting them once they're running.
 
 Trigger the skill with a slash command: `/temporal:temporal-serverless`.
-
-This skill is in Public Preview.
 
 ### Temporal Cloud skill
 

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -94,12 +94,16 @@ certificate rotation, Cloud capacity, batch cancel, terminate, and reset operati
 also works backwards from a symptom — a stuck Workflow, a non-determinism error, unhealthy Workers, a Task Queue
 backlog, or a missed Schedule — until it reaches a root cause.
 
+Trigger the skill with a slash command: `/temporal:temporal-ops`.
+
 This skill is in Public Preview.
 
 ### Temporal Serverless skill
 
 The [Temporal Serverless skill](https://github.com/temporalio/skill-temporal-serverless) guides your AI coding agent
 through configuring and deploying Temporal Workers on serverless compute, and troubleshooting them once they're running.
+
+Trigger the skill with a slash command: `/temporal:temporal-serverless`.
 
 This skill is in Public Preview.
 
@@ -140,6 +144,8 @@ Restart your coding agent after installing.
 The [Temporal Cloud Setup skill](https://github.com/temporalio/skill-temporal-cloud-setup) is a guided experience for
 getting started with Temporal Cloud. Your AI coding agent installs the CLI, creates a Namespace and an API key, connects
 a sample app, and runs its first Workflow on Temporal Cloud.
+
+Trigger the skill with a slash command: `/temporal:temporal-cloud-setup`.
 
 ## Temporal knowledge base MCP server
 

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -56,30 +56,13 @@ Install from the Codex app or CLI:
 - **Codex CLI:** Run `/plugin`, search for **temporal**, and mark it for installation.
 
 </TabItem>
-<TabItem value="npx" label="npx">
-
-This works with Claude Code, Codex, Cline, and other agents.
-
-Every skill in the bundle also has its own repository, so you can install one on its own with the `skills` CLI:
-
-```bash
-npx skills add https://github.com/temporalio/skill-temporal-developer
-```
-
-</TabItem>
-<TabItem value="manual" label="Manual">
-
-Clone a single skill's repository into your Claude skills directory. Change the target directory if you are using agents
-other than Claude:
-
-```bash
-git clone https://github.com/temporalio/skill-temporal-developer.git ~/.claude/skills/temporal-developer
-```
-
-</TabItem>
 </Tabs>
 
 Restart your coding agent after installing.
+
+Every skill in the bundle also has its own repository, linked in the sections below. If you want one skill instead of
+the bundle, install it with the `skills` CLI (`npx skills add <repository-url>`) or clone the repository into your
+agent's skills directory.
 
 ### Temporal Developer skill
 

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -67,8 +67,8 @@ agent's skills directory.
 ### Temporal Developer skill
 
 The [Temporal Developer skill](https://github.com/temporalio/skill-temporal-developer) gives your AI coding agent
-expert-level knowledge of Temporal's programming model — Workflow determinism rules, Activity patterns, Retry Policies,
-error handling, testing strategies, Worker configuration, versioning, and common gotchas.
+expert-level knowledge of Temporal's programming model, including Workflow determinism rules, Activity patterns, Retry
+Policies, error handling, testing strategies, Worker configuration, versioning, and common gotchas.
 
 ### Temporal Ops skill
 
@@ -79,8 +79,8 @@ error handling, testing strategies, Worker configuration, versioning, and common
 The [Temporal Ops skill](https://github.com/temporalio/skill-temporal-ops) administers and diagnoses running Temporal
 Cloud and self-hosted environments through the `temporal` and `tcld` CLIs: Namespace management, API key and mTLS
 certificate rotation, Cloud capacity, batch cancel, terminate, and reset operations, Export, and Search Attributes. It
-also works backwards from a symptom — a stuck Workflow, a non-determinism error, unhealthy Workers, a Task Queue
-backlog, or a missed Schedule — until it reaches a root cause.
+also works backwards from a symptom until it reaches a root cause. Symptoms include a stuck Workflow, a non-determinism
+error, unhealthy Workers, a Task Queue backlog, or a missed Schedule.
 
 Trigger the skill with a slash command: `/temporal:temporal-ops`.
 
@@ -91,7 +91,8 @@ Trigger the skill with a slash command: `/temporal:temporal-ops`.
 </ReleaseNoteHeader>
 
 The [Temporal Serverless skill](https://github.com/temporalio/skill-temporal-serverless) guides your AI coding agent
-through configuring and deploying Temporal Workers on serverless compute, and troubleshooting them once they're running.
+through configuring and deploying [Serverless Workers](/serverless-workers), and troubleshooting them once they're
+running.
 
 Trigger the skill with a slash command: `/temporal:temporal-serverless`.
 
@@ -192,7 +193,7 @@ Check your client's documentation for details on connecting to OAuth-protected M
 Every documentation page is also available as Markdown, so AI tools that fetch a URL can read the docs without an MCP
 connection or sign-in.
 
-- Append `.md` to any page's URL to fetch its Markdown version — for example, `https://docs.temporal.io/workflows.md`.
+- Append `.md` to any page's URL to fetch its Markdown version. For example, `https://docs.temporal.io/workflows.md`.
 - Each page has **Copy for LLM**, **View Markdown**, **Open in ChatGPT**, and **Open in Claude** buttons above its
   content. **Copy for LLM** copies the page's Markdown, with its source URL, to your clipboard. **Open in ChatGPT** and
   **Open in Claude** start a new chat with a prompt telling the model to read the page.

--- a/docs/with-ai.mdx
+++ b/docs/with-ai.mdx
@@ -16,11 +16,10 @@ MCP Server, or direct access to the docs as Markdown.
 Skills give AI agents domain-specific Temporal expertise. They work with Claude Code, Codex, Cursor, and any agent that
 supports [Skills](https://agentskills.io).
 
-### Temporal Developer Skill
+### Install the coding agent plugin
 
-The [Temporal Developer Skill](https://github.com/temporalio/skill-temporal-developer) gives your AI coding agent
-expert-level knowledge of Temporal's programming model — workflow determinism rules, activity patterns, retry policies,
-error handling, testing strategies, worker configuration, versioning, and common gotchas.
+The Temporal plugin installs a bundle of skills. Install it once, then read the sections below for what each skill
+covers.
 
 <Tabs groupId="skill-install" queryString>
 <TabItem value="claude-code" label="Claude Code Plugin">
@@ -31,7 +30,7 @@ error handling, testing strategies, worker configuration, versioning, and common
    /plugin marketplace add temporalio/claude-temporal-plugin
    ```
 
-2. Install the Temporal Developer Skill:
+2. Install the Temporal plugin:
 
    ```bash
    /plugin install temporal@temporal-marketplace
@@ -60,7 +59,7 @@ Install from the Codex app or CLI:
 
 This works with Claude Code, Codex, Cline, and other agents.
 
-Install the skill using the `skills` CLI:
+Every skill in the bundle also has its own repository, so you can install one on its own with the `skills` CLI:
 
 ```bash
 npx skills add https://github.com/temporalio/skill-temporal-developer
@@ -69,8 +68,8 @@ npx skills add https://github.com/temporalio/skill-temporal-developer
 </TabItem>
 <TabItem value="manual" label="Manual">
 
-Clone the skill repository into your Claude skills directory. Change the target directory if you are using agents other
-than Claude:
+Clone a single skill's repository into your Claude skills directory. Change the target directory if you are using agents
+other than Claude:
 
 ```bash
 git clone https://github.com/temporalio/skill-temporal-developer.git ~/.claude/skills/temporal-developer
@@ -81,10 +80,34 @@ git clone https://github.com/temporalio/skill-temporal-developer.git ~/.claude/s
 
 Restart your coding agent after installing.
 
-### Temporal Cloud Skill
+### Temporal Developer skill
 
-The [Temporal Cloud Skill](https://github.com/temporalio/skill-temporal-cloud) helps your AI coding agent troubleshoot
-Temporal Cloud connectivity, authentication, and configuration issues.
+The [Temporal Developer skill](https://github.com/temporalio/skill-temporal-developer) gives your AI coding agent
+expert-level knowledge of Temporal's programming model — Workflow determinism rules, Activity patterns, Retry Policies,
+error handling, testing strategies, Worker configuration, versioning, and common gotchas.
+
+### Temporal Ops skill
+
+The [Temporal Ops skill](https://github.com/temporalio/skill-temporal-ops) administers and diagnoses running Temporal
+Cloud and self-hosted environments through the `temporal` and `tcld` CLIs: Namespace management, API key and mTLS
+certificate rotation, Cloud capacity, batch cancel, terminate, and reset operations, Export, and Search Attributes. It
+also works backwards from a symptom — a stuck Workflow, a non-determinism error, unhealthy Workers, a Task Queue
+backlog, or a missed Schedule — until it reaches a root cause.
+
+This skill is in Public Preview.
+
+### Temporal Serverless skill
+
+The [Temporal Serverless skill](https://github.com/temporalio/skill-temporal-serverless) guides your AI coding agent
+through configuring and deploying Temporal Workers on serverless compute, and troubleshooting them once they're running.
+
+This skill is in Public Preview.
+
+### Temporal Cloud skill
+
+The [Temporal Cloud skill](https://github.com/temporalio/skill-temporal-cloud) is a standalone skill that isn't part of
+the plugin bundle. It helps your AI coding agent troubleshoot Temporal Cloud connectivity, authentication, and
+configuration issues.
 
 <Tabs groupId="skill-install" queryString>
 <TabItem value="npx" label="npx">
@@ -111,6 +134,12 @@ git clone https://github.com/temporalio/skill-temporal-cloud.git ~/.claude/skill
 </Tabs>
 
 Restart your coding agent after installing.
+
+### Temporal Cloud Setup skill
+
+The [Temporal Cloud Setup skill](https://github.com/temporalio/skill-temporal-cloud-setup) is a guided experience for
+getting started with Temporal Cloud. Your AI coding agent installs the CLI, creates a Namespace and an API key, connects
+a sample app, and runs its first Workflow on Temporal Cloud.
 
 ## Temporal knowledge base MCP server
 


### PR DESCRIPTION
## What changed

Restructures the Skills section of `docs/with-ai.mdx` around the plugin bundle rather than a single skill:

- **Install the coding agent plugin** now holds the install instructions (Claude Code, Cursor, Codex, npx, Manual), described as installing a bundle of skills.
- A section per skill follows: Developer (unchanged prose), **Ops**, **Serverless**, and **Cloud Setup**.
- Ops and Serverless are marked Public Preview.
- The Cloud skill is now described as standalone, outside the bundle, and keeps its own install tabs.

## Why

The Temporal plugin now ships a bundle of skills — Developer, Ops, Serverless, and Cloud Setup — but the page only documented Developer and Cloud, and framed installation as a per-skill step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)