### PR TITLE
Document all Audit Log event values

### DIFF
--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -27,49 +27,85 @@ Instead, explore the [Export](/cloud/export) feature, which does let you send cl
 
 ## Which events are supported by Audit Logs? {/* #supported-events */}
 
+The `operation` field can contain the following event values:
+
 - Account
-  - `ChangeAccountPlanType`: Change Account Plan Type
-  - `UpdateAccountAPI`: Configure Audit Logs, Configure Observability Endpoint
-- API Keys
-  - `CreateAPIKey`: Create API Key
-  - `DeleteAPIKey`: Delete API Key
-  - `UpdateAPIKey`: Update API Key
-- Connectivity Rules
-  - `CreateConnectivityRule`: Create Connectivity Rule
-  - `DeleteConnectivityRule`: Delete Connectivity Rule
+  - `ChangeAccountPlanType`
+  - `CreateAccountAuditLogSink`
+  - `DeleteAccountAuditLogSink`
+  - `OffboardAccount`
+  - `SelfServiceOffboardAccount`
+  - `UpdateAccount`
+  - `UpdateAccountAuditLogSink`
+- API keys
+  - `CreateAPIKey`
+  - `CreateApiKey`
+  - `CreateServiceAccountAPIKey`
+  - `DeleteAPIKey`
+  - `DeleteApiKey`
+  - `UpdateAPIKey`
+  - `UpdateApiKey`
+- Billing
+  - `CreateBillingReport`
+- Connectivity rules
+  - `CreateConnectivityRule`
+  - `DeleteConnectivityRule`
+- Custom roles
+  - `CreateCustomRole`
+  - `DeleteCustomRole`
+  - `UpdateCustomRole`
 - Namespace
-  - `CreateNamespaceAPI`: Create Namespace
-  - `DeleteNamespaceAPI`: Delete Namespace
-  - `FailoverNamespacesAPI`: Failover (for High Availability Namespaces)
-  - `RenameCustomSearchAttributeAPI`: Rename Custom Search Attribute
-  - `UpdateNamespaceAPI`: Includes retention period changes, replica edits, authentication method updates, custom search attribute updates, and connectivity rule bindings
-- Namespace Export
-  - `CreateNamespaceExportSink`: Create Namespace Export Sink
-  - `DeleteNamespaceExportSink`: Delete Namespace Export Sink
-  - `UpdateNamespaceExportSink`: Update Namespace Export Sink
-  - `ValidateNamespaceExportSink`: Validate Namespace Export Sink
-- Nexus Endpoint
-  - `CreateNexusEndpoint`: Create Nexus Endpoint
-  - `DeleteNexusEndpoint`: Delete Nexus Endpoint
-  - `UpdateNexusEndpoint`: Update Nexus Endpoint
-- Service Accounts
-  - `CreateServiceAccount`: Create Service Account
-  - `CreateServiceAccountAPIKey`: Create Service Account API Key
-  - `DeleteServiceAccount`: Delete Service Account
-  - `UpdateServiceAccount`: Update Service Account
-- User
-  - `CreateUserAPI`: Create Users
-  - `DeleteUserAPI`: Delete Users
-  - `InviteUsersAPI`: Invite Users
-  - `SetUserNamespaceAccessAPI`: Set User Namespace Access
-  - `UpdateIdentityNamespacePermissionsAPI`: Update Identity Namespace Permissions
-  - `UpdateUserAPI`: Update User Account-level Roles
-  - `UpdateUserNamespacePermissionsAPI`: Update User Namespace Permissions
-- User Groups
-  - `CreateUserGroup`: Create User Group
-  - `DeleteUserGroup`: Delete User Group
-  - `SetUserGroupNamespaceAccess`: Set User Group Namespace Access
-  - `UpdateUserGroup`: Update User Group
+  - `CreateNamespace`
+  - `DeleteNamespace`
+  - `FailoverNamespaces`
+  - `RenameCustomSearchAttribute`
+  - `UpdateNamespace`
+  - `UpdateNamespaceTags`
+  - `UpdateSearchAttributes`
+- Namespace export
+  - `CreateNamespaceExportSink`
+  - `DeleteNamespaceExportSink`
+  - `UpdateNamespaceExportSink`
+  - `ValidateNamespaceExportSink`
+- Nexus endpoints
+  - `CreateNexusEndpoint`
+  - `DeleteNexusEndpoint`
+  - `UpdateNexusEndpoint`
+- Projects
+  - `CreateProject`
+  - `DeleteProject`
+  - `SetServiceAccountProjectAccess`
+  - `SetUserGroupProjectAccess`
+  - `SetUserProjectAccess`
+  - `UpdateProject`
+- Security
+  - `SecretFound`
+- Service accounts
+  - `CreateServiceAccount`
+  - `DeleteServiceAccount`
+  - `SetServiceAccountNamespaceAccess`
+  - `UpdateServiceAccount`
+- Users
+  - `CreateJITUser`
+  - `CreateUser`
+  - `DeleteUser`
+  - `InviteUsers`
+  - `SetUserNamespaceAccess`
+  - `UpdateIdentityNamespacePermissions`
+  - `UpdateUser`
+  - `UpdateUserNamespacePermissions`
+  - `UserAcceptInvitation`
+  - `UserLogin`
+  - `UserSignup`
+- User groups
+  - `AddUserGroupMember`
+  - `CreateUserGroup`
+  - `DeleteUserGroup`
+  - `RemoveUserGroupMember`
+  - `SetUserGroupNamespaceAccess`
+  - `UpdateUserGroup`
+
+The API key event names are case-sensitive. Temporal Cloud emits the `APIKey` or `ApiKey` variant depending on which Control Plane service processes the request.
 
 ### Audit log format
 

