### PR TITLE
Point the serverless troubleshooting guides at provider status pages

### DIFF
--- a/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
@@ -50,6 +50,18 @@ the SDKs with a Cloud Run guide today.
   Terraform module.
 - A Temporal SDK. Use the tabs to select your language and the rest of the page will update accordingly.
 
+## Check Cloud Run known issues {/* #check-known-issues */}
+
+Google lists current Cloud Run defects and limitations on
+[Cloud Run known issues](https://cloud.google.com/run/docs/known-issues). Check it before you choose a region for the
+Worker Pool.
+
+{/* Remove the paragraph below once the deployment latency entry leaves the Cloud Run known issues page. */}
+
+One entry affects this guide today. Creating and updating Cloud Run resources is slower than expected in some regions,
+including `us-central1`. Creating the Worker Pool and the scaling calls Temporal makes against it both take longer
+there. Google recommends deploying to a different region when the added latency is a problem.
+
 ## 1. Write Worker code {/* #write-worker-code */}
 
 A Cloud Run Serverless Worker is a standard long-running Worker. It connects to Temporal, registers its Workflows and

--- a/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
@@ -52,12 +52,14 @@ the SDKs with a Cloud Run guide today.
 
 {/* Remove this admonition once the high deployment latency entry leaves the Cloud Run known issues page. */}
 
-:::caution Choose your region carefully
+:::caution Open Google Cloud issue: high deployment latency in some regions
 
-Creating or updating Cloud Run resources is slower than expected in some regions, including `us-central1`. This affects creating the
-Worker Pool and the scaling calls Temporal makes against it. If latency is a problem in a particular region, Google
-recommends deploying to another region. See
-[High deployment latency in some regions](https://cloud.google.com/run/docs/known-issues#deployment-latency).
+Google currently reports that creating or updating Cloud Run resources takes longer than expected in some regions,
+including `us-central1`. The delay is in Cloud Run, not in Temporal, and it applies to creating the Worker Pool and to
+the scaling calls Temporal makes against it. Google recommends deploying to another region while the issue is open. For
+the current status, see
+[High deployment latency in some regions](https://cloud.google.com/run/docs/known-issues#deployment-latency) in the
+Cloud Run known issues.
 
 :::
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
@@ -50,17 +50,16 @@ the SDKs with a Cloud Run guide today.
   Terraform module.
 - A Temporal SDK. Use the tabs to select your language and the rest of the page will update accordingly.
 
-## Check Cloud Run known issues {/* #check-known-issues */}
+{/* Remove this admonition once the high deployment latency entry leaves the Cloud Run known issues page. */}
 
-Google lists current Cloud Run defects and limitations on
-[Cloud Run known issues](https://cloud.google.com/run/docs/known-issues). Check it before you choose a region for the
-Worker Pool.
+:::caution Choose your region carefully
 
-{/* Remove the paragraph below once the deployment latency entry leaves the Cloud Run known issues page. */}
+Creating or updating Cloud Run resources is slower than expected in some regions, including `us-central1`. This affects creating the
+Worker Pool and the scaling calls Temporal makes against it. If latency is a problem in a particular region, Google
+recommends deploying to another region. See
+[High deployment latency in some regions](https://cloud.google.com/run/docs/known-issues#deployment-latency).
 
-One entry affects this guide today. Creating and updating Cloud Run resources is slower than expected in some regions,
-including `us-central1`. Creating the Worker Pool and the scaling calls Temporal makes against it both take longer
-there. Google recommends deploying to a different region when the added latency is a problem.
+:::
 
 ## 1. Write Worker code {/* #write-worker-code */}
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
@@ -55,9 +55,8 @@ the SDKs with a Cloud Run guide today.
 :::caution Open Google Cloud issue: high deployment latency in some regions
 
 Google currently reports that creating or updating Cloud Run resources takes longer than expected in some regions,
-including `us-central1`. The delay is in Cloud Run, not in Temporal, and it applies to creating the Worker Pool and to
-the scaling calls Temporal makes against it. Google recommends deploying to another region while the issue is open. For
-the current status, see
+including `us-central1`. Google recommends deploying to another region while the issue is open. For the current status,
+see
 [High deployment latency in some regions](https://cloud.google.com/run/docs/known-issues#deployment-latency) in the
 Cloud Run known issues.
 

--- a/docs/troubleshooting/serverless-workers/aws-lambda.mdx
+++ b/docs/troubleshooting/serverless-workers/aws-lambda.mdx
@@ -35,6 +35,8 @@ When a Serverless Worker invocation works correctly, the following sequence happ
 
 Start by determining whether the Lambda function is being invoked at all, then narrow down from there.
 
+If no check below matches what you are seeing, or they all pass, [check for AWS-side issues](#check-aws-issues).
+
 ## Is the Lambda function being invoked? {/* #is-lambda-invoked */}
 
 Check the Lambda function's CloudWatch metrics or invocation logs.
@@ -140,3 +142,18 @@ deployment version than the WCI expects, the Task is not processed, and the WCI 
 
 To fix the loop, update the deployment name and build ID in the Worker code to match the Worker Deployment Version, then
 redeploy the Lambda function.
+
+## Check for AWS-side issues {/* #check-aws-issues */}
+
+Some symptoms come from Lambda rather than from your configuration. Before spending time on the checks above, or after
+they all pass, rule out a provider-side cause:
+
+- [AWS Health Dashboard service history](https://health.aws.amazon.com/health/status) reports active incidents by
+  service and region.
+- [Your account health events](https://health.aws.amazon.com/health/home) reports events scoped to your own resources,
+  such as approaching service quotas.
+
+If an incident explains what you are seeing, the fix is usually to wait it out or move to another region. Temporal
+addresses a function by ARN, which includes the region, so changing region means deploying a new function and updating
+the [compute configuration](/production-deployment/worker-deployments/serverless-workers/aws-lambda#create-worker-deployment-version)
+on the Worker Deployment Version.

--- a/docs/troubleshooting/serverless-workers/aws-lambda.mdx
+++ b/docs/troubleshooting/serverless-workers/aws-lambda.mdx
@@ -145,8 +145,8 @@ redeploy the Lambda function.
 
 ## Check for AWS-side issues {/* #check-aws-issues */}
 
-Some symptoms come from Lambda rather than from your configuration. Before spending time on the checks above, or after
-they all pass, rule out a provider-side cause:
+If the checks above all pass, the cause may be in Lambda rather than in your configuration.
+Rule out a provider-side cause:
 
 - [AWS Health Dashboard service history](https://health.aws.amazon.com/health/status) reports active incidents by
   service and region.

--- a/docs/troubleshooting/serverless-workers/cloud-run.mdx
+++ b/docs/troubleshooting/serverless-workers/cloud-run.mdx
@@ -41,6 +41,8 @@ Temporal changes how many instances the pool runs. When the flow works correctly
 
 Start by determining whether the pool is running instances at all.
 
+If no check below matches what you are seeing, or they all pass, [check for GCP-side issues](#check-gcp-issues).
+
 ## Is the Worker Pool running instances? {/* #is-pool-running */}
 
 Inspect the pool directly. The instance count the WCI has asked Cloud Run for is stored as an annotation on the pool:
@@ -185,3 +187,17 @@ resumes from its last recorded progress instead of restarting.
 
 For how scale-in decisions are made, see
 [Serverless Workers on GCP Cloud Run](/serverless-workers/cloud-run#scale-in).
+
+## Check for GCP-side issues {/* #check-gcp-issues */}
+
+Some symptoms come from Cloud Run rather than from your configuration. Before spending time on the checks above, or
+after they all pass, rule out a provider-side cause:
+
+- [Cloud Run known issues](https://cloud.google.com/run/docs/known-issues) lists current defects and limitations,
+  including ones that affect how long Worker Pool operations take.
+- [Google Cloud Service Health](https://status.cloud.google.com/) reports active incidents by product and region.
+
+If a known issue or incident explains what you are seeing, the fix is usually to wait it out or move to another region.
+Temporal addresses a Worker Pool by project, region, and name, so changing region means creating a new pool and updating
+the [compute configuration](/production-deployment/worker-deployments/serverless-workers/cloud-run#create-worker-deployment-version)
+on the Worker Deployment Version.

--- a/docs/troubleshooting/serverless-workers/cloud-run.mdx
+++ b/docs/troubleshooting/serverless-workers/cloud-run.mdx
@@ -190,8 +190,8 @@ For how scale-in decisions are made, see
 
 ## Check for GCP-side issues {/* #check-gcp-issues */}
 
-Some symptoms come from Cloud Run rather than from your configuration. Before spending time on the checks above, or
-after they all pass, rule out a provider-side cause:
+If the checks above all pass, the cause may be in Cloud Run rather than in your configuration.
+Rule out a provider-side cause:
 
 - [Cloud Run known issues](https://cloud.google.com/run/docs/known-issues) lists current defects and limitations,
   including ones that affect how long Worker Pool operations take.


### PR DESCRIPTION
## What

- Adds a **Check for AWS-side issues** section to the Lambda troubleshooting guide and a **Check for GCP-side issues** section to the Cloud Run troubleshooting guide. Both link the provider's known issues and health dashboard rather than any single incident, so they can stay permanently.
- Adds a caution admonition to the Cloud Run deploy guide, right after the prerequisites, for the [high deployment latency](https://cloud.google.com/run/docs/known-issues#deployment-latency) known issue. An MDX comment above it marks when to delete it.