### PR TITLE
Remove unused dprint dependency

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
-    "dprint.dprint",
     "chrischinchilla.vale-vscode"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.

--- a/package.json
+++ b/package.json
@@ -98,7 +98,6 @@
   "devDependencies": {
     "@playwright/test": "^1.62.0",
     "@types/node": "^26.1.2",
-    "dprint": "^0.55.1",
     "eslint": "^9.8.0",
     "eslint-plugin-react": "^7.23.2",
     "global-jsdom": "^29.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,81 +2189,6 @@
     utility-types "^3.10.0"
     webpack "^5.88.1"
 
-"@dprint/android-arm64@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/android-arm64/-/android-arm64-0.55.1.tgz#7fef45b22238cf107e7d29d662ec0964d668c1e1"
-  integrity sha512-H1UQIcBJEo1dA8AVrkPnw5AYMMGHNe4w0lq9rEDSY3Lds0VUKACu2MK3JLNARpjljh3WKeO109J26Wpq8PTuGQ==
-
-"@dprint/android-x64@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/android-x64/-/android-x64-0.55.1.tgz#1ad30763ed50c193c6a752055551c48fbe7ef7b5"
-  integrity sha512-8dPiGpEo4S4cQhnLaoHtNm4HiqR9DIPr/81z3gWb5qTmJp8bKj+3DO4mAmmldMRBicmpXCss0xudniNTxnWOMg==
-
-"@dprint/darwin-arm64@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/darwin-arm64/-/darwin-arm64-0.55.1.tgz#2e5a08dc0da96df34145bcb96761d448e662147f"
-  integrity sha512-c65u8f63R/etCKP0CZ/RkbMCRC99wgZDt/vhwjY2QdO0k23dMKXKEV6+ruUEwV2toh+QIRT02dRL7BtxjA0V7w==
-
-"@dprint/darwin-x64@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/darwin-x64/-/darwin-x64-0.55.1.tgz#f9b46c6b21a59b0f48f5710b74885cff545e2671"
-  integrity sha512-AsET9+4rMk7ZFEMq3HYl/hYNBMBrR/juiSzclEU0oUCf3koxFbVKL8Srad8Vhyv8jEnOaMn78TCnahmHhp1SCQ==
-
-"@dprint/linux-arm64-glibc@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-arm64-glibc/-/linux-arm64-glibc-0.55.1.tgz#ca93d22932a14d77eba33052b5f0b68097d4e33b"
-  integrity sha512-vt7w+aL2MjtD3RRfnUTDuK/b7xg1/feBe3WoV0S2rGNmPEJI+K7wwBXkOl/I77V9w3PP2zvN/aRY5dMOZrkbSg==
-
-"@dprint/linux-arm64-musl@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-arm64-musl/-/linux-arm64-musl-0.55.1.tgz#69dcb5c17ba6c9028fc436cc29444e58c9133ee2"
-  integrity sha512-7shUIOvJcTn4IYEPlb/Up4KLt5kbDuCTdc3DN68i88XT+nRBFQatD7Qok+6Ysra34KJMxF88QVHiimjH1ABy4A==
-
-"@dprint/linux-loong64-glibc@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-loong64-glibc/-/linux-loong64-glibc-0.55.1.tgz#1145eeea70c609ea610ce1c5d4b5774a6df0fe46"
-  integrity sha512-G2mXiOGpkeC3LP8huSnImxU7hMvRY6rHIW+yBuw1vDDm5r6+H9CVhcXr3TMOk3poZ7IlWwQnDmP0/RuGQUEpYw==
-
-"@dprint/linux-loong64-musl@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-loong64-musl/-/linux-loong64-musl-0.55.1.tgz#08e0533d7b7c2ee02694329ebb16d3377c48d5ad"
-  integrity sha512-uO2r4QPYawDfQUyATr0opqfMkG2hVpz3yScRKs5ve9PWzqx2f5kJaaLuLVoXwSbWqDkozMGPcldAVSpOwGJ24Q==
-
-"@dprint/linux-ppc64-glibc@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-ppc64-glibc/-/linux-ppc64-glibc-0.55.1.tgz#3ca234ad910598ff4499f0d6335b42440f6f8ee5"
-  integrity sha512-NVR+BN4kTQd/vJ91YOGSkBotAM2f1hFD+HD5zq5Oc1djxjl1U2Zvc667UWKamxaXdv/ssZxkLuj0lbvbx9E3/A==
-
-"@dprint/linux-ppc64-musl@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-ppc64-musl/-/linux-ppc64-musl-0.55.1.tgz#c4984fe301464f1b1710492ac2c58d68020e3f22"
-  integrity sha512-34Db83XGoKbwmvIY52sokywIMCmmIZM1vzw4ILlOkKugG51TltBOzLCssT9Rkfxz/TjR9dgwtBHEQJZjftuQ6Q==
-
-"@dprint/linux-riscv64-glibc@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-riscv64-glibc/-/linux-riscv64-glibc-0.55.1.tgz#07cc4bc7200358d2d0b81c40a49369d9a9642e66"
-  integrity sha512-MVeYH48GhR3QkfhMhhYbXl9x+iO2sK1nNpr2ByJ4IKogHIlvlFff0eeukqAZZAod+rhAzJnLMBGgIDbIUHWK1g==
-
-"@dprint/linux-x64-glibc@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-x64-glibc/-/linux-x64-glibc-0.55.1.tgz#a01ec6ea6de9842ec12c911298343c67c1435342"
-  integrity sha512-ILHgXOIIXeZDjt51egaC4kmu744UuNfaauUM1El+dG9QGan4Vv4f0RRDDbQMKN95zTpacECuNKEhuUtS8euNWA==
-
-"@dprint/linux-x64-musl@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/linux-x64-musl/-/linux-x64-musl-0.55.1.tgz#1f5a236f7cf68a28fb1b95eb17a1a9421aa5f17a"
-  integrity sha512-SwWxWd313VkeH63fR4IlQCDfJNJ+mSw50BidP0PQInCNbUHYOIeWTcyzAaVa8GQdLvmhiNcJ0pmTDOL0F98QIQ==
-
-"@dprint/win32-arm64@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/win32-arm64/-/win32-arm64-0.55.1.tgz#76233c02e46f47aae4af281125bf258173da91c5"
-  integrity sha512-9jiZWZ2AkaaXIkaOpOoiP6v0XxuBFp1Hyi3kUMUAY4NVCmvlSEDQhr+UZgnDhozYygDbAV13iNMLERDeoUa0nA==
-
-"@dprint/win32-x64@0.55.1":
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/@dprint/win32-x64/-/win32-x64-0.55.1.tgz#aec2b04b9290230bf76ad90bc111ad1e4249bc22"
-  integrity sha512-+RmeJL8zzlEWTcrvyFN51rz0S98tV43Socs7xeVGE2S/EH5dG2fG2/fBe6RB3kuyZSfGqByApYeicIdshYIAgw==
-
 "@emnapi/core@^1.5.0":
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.9.1.tgz#2143069c744ca2442074f8078462e51edd63c7bd"
@@ -6749,27 +6674,6 @@ dot-prop@^6.0.1:
   integrity sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==
   dependencies:
     is-obj "^2.0.0"
-
-dprint@^0.55.1:
-  version "0.55.1"
-  resolved "https://registry.yarnpkg.com/dprint/-/dprint-0.55.1.tgz#5533db033613593dcdc099aa9db3a4bb879b9033"
-  integrity sha512-tgUCT9gAM7veMvLX5NmRoYVLnKGKrIYRXpNpJDJj5U7/YIIJef5rLJhPZaJXwB7ad2Vo0Kv//nQM1xkrn5j8kQ==
-  optionalDependencies:
-    "@dprint/android-arm64" "0.55.1"
-    "@dprint/android-x64" "0.55.1"
-    "@dprint/darwin-arm64" "0.55.1"
-    "@dprint/darwin-x64" "0.55.1"
-    "@dprint/linux-arm64-glibc" "0.55.1"
-    "@dprint/linux-arm64-musl" "0.55.1"
-    "@dprint/linux-loong64-glibc" "0.55.1"
-    "@dprint/linux-loong64-musl" "0.55.1"
-    "@dprint/linux-ppc64-glibc" "0.55.1"
-    "@dprint/linux-ppc64-musl" "0.55.1"
-    "@dprint/linux-riscv64-glibc" "0.55.1"
-    "@dprint/linux-x64-glibc" "0.55.1"
-    "@dprint/linux-x64-musl" "0.55.1"
-    "@dprint/win32-arm64" "0.55.1"
-    "@dprint/win32-x64" "0.55.1"
 
 dunder-proto@^1.0.0, dunder-proto@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Summary
- remove the unused `dprint` development dependency and its lockfile entries
- remove the stale VS Code dprint extension recommendation
- supersedes #5166, which attempted to upgrade dprint

## Verification
- `git grep -n -i dprint` (no tracked uses)
- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn test`
- `yarn build`