### PR TITLE
Exclude CLI from gRPC metadata environment variable

### DIFF
--- a/docs/references/client-environment-configuration.mdx
+++ b/docs/references/client-environment-configuration.mdx
@@ -163,7 +163,7 @@ Sets gRPC headers. The part after `_META_` becomes the header key, so `TEMPORAL_
 
 - TOML key: `profile.<name>.grpc_meta`
 - CLI flag: `--grpc-meta`
-- Read by: every client
+- Read by: every client except CLI
 
 ## Codec Server variables
 


### PR DESCRIPTION
## Summary
- document that `TEMPORAL_GRPC_META_*` is read by every client except the Temporal CLI
- align the environment configuration reference with the drift checker

## Validation
- `node bin/check-env-config-table.js`
- `vale --config .vale-ci.ini docs/references/client-environment-configuration.mdx`