### PR TITLE
Fix accuracy issues in the Temporal Service configuration references

### DIFF
--- a/docs/production-deployment/self-hosted-guide/monitoring.mdx
+++ b/docs/production-deployment/self-hosted-guide/monitoring.mdx
@@ -76,7 +76,7 @@ temporal server start-dev --metrics-port 8000
 
 :::info
 
-Refer to the [Temporal Cluster configuration reference](/references/configuration#global) to expose metrics from a production service.
+Refer to the [Temporal Service configuration reference](/references/configuration#global) to expose metrics from a production service.
 
 :::
 

--- a/docs/references/configuration.mdx
+++ b/docs/references/configuration.mdx
@@ -1,14 +1,14 @@
 ---
 id: configuration
-title: Temporal Cluster configuration reference
-sidebar_label: Cluster configuration
-description: Configure a Temporal Cluster using the development.yaml file to set global parameters, metrics, security, persistence, and service roles, ensuring a streamlined setup and management process.
+title: Temporal Service configuration reference
+sidebar_label: Service configuration
+description: Configure a Temporal Service using the development.yaml file to set global parameters, metrics, security, persistence, and service roles, ensuring a streamlined setup and management process.
 toc_max_heading_level: 4
 tags:
   - Reference
 ---
 
-Much of the behavior of a Temporal Cluster is configured using the `development.yaml` file and may contain the following top-level sections:
+Much of the behavior of a Temporal Service is configured using the `development.yaml` file and may contain the following top-level sections:
 
 - [`global`](#global)
 - [`persistence`](#persistence)
@@ -50,14 +50,14 @@ Default is 10s.
 
 #### broadcastAddress
 
-Used by gossip protocol to communicate with other hosts in the same Cluster for membership info.
-Use IP address that is reachable by other hosts in the same Cluster.
-If there is only one host in the Cluster, you can use 127.0.0.1.
+Used by gossip protocol to communicate with other hosts in the same Service for membership info.
+Use IP address that is reachable by other hosts in the same Service.
+If there is only one host in the Service, you can use 127.0.0.1.
 Check `net.ParseIP` for supported syntax, only IPv4 is supported.
 
 ### metrics
 
-Configures the Cluster's metric subsystem.
+Configures the Service's metric subsystem.
 Specific providers are configured using provider names as the keys.
 
 - [`statsd`](#statsd)
@@ -167,7 +167,7 @@ global:
           - /path/to/frontend/server/CA/files
 ```
 
-Below is an additional example of a fully secured cluster using mutual TLS for both frontend and internode communication with manually specified CAs:
+Below is an additional example of a fully secured Temporal Service using mutual TLS for both frontend and internode communication with manually specified CAs:
 
 ```yaml
 global:
@@ -282,7 +282,7 @@ global:
 ## persistence
 
 The `persistence` section holds configuration for the data store/persistence layer.
-The following example shows a minimal specification for a password-secured Cluster using Cassandra.
+The following example shows a minimal specification for a password-secured Temporal Service using Cassandra.
 
 ```yaml
 persistence:
@@ -317,10 +317,10 @@ The following top level configuration items are required:
 
 ### numHistoryShards
 
-_Required_ - The number of history shards to create when initializing the Cluster.
+_Required_ - The number of history shards to create when initializing the Service.
 
 **Warning:** This value is immutable and will be ignored after the first run.
-Please ensure you set this value appropriately high enough to scale with the worst case peak load for this Cluster.
+Please ensure you set this value appropriately high enough to scale with the worst case peak load for this Service.
 
 ### defaultStore
 
@@ -328,11 +328,11 @@ _Required_ - The name of the data store definition that should be used by the Te
 
 ### visibilityStore
 
-_Required_ - The name of the primary data store definition that should be used to set up [Visibility](/temporal-service/visibility) on the Temporal Cluster.
+_Required_ - The name of the primary data store definition that should be used to set up [Visibility](/temporal-service/visibility) on the Temporal Service.
 
 ### secondaryVisibilityStore
 
-_Optional_ - The name of the secondary data store definition that should be used to set up [Dual Visibility](/dual-visibility) on the Temporal Cluster.
+_Optional_ - The name of the secondary data store definition that should be used to set up [Dual Visibility](/dual-visibility) on the Temporal Service.
 
 ### datastores
 
@@ -340,7 +340,7 @@ _Required_ - contains named data store definitions to be referenced.
 
 Each definition is defined with a heading declaring a name (ie: `default:` and `visibility:` above), which contains a data store definition.
 
-Data store definitions must be either `cassandra` or `sql`.
+Data store definitions must be one of `cassandra`, `sql`, `elasticsearch`, or `customDatastore`.
 
 #### cassandra
 
@@ -431,9 +431,10 @@ clusterMetadata:
 ## services
 
 The `services` section contains configuration keyed by service role type.
-There are four supported service roles:
+There are five supported service roles:
 
 - `frontend`
+- `internal-frontend`
 - `matching`
 - `worker`
 - `history`
@@ -458,9 +459,9 @@ _Required_
 `rpc` contains settings related to the way a service interacts with other services. The following values are supported:
 
 - `grpcPort`: Port on which gRPC will listen.
-- `membershipPort`: Port used to communicate with other hosts in the same Cluster for membership info.
+- `membershipPort`: Port used to communicate with other hosts in the same Service for membership info.
   Each service should use different port.
-  If there are multiple Temporal Clusters in your environment (Kubernetes for example), and they have network access to each other, each Cluster should use a different membership port.
+  If there are multiple Temporal Services in your environment (Kubernetes for example), and they have network access to each other, each Service should use a different membership port.
 - `bindOnLocalHost`: Determines whether uses `127.0.0.1` as the listener address.
 - `bindOnIP`: Used to bind service on specific IP, or `0.0.0.0`.
   Check `net.ParseIP` for supported syntax, only IPv4 is supported, mutually exclusive with `BindOnLocalHost` option.
@@ -469,7 +470,13 @@ _Required_
 
 ## publicClient
 
-The `publicClient` is a required section describing the configuration needed for a worker to connect to Temporal server for background server maintenance.
+_Optional_ - The `publicClient` section describes how internal nodes (History, Matching, Worker) connect to the Frontend Service. In many configurations you can leave this section out entirely:
+
+- Locate `internal-frontend` via membership and connect using internode TLS. Leave `publicClient` out of your config and add an `internal-frontend` role under [`services`](#services).
+- Locate `frontend` via membership and connect using Frontend TLS. Leave `publicClient` out of your config and don't add an `internal-frontend` role.
+- Connect to an explicit endpoint, bypassing membership, by setting `hostPort` below.
+
+Configuring both an `internal-frontend` role and a non-empty `publicClient` section is invalid; the Temporal Service refuses to start in that case.
 
 - `hostPort` IPv4 host port or DNS name to reach Temporal frontend, [reference](https://github.com/grpc/grpc/blob/master/doc/naming.md)
 
@@ -491,18 +498,18 @@ It can be enabled on `history` and `visibility` data.
 
 The following list describes supported values for each configuration on the `history` and `visibility` data.
 
-- `state`: State for Archival setting. Supported values are `enabled`, `disabled`. This value must be `enabled` to use Archival with any Namespace in your Cluster.
-  - `enabled`: Enables Archival in your Cluster setup. When set to `enabled`, `URI` and `namespaceDefaults` values must be provided.
-  - `disabled`: Disables Archival in your Cluster setup. When set to `disabled`, the `enableRead` value must be set to `false`, and under `namespaceDefaults`, `state` must be set to `disabled`, with no values set for `provider` and `URI` fields.
+- `state`: State for Archival setting. Supported values are `enabled`, `disabled`. This value must be `enabled` to use Archival with any Namespace in your Service.
+  - `enabled`: Enables Archival in your Service setup. When set to `enabled`, `URI` and `namespaceDefaults` values must be provided.
+  - `disabled`: Disables Archival in your Service setup. When set to `disabled`, the `enableRead` value must be set to `false`, and under `namespaceDefaults`, `state` must be set to `disabled`, with no values set for `provider` and `URI` fields.
 - `enableRead`: Supported values are `true` or `false`. Set to `true` to allow read operations from the archived Event History data.
 - `provider`: Location where data should be archived. Subprovider configs are `filestore`, `gstorage`, `s3`, or `your_custom_provider`. Default configuration specifies `filestore`.
 
 Example:
 
-- To enable Archival in your Cluster configuration:
+- To enable Archival in your Service configuration:
 
   ```yaml
-  # Cluster-level Archival config enabled
+  # Service-level Archival config enabled
   archival:
     # Event History configuration
     history:
@@ -527,10 +534,10 @@ Example:
           dirMode: '0766'
   ```
 
-- To disable Archival in your Cluster configuration:
+- To disable Archival in your Service configuration:
 
   ```yaml
-  # Cluster-level Archival config disabled
+  # Service-level Archival config disabled
   archival:
     history:
       state: 'disabled'
@@ -609,7 +616,7 @@ dcRedirectionPolicy:
 
 _Optional_
 
-Configuration for setting up file-based [dynamic configuration](/temporal-service/configuration#dynamic-configuration) client for the Cluster.
+Configuration for setting up file-based [dynamic configuration](/temporal-service/configuration#dynamic-configuration) client for the Service.
 
 This setting is required if specifying dynamic configuration. Supported configuration values are as follows:
 

--- a/docs/references/dynamic-configuration.mdx
+++ b/docs/references/dynamic-configuration.mdx
@@ -1,17 +1,17 @@
 ---
 id: dynamic-configuration
-title: Temporal Cluster dynamic configuration reference
+title: Temporal Service dynamic configuration reference
 sidebar_label: Dynamic configuration
-description: Temporal Cluster offers dynamic configuration keys that you can update on the fly to optimize performance without service interruption. Customize these settings to meet specific Workflow, Activity, Namespace, or Task Queue requirements, and test thoroughly before deploying to production. For more details, visit the Temporal GitHub repository.
+description: Temporal Service offers dynamic configuration keys that you can update on the fly to optimize performance without service interruption. Customize these settings to meet specific Workflow, Activity, Namespace, or Task Queue requirements, and test thoroughly before deploying to production. For more details, visit the Temporal GitHub repository.
 toc_max_heading_level: 4
 tags:
   - Reference
 ---
 
-Temporal Cluster provides [dynamic configuration](/temporal-service/configuration#dynamic-configuration) keys that you can update and apply to a running Cluster without restarting your services.
+Temporal Service provides [dynamic configuration](/temporal-service/configuration#dynamic-configuration) keys that you can update and apply to a running Service without restarting your services.
 
-The dynamic configuration keys are set with default values when you create your Cluster configuration.
-You can override these values as you test your Cluster setup for optimal performance according to your workload requirements.
+The dynamic configuration keys are set with default values when you create your Service configuration.
+You can override these values as you test your Service setup for optimal performance according to your workload requirements.
 
 For the complete list of dynamic configuration keys, see [https://github.com/temporalio/temporal/blob/main/common/dynamicconfig/constants.go](https://github.com/temporalio/temporal/blob/main/common/dynamicconfig/constants.go).
 Ensure that you check server release notes for any changes to these keys and values.
@@ -24,7 +24,7 @@ For the default values of dynamic configuration keys, check the following links:
 - [Worker Service](https://github.com/temporalio/temporal/blob/48dc5a95949ea0e555ce0f48e0031b54633fc703/service/worker/service.go#L185)
 
 Setting dynamic configuration is optional.
-Change these values only if you need to override the default values to achieve better performance on your Temporal Cluster.
+Change these values only if you need to override the default values to achieve better performance on your Temporal Service.
 Also, ensure that you test your changes before setting these in production.
 
 ## Format
@@ -63,12 +63,12 @@ testGetMapPropertyKey:
 ### Constraints
 
 You can define constraints on some dynamic configuration keys to set specific values that apply on a Namespace or Task Queue level.
-Not defining constraints on a dynamic configuration key sets the values across the Cluster.
+Not defining constraints on a dynamic configuration key sets the values across the Service.
 
 - To set global values for the configuration key with no constraints, use the following:
 
   ```yaml
-  frontend.globalNamespaceRPS: # Total per-Namespace RPC rate limit applied across the Cluster.
+  frontend.globalNamespaceRPS: # Total per-Namespace RPC rate limit applied across the Service.
     - value: 5000
   ```
 
@@ -127,17 +127,16 @@ For more examples on how dynamic configuration is set, see [samples-server](http
 
 ## Commonly used dynamic configuration keys
 
-The following table lists commonly used dynamic configuration keys that can be used for rate limiting requests to the Temporal Cluster.
+The following table lists commonly used dynamic configuration keys that can be used for rate limiting requests to the Temporal Service.
 
 Setting dynamic configuration keys is optional.
-If you choose to update these values for your Temporal Cluster, ensure that you are provisioning enough resources to handle the load.
+If you choose to update these values for your Temporal Service, ensure that you are provisioning enough resources to handle the load.
 
-All values listed here are for Temporal server v1.21.
-Check [server release notes](https://github.com/temporalio/temporal/releases) to verify any potential breaking changes when upgrading your versions.
+Check [server release notes](https://github.com/temporalio/temporal/releases) to verify any potential breaking changes when upgrading your versions — some keys below note the server version they apply to.
 
 ### Service-level RPS limits
 
-The Requests Per Second (RPS) dynamic configuration keys set the rate at which requests can be made to each service in your Cluster.
+The Requests Per Second (RPS) dynamic configuration keys set the rate at which requests can be made to each service in your Service.
 
 When scaling your services, tune the RPS to test your workload and set acceptable provisioning benchmarks.
 Exceeding these limits results in `ResourceExhaustedError`.
@@ -147,9 +146,9 @@ Exceeding these limits results in `ResourceExhaustedError`.
 | Frontend                               |      |                                                                                                                                                                                                                                                      |               |
 | `frontend.rps`                         | Int  | Rate limit (requests/second) for requests accepted by each Frontend Service host.                                                                                                                                                                    | 2400          |
 | `frontend.namespaceRPS`                | Int  | Rate limit (requests/second) for requests accepted by each Namespace on the Frontend Service.                                                                                                                                                        | 2400          |
-| `frontend.namespaceCount`              | Int  | Limit on the number of concurrent Task Queue polls per Namespace per Frontend Service host.                                                                                                                                                          | 1200          |
-| `frontend.globalNamespaceRPS`          | Int  | Rate limit (requests/second) for requests accepted per Namespace, applied across Cluster. The limit is evenly distributed among available Frontend Service instances. If this is set, it overrides the per-instance limit (`frontend.namespaceRPS`). | 0             |
-| `internal-frontend.globalNamespaceRPS` | Int  | Rate limit (requests/second) for requests accepted on each Internal-Frontend Service host applied across the Cluster.                                                                                                                                | 0             |
+| `frontend.namespaceCount`              | Int  | Limits concurrent long-running requests per Namespace per Frontend Service host, per API method. Example requests include long-poll requests and `Query` requests. Kept for backwards compatibility; the underlying setting is not specific to Task Queue polls. | 1200          |
+| `frontend.globalNamespaceRPS`          | Int  | Rate limit (requests/second) for requests accepted per Namespace, applied across the Service. The limit is evenly distributed among available Frontend Service instances. If this is set, it overrides the per-instance limit (`frontend.namespaceRPS`). | 0             |
+| `internal-frontend.globalNamespaceRPS` | Int  | Rate limit (requests/second) for requests accepted on each Internal-Frontend Service host applied across the Service.                                                                                                                                | 0             |
 | History                                |      |                                                                                                                                                                                                                                                      |               |
 | `history.rps`                          | Int  | Rate limit (requests/second) for requests accepted by each History Service host.                                                                                                                                                                     | 3000          |
 | Matching                               |      |                                                                                                                                                                                                                                                      |               |
@@ -174,10 +173,10 @@ If the number of queries made to the Persistence store exceeds the dynamic confi
 | `history.persistenceMaxQPS`               | Int  | Maximum number of queries per second that the History host can send to the Persistence store.                                                                                                                                                           | 9000          |
 | `history.persistenceNamespaceMaxQPS`      | Int  | Maximum number of queries per second for each Namespace that the History host can send to the Persistence store. <br /> If the value set for this config is less than or equal to 0, then the value set for `history.persistenceMaxQPS` will apply.     | 0             |
 | Matching                                  |      |                                                                                                                                                                                                                                                         |               |
-| `matching.persistenceMaxQPS`              | Int  | Maximum number of queries per second that the Matching Service host can send to the Persistence store.                                                                                                                                                  | 9000          |
+| `matching.persistenceMaxQPS`              | Int  | Maximum number of queries per second that the Matching Service host can send to the Persistence store.                                                                                                                                                  | 3000          |
 | `matching.persistenceNamespaceMaxQPS`     | Int  | Maximum number of queries per second that the Matching host can send to the Persistence store for each Namespace.<br /> If the value set for this config is less than or equal to 0, the value set for `matching.persistenceMaxQPS` will apply.         | 0             |
 | Worker                                    |      |                                                                                                                                                                                                                                                         |               |
-| `worker.persistenceMaxQPS`                | Int  | Maximum number of queries per second that the Worker Service host can send to the Persistence store.                                                                                                                                                    | 100           |
+| `worker.persistenceMaxQPS`                | Int  | Maximum number of queries per second that the Worker Service host can send to the Persistence store.                                                                                                                                                    | 500           |
 | `worker.persistenceNamespaceMaxQPS`       | Int  | Maximum number of queries per second that the Worker host can send to the Persistence store for each Namespace. <br /> If the value set for this config is less than or equal to 0, the value set for `worker.persistenceMaxQPS` will apply.            | 0             |
 | Visibility                                |      |                                                                                                                                                                                                                                                         |               |
 | `system.visibilityPersistenceMaxReadQPS`  | Int  | Maximum number queries per second that Visibility database can receive for read operations.                                                                                                                                                             | 9000          |
@@ -185,7 +184,7 @@ If the number of queries made to the Persistence store exceeds the dynamic confi
 
 ### Activity and Workflow default policy setting
 
-You can define default values for Activity and Workflow [Retry Policies](/encyclopedia/retry-policies) at the Cluster level with the following dynamic configuration keys.
+You can define default values for Activity and Workflow [Retry Policies](/encyclopedia/retry-policies) at the Service level with the following dynamic configuration keys.
 
 | Dynamic configuration key            | Type                          | Description                                                                                                       | Default value                                                                                   |
 | ------------------------------------ | ----------------------------- | ----------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
@@ -194,7 +193,7 @@ You can define default values for Activity and Workflow [Retry Policies](/encycl
 
 ### Size limit settings
 
-The Persistence store in the Cluster has default size limits set for optimal performance. The dynamic configuration keys relating to some of these are listed below.
+The Persistence store in the Service has default size limits set for optimal performance. The dynamic configuration keys relating to some of these are listed below.
 
 The default values on these keys are based on extensive testing.
 You can change these values, but ensure that you are provisioning enough database resources to handle the changed values.
@@ -219,7 +218,7 @@ For details on platform limits, see the [Temporal Platform limits sheet](/self-h
 
 ### Secondary visibility settings
 
-Secondary visibility configuration keys enable Dual Visibility on your Temporal Cluster.
+Secondary visibility configuration keys enable Dual Visibility on your Temporal Service.
 This can be useful when migrating a Visibility database or creating a backup Visibility store.
 
 | Dynamic configuration key                  | Type    | Description                                                                                                                                                                                                                                                                                                                                                                                                          | Default value |
@@ -244,6 +243,6 @@ For more detailed explanation of these configs see the [in-repo Nexus architectu
 | Dynamic configuration key                              | Type    | Description                                                                                                                                                                                                                                      | Default value       |
 | ------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- |
 | `system.enableNexus`                                   | Boolean | Enables Nexus Features. Removed in 1.31.0 (Nexus is always enabled).                                                                                                                                                                            | `true` (since 1.27) |
-| `component.nexusoperations.useSystemCallbackURL`       | String  | Controls whether to use temporal://system as the callback URL generated by the server. (Server 1.30 or newer)     											                                              | `false`             |
+| `component.nexusoperations.useSystemCallbackURL`       | Boolean | Controls whether to use temporal://system as the callback URL generated by the server. (Server 1.30 or newer)     											                                              | `true` (since 1.31.0; `false` on 1.30.x)             |
 | `component.nexusoperations.callback.endpoint.template` | String  | Defines the URL template used to construct Nexus callback URLs. (Only required for the experimental external endpoint target feature or servers older than 1.30.) 										      | unset               |
 | `component.callbacks.allowedAddresses`                 | Object  | Defines the security allow-list of callback URL patterns that the server will accept; used to restrict what callback endpoints can be invoked. (Only required for the experimental external endpoint target feature or servers older than 1.30.) | unset               |


### PR DESCRIPTION
## Summary
- `dynamic-configuration.mdx`: corrects `matching.persistenceMaxQPS` (9000 → 3000) and `worker.persistenceMaxQPS` (100 → 500) defaults, fixes `component.nexusoperations.useSystemCallbackURL`'s type (Boolean, not String) and default (`true` since v1.31.0), broadens `frontend.namespaceCount`'s description (it also gates long-poll/`Query` requests, not just Task Queue polls), and removes a blanket "all values are for v1.21" claim that contradicted the page's own version-gated Nexus settings a few sections later.
- `configuration.mdx`: fixes the datastore type list (`cassandra`/`sql`/`elasticsearch`/`customDatastore` — not just `cassandra`/`sql`, which contradicted the page's own example six lines above) and the `publicClient` section, which described it as required when it's actually optional and invalid to combine with an `internal-frontend` service role. Adds `internal-frontend` as a fifth service role.
- Both pages: replace "Temporal Cluster" with "Temporal Service" in titles, sidebar labels, and body prose, per current style guidance. Multi-Cluster Replication terminology and config/code identifiers (`clusterMetadata`, `remoteClusterAuth`, etc.) are left untouched.
- `monitoring.mdx`: updates a cross-reference's link text to match `configuration.mdx`'s new title.

Every value fix is verified directly against the `temporalio/temporal` source at the relevant tags/main (citations available on request).

## Test plan
- [x] `vale --config .vale-ci.ini` on both changed reference pages: 0 errors, 0 warnings
- [x] `yarn build`: passes, 0 broken links/anchors
- [x] `yarn check:orphans`: clean
- [x] Visually spot-checked the rendered `configuration.mdx` page (services/publicClient sections) against the built site