### PR TITLE
Add Arize AX to Python integration listings

### DIFF
--- a/docs/develop/python/index.mdx
+++ b/docs/develop/python/index.mdx
@@ -83,6 +83,7 @@ From there, you can dive deeper into any of the Temporal primitives to start bui
 
 ## [Integrations](/develop/python/integrations)
 
+- [Arize AX integration](https://arize.com/docs/ax/integrations/python-agent-frameworks/temporal/temporal-tracing)
 - [Braintrust integration](https://www.braintrust.dev/docs/integrations/sdk-integrations/temporal#python)
 - [Deep Agents integration](/develop/python/integrations/deepagents)
 - [Google ADK integration](/develop/python/integrations/google-adk)

--- a/docs/develop/python/integrations/index.mdx
+++ b/docs/develop/python/integrations/index.mdx
@@ -13,7 +13,8 @@ description: Integrations with other tools and services.
 import IntegrationsGrid from '@site/src/components/IntegrationsGrid';
 
 The following integrations are available for the Temporal Python SDK.
-These integrations are built on the Temporal Python SDK's [Plugin system](/develop/plugins-guide), which you can also
-use to build your own integrations.
+Temporal-maintained SDK and framework integrations are built on the Temporal Python SDK's
+[Plugin system](/develop/plugins-guide), which you can also use to build your own integrations. Some observability
+entries link to partner guides that use OpenTelemetry or other open standards with Temporal.
 
 <IntegrationsGrid defaultSdks={["Python"]} />

--- a/src/components/IntegrationsGrid/integrations-data.json
+++ b/src/components/IntegrationsGrid/integrations-data.json
@@ -9,6 +9,15 @@
     "href": "/develop/typescript/integrations/ai-sdk"
   },
   {
+    "name": "Arize AX",
+    "description": "Observe, troubleshoot, and evaluate Temporal AI agents with OpenTelemetry traces in Arize AX.",
+    "tags": [
+      "Agent observability"
+    ],
+    "sdk": "Python",
+    "href": "https://arize.com/docs/ax/integrations/python-agent-frameworks/temporal/temporal-tracing"
+  },
+  {
     "name": "Braintrust",
     "description": "Monitor and evaluate AI application performance with Braintrust observability.",
     "tags": [


### PR DESCRIPTION
## Summary
- Add Arize AX to the Temporal integrations catalog as a Python agent observability option.
- Add the same Arize AX Temporal guide to the Python SDK integrations list.

## Notes
The linked guide uses Temporal Python OpenTelemetry tracing plus OpenInference instrumentation so Temporal AI-agent spans can be exported to Arize AX. This mirrors the existing external observability listings for Braintrust and Langfuse without adding a new Temporal SDK plugin page.

## Testing
- `jq empty src/components/IntegrationsGrid/integrations-data.json`
- `git diff --check`