### PR TITLE
Fix Payload Codec typo

### DIFF
--- a/docs/encyclopedia/data-conversion/payload-codec.mdx
+++ b/docs/encyclopedia/data-conversion/payload-codec.mdx
@@ -26,7 +26,7 @@ Use a custom Payload Codec to transform your Payloads; for example, implementing
 
 ### Operational Chain
 
-In practice, the [Payload Converter](/payload-converter) and Payload Codex operate in a chain to handle data securely. Incoming data first passes through a Payload Converter through the `toPayload` method, turning application objects into Payloads. These Payloads are then processed by the Payload Codec through the `encode` method, which adjusts the Payload according to the required security or efficiency needs before it is sent to the Temporal Cluster.
+In practice, the [Payload Converter](/payload-converter) and Payload Codec operate in a chain to handle data securely. Incoming data first passes through a Payload Converter through the `toPayload` method, turning application objects into Payloads. These Payloads are then processed by the Payload Codec through the `encode` method, which adjusts the Payload according to the required security or efficiency needs before it is sent to the Temporal Cluster.
 
 The process is symmetric for outgoing data. Payloads retrieved from the Temporal Cluster first pass through the Payload Codec through the `decode` method, which reverses any transformations applied during encoding. Finally, the resulting Payload is converted back into an application object by the Payload Converter through the `fromPayload` method, making it ready for use within the application.
 


### PR DESCRIPTION
Fixes a typo: `Payload Codex` → `Payload Codec`.