### PR TITLE
Clarify Audit Log status semantics

### DIFF
--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -106,7 +106,7 @@ For supported Control Plane operations, the `status` field describes the outcome
 Audit logs do not capture authentication failures.
 
 For an asynchronous operation, `OK` means that Temporal Cloud accepted the API call.
-The operation can fail after the Audit Log event is emitted, and the event is not updated with the final outcome.
+The operation can fail after the audit log event is emitted, and the event is not updated with the final outcome.
 Use [`GetAsyncOperation`](https://saas-api.tmprl.cloud/docs/httpapi.html#tag/operations/GET/cloud/operations/%7BasyncOperationId%7D) to check the operation state and failure reason.
 
 The `async_operation_id` field can contain a request identifier or an async operation identifier.

--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -71,7 +71,7 @@ Instead, explore the [Export](/cloud/export) feature, which does let you send cl
   - `SetUserGroupNamespaceAccess`: Set User Group Namespace Access
   - `UpdateUserGroup`: Update User Group
 
-### Audit Log format
+### Audit log format
 
 :::info DEPRECATION NOTICE
 
@@ -89,12 +89,28 @@ Audit Logs use the following JSON format:
   "x_forwarded_for":    // The IP address(es) making the call
   "emit_time":          // Time the operation was recorded
   "log_id":             // Unique ID of the log entry
-  "async_operation_id": // Optional async operation id set by the user when sending a request
+  "async_operation_id": // Request or async operation identifier for correlation
   "request_id":         // DEPRECATED, use async_operation_id
   "status":             // Status, such as OK or ERROR
   "version":            // Version of the log entry
 }
 ```
+
+#### How to interpret the status
+
+For supported Control Plane operations, the `status` field describes the outcome of the Temporal Cloud API call:
+
+- `OK`: The API call returned successfully.
+- `ERROR`: The API call returned an error. This includes authorization failures, such as when the authenticated principal does not have permission to perform the operation.
+
+Audit Logs do not capture authentication failures.
+
+For an asynchronous operation, `OK` means that Temporal Cloud accepted the API call.
+The operation can fail after the Audit Log event is emitted, and the event is not updated with the final outcome.
+Use [`GetAsyncOperation`](https://saas-api.tmprl.cloud/docs/httpapi.html#tag/operations/GET/cloud/operations/%7BasyncOperationId%7D) to check the operation state and failure reason.
+
+The `async_operation_id` field can contain a request identifier or an async operation identifier.
+Its presence does not indicate that the API call started an asynchronous operation.
 
 :::note
 
@@ -104,7 +120,7 @@ Temporal provides the caller IP address in that format to allow customers to ide
 
 :::
 
-### Example of an Audit Log
+### Example of an audit log
 
 ```json
 [
@@ -148,14 +164,14 @@ Temporal provides the caller IP address in that format to allow customers to ide
 ]
 ```
 
-## How to configure an Audit Log Integration {/* #configure-audit-logs */}
+## How to configure an audit log integration {/* #configure-audit-logs */}
 
 Audit Logs can be configured in AWS Kinesis or GCP Pub/Sub.
 
 - [AWS Kinesis Instructions](/cloud/audit-logs-aws)
 - [GCP Pub/Sub Instructions](/cloud/audit-logs-gcp)
 
-## How to troubleshoot Audit Log sink {/* #troubleshoot-audit-logs */}
+## How to troubleshoot an audit log sink {/* #troubleshoot-audit-logs */}
 
 The Audit Logs page of the Temporal Cloud UI provides the current status of an Audit Log Integration.
 
@@ -171,7 +187,7 @@ To retrieve logs up to the past 30 days, you will need to file a request.
 If you experience an issue with an Audit Log sink, we can provide the missing audit information.
 Open a support ticket to request assistance.
 
-## How to delete an Audit Log sink {/* #delete-an-audit-log-sink */}
+## How to delete an audit log sink {/* #delete-an-audit-log-sink */}
 
 To delete an Audit Log sink, follow these steps:
 
@@ -183,7 +199,7 @@ To delete an Audit Log sink, follow these steps:
 After you confirm the deletion, the Audit Log Sink is removed from your account and logs stop flowing to your stream.
 
 
-## View an Audit Log {/* #view-an-audit-log */}
+## View an audit log {/* #view-an-audit-log */}
 
 An Audit Log can be viewed in the Temporal Cloud UI.
 1. In the Temporal Cloud UI, select **Settings**.
@@ -191,7 +207,7 @@ An Audit Log can be viewed in the Temporal Cloud UI.
 
 Up to 1,000 events can be downloaded from the Audit Log UI to a local file.
 
-## Access an Audit Log via API {/* #audit-log-api */}
+## Access an audit log via API {/* #audit-log-api */}
 
 An Audit Log can be accessed using the [Temporal Cloud Ops API](/ops). Use the API to access
 an Audit Log if you wish to make dashboards for viewing an Audit Log outside of Temporal Cloud.
@@ -205,4 +221,3 @@ The API allows:
 - EndTimeExclusive: Filter for UTC time < (defaults to current time) - optional
 - PageSize: Cannot exceed 1000. Defaults to 100. - optional
 - PageToken: The page token if this is continuing from another response - optional
-

--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -103,7 +103,7 @@ For supported Control Plane operations, the `status` field describes the outcome
 - `OK`: The API call returned successfully.
 - `ERROR`: The API call returned an error. This includes authorization failures, such as when the authenticated principal does not have permission to perform the operation.
 
-Audit Logs do not capture authentication failures.
+Audit logs do not capture authentication failures.
 
 For an asynchronous operation, `OK` means that Temporal Cloud accepted the API call.
 The operation can fail after the Audit Log event is emitted, and the event is not updated with the final outcome.

--- a/docs/evaluate/temporal-cloud/overview.mdx
+++ b/docs/evaluate/temporal-cloud/overview.mdx
@@ -122,7 +122,9 @@ Deploy a [Codec Server](/production-deployment/data-encryption) to decrypt data 
 ### Compliance
 
 Temporal Technologies maintains SOC 2 Type 2 certification and complies with GDPR and HIPAA regulations.
-Audit logs capture all API operations and can be exported to your security monitoring systems.
+Audit Logs capture supported operations in the Temporal Cloud Control Plane and can be exported to your security
+monitoring systems.
+See [Audit Logs](/cloud/audit-logs) for the supported operations and coverage details.
 
 See [Security model](/cloud/security) for complete details.
 

--- a/docs/evaluate/temporal-cloud/overview.mdx
+++ b/docs/evaluate/temporal-cloud/overview.mdx
@@ -122,7 +122,7 @@ Deploy a [Codec Server](/production-deployment/data-encryption) to decrypt data 
 ### Compliance
 
 Temporal Technologies maintains SOC 2 Type 2 certification and complies with GDPR and HIPAA regulations.
-Audit Logs capture supported operations in the Temporal Cloud Control Plane and can be exported to your security
+Audit logs capture supported operations in the Temporal Cloud Control Plane and can be exported to your security
 monitoring systems.
 See [Audit Logs](/cloud/audit-logs) for the supported operations and coverage details.
 

--- a/docs/evaluate/temporal-cloud/overview.mdx
+++ b/docs/evaluate/temporal-cloud/overview.mdx
@@ -124,7 +124,7 @@ Deploy a [Codec Server](/production-deployment/data-encryption) to decrypt data 
 Temporal Technologies maintains SOC 2 Type 2 certification and complies with GDPR and HIPAA regulations.
 Audit logs capture supported operations in the Temporal Cloud Control Plane and can be exported to your security
 monitoring systems.
-See [Audit Logs](/cloud/audit-logs) for the supported operations and coverage details.
+See [audit logs](/cloud/audit-logs) for the supported operations and coverage details.
 
 See [Security model](/cloud/security) for complete details.
 


### PR DESCRIPTION
## Summary

- Explain that Audit Log status reflects the outcome of the Temporal Cloud API call.
- Document that authorization failures are recorded as ERROR, while authentication failures are not captured.
- Clarify that OK for an asynchronous operation means the request was accepted and does not guarantee final completion.
- Explain that async_operation_id is a correlation field and does not identify whether the call was asynchronous.
- Bring headings on the edited page into sentence case.

## Validation

- vale --config .vale-ci.ini docs/cloud/audit-logs.mdx
- git diff --check

The local production build was blocked before MDX compilation because the existing dependency installation does not contain the satori package required by current main.