### PR TITLE
Mark Cloud Ops API as GA and document versioning and availability

### DIFF
--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -10,12 +10,6 @@ tags:
   - Temporal Cloud
 ---
 
-import { ReleaseNoteHeader } from '@site/src/components';
-
-<ReleaseNoteHeader
-  type="publicPreview"
-/>
-
 The Temporal Cloud Operations API, or the Cloud Ops API, is an open source, public [HTTP API](https://saas-api.tmprl.cloud/docs/httpapi.html#description/introduction) and [gRPC API](https://github.com/temporalio/cloud-api/tree/main) for programmatically managing Temporal Cloud Control Plane resources, including [Namespaces](/cloud/namespaces), [Users](/cloud/manage-access/users), [Service Accounts](/cloud/manage-access/service-accounts), [API keys](/cloud/api-keys), and others. The Temporal Cloud [Terraform Provider](/cloud/terraform-provider), [tcld CLI](/cloud/tcld), and Web UI all use the Cloud Ops API.
 
 ## Develop applications with the Cloud Ops API
@@ -141,6 +135,18 @@ For HTTP clients, the version header is optional. If omitted, the HTTP gateway d
 
 For production HTTP automation, still pin an explicit version so behavior does not change when the gateway’s latest version advances.
 
+### API versioning and deprecation
+
+Use the latest Cloud Ops API version for new integrations, and keep your `temporal-cloud-api-version` header on a supported version.
+
+Temporal supports each Cloud Ops API version for at least one year after its release. When an API version is scheduled for deprecation:
+
+- Temporal provides at least six months' notice before the version becomes unsupported.
+- The minimum supported API version and deprecation timeline are published in the [Cloud Ops API repository](https://github.com/temporalio/cloud-api).
+- Temporal provides migration guidance when an API change requires you to update your integration.
+
+After the deprecation period, requests that use a version older than the minimum supported version can be rejected.
+
 ### Connection URL
 
 - gRPC: `saas-api.tmprl.cloud:443`
@@ -151,6 +157,14 @@ For production HTTP automation, still pin an explicit version so behavior does n
 1. Generate an [API Key for authentication](/cloud/api-keys#manage-api-keys). Required permissions vary by operation; see [roles and permissions](/cloud/manage-access/roles-and-permissions).
 2. Establish a secure connection. For Go, see [Cloud Ops API client setup](https://github.com/temporalio/cloud-samples-go/blob/main/client/api/client.go).
 3. Execute operations. For request and response messages, see `cloudservice/v1/request_response.proto`. For services, see `cloudservice/v1/service.proto`.
+
+## Availability
+
+Temporal targets 99.99% monthly availability for the Cloud Ops API across its HTTP and gRPC interfaces.
+
+Availability measures whether valid Cloud Ops API requests can be successfully served. Server-side failures count against this objective. Client errors, such as invalid requests and authentication or authorization failures, do not. Documented rate-limit responses (`ResourceExhausted`) also do not count against availability.
+
+This availability objective applies only to Temporal Cloud control-plane operations. It is not a contractual service-level agreement and does not change the Temporal Cloud [SLA](/cloud/sla). Workflow and Activity execution are data-plane operations covered by that SLA.
 
 ## Rate limits
 

--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -137,15 +137,9 @@ For production HTTP automation, still pin an explicit version so behavior does n
 
 ### API versioning and deprecation
 
-Use the latest Cloud Ops API version for new integrations, and keep your `temporal-cloud-api-version` header on a supported version.
+Use the latest Cloud Ops API version for new integrations, and keep your `temporal-cloud-api-version` header up to date.
 
-Temporal supports each Cloud Ops API version for at least one year after its release. When an API version is scheduled for deprecation:
-
-- Temporal provides at least six months' notice before the version becomes unsupported.
-- The minimum supported API version and deprecation timeline are published in the [Cloud Ops API repository](https://github.com/temporalio/cloud-api).
-- Temporal provides migration guidance when an API change requires you to update your integration.
-
-After the deprecation period, requests that use a version older than the minimum supported version can be rejected.
+Temporal currently supports all Cloud Ops API versions. Each version is supported for at least one year after its release. When an API version is scheduled for deprecation, Temporal provides at least six months' notice before the version becomes unsupported, and provides migration guidance when an API change requires you to update your integration.
 
 ### Connection URL
 

--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -158,7 +158,7 @@ Exceptions to these timelines may be necessary for critical security, legal, or 
 
 Temporal targets 99.99% monthly availability for the Cloud Ops API across its HTTP and gRPC interfaces.
 
-Availability measures whether valid Cloud Ops API requests can be successfully served. Server-side failures count against this objective. Client errors, such as invalid requests and authentication or authorization failures, do not. Documented rate-limit responses (`ResourceExhausted`) also do not count against availability.
+Availability measures whether valid Cloud Ops API requests can be successfully served. Server-side failures count against this objective. Client errors, such as invalid requests and authentication or authorization failures, do not. Documented rate-limit responses (`ResourceExhausted` for gRPC, HTTP 429) do not count against availability.
 
 This availability objective applies only to Temporal Cloud control-plane operations. It is not a contractual service-level agreement and does not change the Temporal Cloud [SLA](/cloud/sla). Workflow and Activity execution are data-plane operations covered by that SLA.
 

--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -139,7 +139,7 @@ For production HTTP automation, still pin an explicit version so behavior does n
 
 We recommend using the latest Cloud Ops API version for new integrations, and keeping your client version up to date to within one year of the latest release instead of pinning to an older version indefinitely.
 
-Temporal supports each Cloud Ops API version for at least one year after its release. When an API version is scheduled for deprecation, Temporal provides at least six months' notice before the version becomes unsupported, and provides migration guidance when an API change requires you to update your integration.
+Temporal supports each Cloud Ops API version for at least one year after its release. Before a version becomes unsupported, Temporal provides at least six months’ notice and migration guidance if you need to update your integration.
 
 Exceptions to these timelines may be necessary for critical security, legal, or service-integrity reasons. Temporal provides notice whenever practicable.
 

--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -137,7 +137,7 @@ For production HTTP automation, still pin an explicit version so behavior does n
 
 ### API versioning and deprecation
 
-Use the latest Cloud Ops API version for new integrations. Keep existing clients on a version released within the last year.
+Use the latest Cloud Ops API version for new integrations. Prefer a recent version for existing clients instead of pinning to an older one indefinitely.
 
 Temporal supports each Cloud Ops API version for at least one year after its release. When an API version is scheduled for deprecation, Temporal provides at least six months' notice before the version becomes unsupported, and provides migration guidance when an API change requires you to update your integration.
 

--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -137,9 +137,9 @@ For production HTTP automation, still pin an explicit version so behavior does n
 
 ### API versioning and deprecation
 
-Use the latest Cloud Ops API version for new integrations, and keep your `temporal-cloud-api-version` header up to date.
+Use the latest Cloud Ops API version for new integrations. Keep existing clients on a version released within the last year.
 
-Temporal currently supports all Cloud Ops API versions. Each version is supported for at least one year after its release. When an API version is scheduled for deprecation, Temporal provides at least six months' notice before the version becomes unsupported, and provides migration guidance when an API change requires you to update your integration.
+Temporal supports each Cloud Ops API version for at least one year after its release. When an API version is scheduled for deprecation, Temporal provides at least six months' notice before the version becomes unsupported, and provides migration guidance when an API change requires you to update your integration.
 
 ### Connection URL
 

--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -158,9 +158,9 @@ Exceptions to these timelines may be necessary for critical security, legal, or 
 
 Temporal targets 99.99% monthly availability for the Cloud Ops API across its HTTP and gRPC interfaces.
 
-Availability measures whether valid Cloud Ops API requests can be successfully served. Server-side failures count against this objective. Client errors, such as invalid requests and authentication or authorization failures, do not. Documented rate-limit responses (`ResourceExhausted` for gRPC, HTTP 429) do not count against availability.
+Availability measures whether valid Cloud Ops API requests are successfully served. Server-side failures count against this objective; client-caused errors, including invalid requests and authentication or authorization failures, do not. Responses due to documented rate limits (`ResourceExhausted` for gRPC and HTTP 429) are also excluded because they represent intentional throttling rather than service unavailability.
 
-This availability objective applies only to Temporal Cloud control-plane operations. It is not a contractual service-level agreement and does not change the Temporal Cloud [SLA](/cloud/sla). Workflow and Activity execution are data-plane operations covered by that SLA.
+This availability objective applies only to the Cloud Ops API. It is not a contractual service-level agreement and does not change the Temporal Cloud [SLA](/cloud/sla). Temporal Service operations, including Workflow and Activity execution, are covered separately by the Temporal Cloud SLA.
 
 ## Rate limits
 

--- a/docs/cloud/operation-api.mdx
+++ b/docs/cloud/operation-api.mdx
@@ -137,9 +137,11 @@ For production HTTP automation, still pin an explicit version so behavior does n
 
 ### API versioning and deprecation
 
-Use the latest Cloud Ops API version for new integrations. Prefer a recent version for existing clients instead of pinning to an older one indefinitely.
+We recommend using the latest Cloud Ops API version for new integrations, and keeping your client version up to date to within one year of the latest release instead of pinning to an older version indefinitely.
 
 Temporal supports each Cloud Ops API version for at least one year after its release. When an API version is scheduled for deprecation, Temporal provides at least six months' notice before the version becomes unsupported, and provides migration guidance when an API change requires you to update your integration.
+
+Exceptions to these timelines may be necessary for critical security, legal, or service-integrity reasons. Temporal provides notice whenever practicable.
 
 ### Connection URL
 


### PR DESCRIPTION
## Summary

- Removes the Public Preview callout from the [Cloud Ops API](https://docs.temporal.io/ops) page now that the GA launch review is approved.
- Adds the customer-facing API versioning and deprecation policy: each version is supported for at least one year; Temporal gives at least six months' notice before a version becomes unsupported. Note: we are not deprecating any versions at this moment, so no need to specify min supported version or deprecated version at this moment.
- Adds the Cloud Ops API availability objective (99.99% monthly target) and states that this is a control-plane objective, not a change to the Temporal Cloud [SLA](https://docs.temporal.io/cloud/sla).

## Why

Customers have been treating Public Preview as a production-readiness warning. GA needs a published support window and an availability objective so teams can build long-lived integrations against the API.

## Copy decisions

This PR does **not** publish the original draft verbatim.

Omitted as not customer-facing:

- Security / legal / service-integrity exception and "whenever practicable" (contract/MSA language)
- Internal SLO rationale for excluding `ResourceExhausted`
- gRPC error-code taxonomy, 2-year internal buffer, LRR process, observed 99.998% / latency

Rewritten:

- "targets 99.99%" kept, with an explicit "not a contractual SLA" caveat so it is not read as a new Cloud SLA
- Min supported version, published deprecation timeline, and post-deprecation request rejection omitted. All versions are currently supported, and those artifacts are not published yet.

## Follow-ups (not in this PR)

- [temporalio/cloud-api](https://github.com/temporalio/cloud-api) README still says Public Preview / "subject to change".
- Terraform provider page still has a Public Preview `ssdi` note (`docs/cloud/terraform-provider.mdx`).

## Test plan

- [ ] Preview the `/ops` page: Public Preview banner is gone.
- [ ] Confirm versioning and Availability sections render and the SLA link goes to `/cloud/sla`.
- [ ] Confirm Legal/eng agree this is an availability **objective**, not a contractual SLA.