### PR TITLE
Split the shared Task Queue guidance by compute provider

### DIFF
--- a/docs/encyclopedia/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/aws-lambda.mdx
@@ -50,6 +50,15 @@ Each invocation is independent.
 The Worker starts, creates a fresh client connection, processes multiple Tasks until near the execution time limit, and then shuts down gracefully.
 There is no shared state across invocations.
 
+### Sharing a Task Queue with long-lived Workers {/* #sharing-a-task-queue */}
+
+A Lambda Worker exists only for the duration of an invocation, and sync match failure is the primary signal that starts
+one. Between invocations no Lambda Worker is polling, so an available long-lived Worker receives the Task by sync match
+first. The Serverless Workers act as spillover capacity for the long-lived fleet.
+
+See [Scaling with long-lived Workers](/serverless-workers#scaling-with-long-lived-workers) for the scaling settings to
+avoid on the long-lived Workers.
+
 ## Worker Versioning {/* #worker-versioning */}
 
 Serverless Workers require [Worker Versioning](/worker-versioning), and the compute provider must invoke a stable,

--- a/docs/encyclopedia/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/aws-lambda.mdx
@@ -52,12 +52,16 @@ There is no shared state across invocations.
 
 ### Sharing a Task Queue with long-lived Workers {/* #sharing-a-task-queue */}
 
-A Lambda Worker exists only for the duration of an invocation, and sync match failure is the primary signal that starts
-one. Between invocations no Lambda Worker is polling, so an available long-lived Worker receives the Task by sync match
-first. The Serverless Workers act as spillover capacity for the long-lived fleet.
+The WCI invokes a Lambda Worker when a sync match fails, or when the Worker Deployment Version's Task Queues have a
+backlog. A long-lived fleet that keeps up with the work leaves neither, so no Lambda Workers are invoked. The Serverless
+Workers act as spillover capacity for the long-lived fleet.
 
-See [Scaling with long-lived Workers](/serverless-workers#scaling-with-long-lived-workers) for the scaling settings to
-avoid on the long-lived Workers.
+:::caution
+
+Do not enable dynamic scaling on the long-lived Workers sharing the Task Queue. Both scalers react to the same backlog,
+so the long-lived Workers may add capacity for the Tasks Temporal is already invoking Lambda Workers to handle.
+
+:::
 
 ## Worker Versioning {/* #worker-versioning */}
 

--- a/docs/encyclopedia/workers/serverless-workers/cloud-run.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/cloud-run.mdx
@@ -70,13 +70,21 @@ When there is no work, the WCI can scale the pool to zero; the next sync match f
 
 ### Sharing a Task Queue with long-lived Workers {/* #sharing-a-task-queue */}
 
-A Worker Pool instance polls the Task Queue continuously for as long as it stays in the pool. While the pool is running
-instances, the Matching Service can sync match Tasks to them directly, so the pool takes a share of the Task Queue's
-work rather than only the overflow. A Cloud Run pool acts as spillover capacity for a long-lived fleet only while it
-sits at zero instances.
+A Worker Pool sharing a Task Queue with long-lived Workers scales up to cover the Task Queue's full workload, even when
+the long-lived Workers are already handling all of it. The result is pool instances that duplicate capacity you already
+run and pay for.
 
-See [Scaling with long-lived Workers](/serverless-workers#scaling-with-long-lived-workers) for the scaling settings to
-avoid on the long-lived Workers.
+The WCI sizes the pool from the rate of Tasks arriving on the Worker Deployment Version's Task Queues, and nothing in
+that measurement accounts for the long-lived Workers. Tasks they process raise the pool's target instance count exactly
+as unhandled Tasks would. Sync matching to a long-lived Worker suppresses the immediate scale-up when a Task arrives, but
+the periodic re-sizing scales the pool up regardless.
+
+:::caution
+
+Give the Serverless Workers their own Task Queue unless you intend to run both fleets. A Worker Pool does not take a
+spillover role behind a long-lived fleet.
+
+:::
 
 ## Worker Versioning {/* #worker-versioning */}
 

--- a/docs/encyclopedia/workers/serverless-workers/cloud-run.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/cloud-run.mdx
@@ -70,21 +70,14 @@ When there is no work, the WCI can scale the pool to zero; the next sync match f
 
 ### Sharing a Task Queue with long-lived Workers {/* #sharing-a-task-queue */}
 
-A Worker Pool sharing a Task Queue with long-lived Workers scales up to cover the Task Queue's full workload, even when
-the long-lived Workers are already handling all of it. The result is pool instances that duplicate capacity you already
-run and pay for.
+Do not share a Task Queue between a Worker Pool and long-lived Workers. The pool scales up to cover the Task Queue's
+full workload even when the long-lived Workers are already handling all of it, so you run and pay for pool instances
+that duplicate capacity you already have.
 
 The WCI sizes the pool from the rate of Tasks arriving on the Worker Deployment Version's Task Queues, and nothing in
 that measurement accounts for the long-lived Workers. Tasks they process raise the pool's target instance count exactly
-as unhandled Tasks would. Sync matching to a long-lived Worker suppresses the immediate scale-up when a Task arrives, but
-the periodic re-sizing scales the pool up regardless.
-
-:::caution
-
-Give the Serverless Workers their own Task Queue unless you intend to run both fleets. A Worker Pool does not take a
-spillover role behind a long-lived fleet.
-
-:::
+as unhandled Tasks would. Sync matching to a long-lived Worker suppresses the immediate scale-up when a Task arrives,
+but the periodic re-sizing scales the pool up regardless.
 
 ## Worker Versioning {/* #worker-versioning */}
 

--- a/docs/encyclopedia/workers/serverless-workers/cloud-run.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/cloud-run.mdx
@@ -68,6 +68,16 @@ Scale-in is more conservative than scale-out.
 The WCI holds capacity while sync match failures are still occurring, and it applies a cooldown before reducing the pool, so it does not remove instances that are about to be needed again.
 When there is no work, the WCI can scale the pool to zero; the next sync match failure or backlog scales it back up.
 
+### Sharing a Task Queue with long-lived Workers {/* #sharing-a-task-queue */}
+
+A Worker Pool instance polls the Task Queue continuously for as long as it stays in the pool. While the pool is running
+instances, the Matching Service can sync match Tasks to them directly, so the pool takes a share of the Task Queue's
+work rather than only the overflow. A Cloud Run pool acts as spillover capacity for a long-lived fleet only while it
+sits at zero instances.
+
+See [Scaling with long-lived Workers](/serverless-workers#scaling-with-long-lived-workers) for the scaling settings to
+avoid on the long-lived Workers.
+
 ## Worker Versioning {/* #worker-versioning */}
 
 Serverless Workers require [Worker Versioning](/worker-versioning). Create one Worker Pool for each Worker Deployment

--- a/docs/encyclopedia/workers/serverless-workers/index.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/index.mdx
@@ -154,20 +154,12 @@ Refer to the autoscaling section for your compute provider:
 
 ## Scaling with long-lived Workers {/* #scaling-with-long-lived-workers */}
 
-Serverless Workers can share a Task Queue with long-lived Workers. How the two divide the work depends on the compute
-provider's execution model, so refer to the section for your compute provider:
+Serverless Workers can share a Task Queue with long-lived Workers. What the WCI does with the Tasks the long-lived
+Workers are already handling depends on the compute provider, and so does the guidance. Refer to the section for your
+compute provider:
 
 - [AWS Lambda](/serverless-workers/aws-lambda#sharing-a-task-queue)
 - [GCP Cloud Run](/serverless-workers/cloud-run#sharing-a-task-queue)
-
-:::caution
-
-If you configure Serverless and long-lived Workers on the same Task Queue, do not enable dynamic scaling on the
-long-lived Workers. The two groups cannot coordinate their scaling behavior. If both scale dynamically, the long-lived
-Workers may add capacity for the same Tasks that Temporal is simultaneously scaling Serverless Workers to handle,
-leading to surplus Workers on both sides and unpredictable scaling.
-
-:::
 
 ## Worker lifecycle {/* #worker-lifecycle */}
 

--- a/docs/encyclopedia/workers/serverless-workers/index.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/index.mdx
@@ -155,16 +155,10 @@ Refer to the autoscaling section for your compute provider:
 ## Scaling with long-lived Workers {/* #scaling-with-long-lived-workers */}
 
 Serverless Workers can share a Task Queue with long-lived Workers. How the two divide the work depends on the compute
-provider's execution model.
+provider's execution model, so refer to the section for your compute provider:
 
-On AWS Lambda, a Worker exists only for the duration of an invocation, and sync match failure is the primary signal that
-starts one. Between invocations no Lambda Worker is polling, so an available long-lived Worker receives the Task by sync
-match first. The Serverless Workers act as spillover capacity for the long-lived fleet.
-
-On GCP Cloud Run, a Worker Pool instance polls the Task Queue continuously for as long as it stays in the pool. While the
-pool is running instances, the Matching Service can sync match Tasks to them directly, so the pool takes a share of the
-Task Queue's work rather than only the overflow. A Cloud Run pool acts as spillover capacity only while it sits at zero
-instances.
+- [AWS Lambda](/serverless-workers/aws-lambda#sharing-a-task-queue)
+- [GCP Cloud Run](/serverless-workers/cloud-run#sharing-a-task-queue)
 
 :::caution
 

--- a/docs/encyclopedia/workers/serverless-workers/index.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/index.mdx
@@ -154,16 +154,24 @@ Refer to the autoscaling section for your compute provider:
 
 ## Scaling with long-lived Workers {/* #scaling-with-long-lived-workers */}
 
-Serverless Workers can share a Task Queue with long-lived Workers. Because Serverless Workers are only invoked on
-sync match failure, Serverless Workers only pick up Tasks that no long-lived Worker was available
-to handle. In practice, the Serverless Workers act as spillover capacity for the long-lived fleet.
+Serverless Workers can share a Task Queue with long-lived Workers. How the two divide the work depends on the compute
+provider's execution model.
+
+On AWS Lambda, a Worker exists only for the duration of an invocation, and sync match failure is the primary signal that
+starts one. Between invocations no Lambda Worker is polling, so an available long-lived Worker receives the Task by sync
+match first. The Serverless Workers act as spillover capacity for the long-lived fleet.
+
+On GCP Cloud Run, a Worker Pool instance polls the Task Queue continuously for as long as it stays in the pool. While the
+pool is running instances, the Matching Service can sync match Tasks to them directly, so the pool takes a share of the
+Task Queue's work rather than only the overflow. A Cloud Run pool acts as spillover capacity only while it sits at zero
+instances.
 
 :::caution
 
 If you configure Serverless and long-lived Workers on the same Task Queue, do not enable dynamic scaling on the
 long-lived Workers. The two groups cannot coordinate their scaling behavior. If both scale dynamically, the long-lived
-Workers may scale up to handle the same Tasks that Temporal is simultaneously invoking Serverless Workers for, leading
-to unnecessary invocations and unpredictable scaling.
+Workers may add capacity for the same Tasks that Temporal is simultaneously scaling Serverless Workers to handle,
+leading to surplus Workers on both sides and unpredictable scaling.
 
 :::
 


### PR DESCRIPTION
## What

The Serverless Workers "Scaling with long-lived Workers" section described AWS Lambda behavior only. The two compute providers size their Workers from different signals, so the guidance is now a subsection on each provider page.

Lambda invokes a Worker on sync match failure or backlog, so a long-lived fleet that keeps up produces neither and the Serverless Workers act as spillover capacity.

Cloud Run sizes the pool from the arrival rate on the Worker Deployment Version's Task Queues, which counts Tasks the long-lived Workers are already processing. The pool scales up to duplicate their capacity, so the guidance is to give the Serverless Workers their own Task Queue.

The Cloud Run behavior is read from `rate_based.go` on `temporal-auto-scaled-workers` `main`, not verified by testing. Worth a check from someone on the WCI side before merge.