### PR TITLE
fix: improve Markdown content negotiation

### DIFF
--- a/api/markdown-not-found.js
+++ b/api/markdown-not-found.js
@@ -1,0 +1,18 @@
+const body = `# Page not found
+
+This URL does not match a page in the Temporal documentation.
+
+## Where to look next
+
+- [Documentation index](https://docs.temporal.io/llms.txt)
+- [Documentation sitemap](https://docs.temporal.io/sitemap.xml)
+- [Temporal documentation home](https://docs.temporal.io/)
+`;
+
+module.exports = (_request, response) => {
+  response
+    .status(404)
+    .setHeader('Content-Type', 'text/markdown; charset=utf-8')
+    .setHeader('Vary', 'Accept, Accept-Encoding')
+    .send(body);
+};

--- a/middleware.js
+++ b/middleware.js
@@ -2,14 +2,15 @@ import { rewrite, next } from '@vercel/functions';
 
 export default function middleware(request) {
   const accept = request.headers.get('accept') || '';
+  const headers = { Vary: 'Accept, Accept-Encoding' };
 
   if (accept.includes('text/markdown')) {
     const url = new URL(request.url);
     const path = url.pathname.replace(/\/+$/, '') || '/index';
-    return rewrite(new URL(`${path}.md`, request.url));
+    return rewrite(new URL(`${path}.md`, request.url), { headers });
   }
 
-  return next();
+  return next({ headers });
 }
 
 export const config = {

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,17 @@
     {
       "source": "/img/og/:path*",
       "destination": "/img/assets/open-graph-shiny.jpg"
+    },
+    {
+      "source": "/:path((?!api/).*)",
+      "has": [
+        {
+          "type": "header",
+          "key": "accept",
+          "value": ".*text/markdown.*"
+        }
+      ],
+      "destination": "/api/markdown-not-found"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- add `Vary: Accept, Accept-Encoding` to both negotiated Markdown and HTML responses
- return a recoverable Markdown 404 with documentation links for missing Markdown routes

## Validation
- `yarn build`
- `node tests/run-all.mjs`
- `vercel build --prod --yes`