--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -30,80 +30,80 @@ Instead, explore the [Export](/cloud/export) feature, which does let you send cl
 The `operation` field can contain the following event values:
 
 - Account
-  - `ChangeAccountPlanType`
-  - `CreateAccountAuditLogSink`
-  - `DeleteAccountAuditLogSink`
-  - `OffboardAccount`
-  - `SelfServiceOffboardAccount`
-  - `UpdateAccount`
-  - `UpdateAccountAuditLogSink`
+  - `ChangeAccountPlanType`: Change Account Plan Type
+  - `CreateAccountAuditLogSink`: Create Account Audit Log Sink
+  - `DeleteAccountAuditLogSink`: Delete Account Audit Log Sink
+  - `OffboardAccount`: Offboard Account
+  - `SelfServiceOffboardAccount`: Self-Service Offboard Account
+  - `UpdateAccount`: Update Account
+  - `UpdateAccountAuditLogSink`: Update Account Audit Log Sink
 - API keys
-  - `CreateAPIKey`
-  - `CreateApiKey`
-  - `CreateServiceAccountAPIKey`
-  - `DeleteAPIKey`
-  - `DeleteApiKey`
-  - `UpdateAPIKey`
-  - `UpdateApiKey`
+  - `CreateAPIKey`: Create API Key
+  - `CreateApiKey`: Create API Key
+  - `CreateServiceAccountAPIKey`: Create Service Account API Key
+  - `DeleteAPIKey`: Delete API Key
+  - `DeleteApiKey`: Delete API Key
+  - `UpdateAPIKey`: Update API Key
+  - `UpdateApiKey`: Update API Key
 - Billing
-  - `CreateBillingReport`
+  - `CreateBillingReport`: Create Billing Report
 - Connectivity rules
-  - `CreateConnectivityRule`
-  - `DeleteConnectivityRule`
+  - `CreateConnectivityRule`: Create Connectivity Rule
+  - `DeleteConnectivityRule`: Delete Connectivity Rule
 - Custom roles
-  - `CreateCustomRole`
-  - `DeleteCustomRole`
-  - `UpdateCustomRole`
+  - `CreateCustomRole`: Create Custom Role
+  - `DeleteCustomRole`: Delete Custom Role
+  - `UpdateCustomRole`: Update Custom Role
 - Namespace
-  - `CreateNamespace`
-  - `DeleteNamespace`
-  - `FailoverNamespaces`
-  - `RenameCustomSearchAttribute`
-  - `UpdateNamespace`
-  - `UpdateNamespaceTags`
-  - `UpdateSearchAttributes`
+  - `CreateNamespace`: Create Namespace
+  - `DeleteNamespace`: Delete Namespace
+  - `FailoverNamespaces`: Failover Namespaces
+  - `RenameCustomSearchAttribute`: Rename Custom Search Attribute
+  - `UpdateNamespace`: Update Namespace
+  - `UpdateNamespaceTags`: Update Namespace Tags
+  - `UpdateSearchAttributes`: Update Search Attributes
 - Namespace export
-  - `CreateNamespaceExportSink`
-  - `DeleteNamespaceExportSink`
-  - `UpdateNamespaceExportSink`
-  - `ValidateNamespaceExportSink`
+  - `CreateNamespaceExportSink`: Create Namespace Export Sink
+  - `DeleteNamespaceExportSink`: Delete Namespace Export Sink
+  - `UpdateNamespaceExportSink`: Update Namespace Export Sink
+  - `ValidateNamespaceExportSink`: Validate Namespace Export Sink
 - Nexus endpoints
-  - `CreateNexusEndpoint`
-  - `DeleteNexusEndpoint`
-  - `UpdateNexusEndpoint`
+  - `CreateNexusEndpoint`: Create Nexus Endpoint
+  - `DeleteNexusEndpoint`: Delete Nexus Endpoint
+  - `UpdateNexusEndpoint`: Update Nexus Endpoint
 - Projects
-  - `CreateProject`
-  - `DeleteProject`
-  - `SetServiceAccountProjectAccess`
-  - `SetUserGroupProjectAccess`
-  - `SetUserProjectAccess`
-  - `UpdateProject`
+  - `CreateProject`: Create Project
+  - `DeleteProject`: Delete Project
+  - `SetServiceAccountProjectAccess`: Set Service Account Project Access
+  - `SetUserGroupProjectAccess`: Set User Group Project Access
+  - `SetUserProjectAccess`: Set User Project Access
+  - `UpdateProject`: Update Project
 - Security
-  - `SecretFound`
+  - `SecretFound`: Secret Found
 - Service accounts
-  - `CreateServiceAccount`
-  - `DeleteServiceAccount`
-  - `SetServiceAccountNamespaceAccess`
-  - `UpdateServiceAccount`
+  - `CreateServiceAccount`: Create Service Account
+  - `DeleteServiceAccount`: Delete Service Account
+  - `SetServiceAccountNamespaceAccess`: Set Service Account Namespace Access
+  - `UpdateServiceAccount`: Update Service Account
 - Users
-  - `CreateJITUser`
-  - `CreateUser`
-  - `DeleteUser`
-  - `InviteUsers`
-  - `SetUserNamespaceAccess`
-  - `UpdateIdentityNamespacePermissions`
-  - `UpdateUser`
-  - `UpdateUserNamespacePermissions`
-  - `UserAcceptInvitation`
-  - `UserLogin`
-  - `UserSignup`
+  - `CreateJITUser`: Create JIT User
+  - `CreateUser`: Create User
+  - `DeleteUser`: Delete User
+  - `InviteUsers`: Invite Users
+  - `SetUserNamespaceAccess`: Set User Namespace Access
+  - `UpdateIdentityNamespacePermissions`: Update Identity Namespace Permissions
+  - `UpdateUser`: Update User
+  - `UpdateUserNamespacePermissions`: Update User Namespace Permissions
+  - `UserAcceptInvitation`: User Accept Invitation
+  - `UserLogin`: User Login
+  - `UserSignup`: User Signup
 - User groups
-  - `AddUserGroupMember`
-  - `CreateUserGroup`
-  - `DeleteUserGroup`
-  - `RemoveUserGroupMember`
-  - `SetUserGroupNamespaceAccess`
-  - `UpdateUserGroup`
+  - `AddUserGroupMember`: Add User Group Member
+  - `CreateUserGroup`: Create User Group
+  - `DeleteUserGroup`: Delete User Group
+  - `RemoveUserGroupMember`: Remove User Group Member
+  - `SetUserGroupNamespaceAccess`: Set User Group Namespace Access
+  - `UpdateUserGroup`: Update User Group
 
 The API key event names are case-sensitive. Temporal Cloud emits the `APIKey` or `ApiKey` variant depending on which Control Plane service processes the request.
 

--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -79,7 +79,7 @@ The `operation` field can contain the following event values:
   - `SetUserProjectAccess`: Set User Project Access
   - `UpdateProject`: Update Project
 - Security
-  - `SecretFound`: Secret Found
+  - `SecretFound`: Detect Exposed API Key
 - Service accounts
   - `CreateServiceAccount`: Create Service Account
   - `DeleteServiceAccount`: Delete Service Account
@@ -104,8 +104,6 @@ The `operation` field can contain the following event values:
   - `RemoveUserGroupMember`: Remove User Group Member
   - `SetUserGroupNamespaceAccess`: Set User Group Namespace Access
   - `UpdateUserGroup`: Update User Group
-
-The API key event names are case-sensitive. Temporal Cloud emits the `APIKey` or `ApiKey` variant depending on which Control Plane service processes the request.
 
 ### Audit log format
 


### PR DESCRIPTION
## Summary

- Replace incomplete and incorrect Audit Log operation names with all 62 values observed in the Control Plane audit log
- Group operation values by resource type
- Document the case-sensitive `APIKey` and `ApiKey` variants

## Why

The existing reference omitted many emitted events and showed several Go constant names, such as `CreateNamespaceAPI`, instead of the actual `operation` values.

## Validation

- `vale --config .vale-ci.ini docs/cloud/audit-logs.mdx`
- `corepack yarn@1.22.22 build`
- Exact set comparison against the 62 operation values from the source thread