### PR TITLE
Fix accuracy issues in the Web UI reference pages

### DIFF
--- a/docs/references/web-ui-configuration.mdx
+++ b/docs/references/web-ui-configuration.mdx
@@ -2,7 +2,7 @@
 id: web-ui-configuration
 title: Temporal Web UI configuration reference
 sidebar_label: Web UI config
-description:  Manage your Temporal Server efficiently with development.yaml. Set parameters for Auth, TLS, ports, and more.
+description:  Manage your Temporal Web UI Server efficiently with development.yaml. Set parameters for Auth, TLS, ports, and more.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/web-ui-configuration.mdx
+++ b/docs/references/web-ui-configuration.mdx
@@ -17,7 +17,7 @@ Multiple configuration files can be created for configuring specific areas of th
 
 ## auth
 
-Configures authorization for the Temporal Server.
+Configures authorization for the Temporal Web UI Server — controlling who can access the Web UI itself, not authorization against the Temporal Service.
 Settings apply when Auth is enabled.
 
 ```yaml
@@ -62,7 +62,6 @@ codec:
   endpoint: http://your-codec-server-endpoint
   passAccessToken: false
   includeCredentials: false
-  decodeEventHistoryDownload: false
 ```
 
 ## cors
@@ -145,14 +144,6 @@ Hides any errors resulting from a Query to the Workflow.
 hideWorkflowQueryErrors: false
 ```
 
-## notifyOnNewVersion
-
-When enabled—that is, when set to `true`—a notification appears in the UI when a newer version of the [Temporal Server](/temporal-service/temporal-server) is available.
-
-```yaml
-notifyOnNewVersion: true
-```
-
 ## port
 
 The port used by the Temporal Web UI Server and any APIs.
@@ -199,7 +190,7 @@ temporalGrpcAddress: default
 
 ## tls
 
-Transport Layer Security (TLS) configuration for the Temporal Server.
+Transport Layer Security (TLS) configuration for the Web UI Server's outbound connection to the Temporal Service's frontend — not the Temporal Service's own listener.
 Settings apply when TLS is enabled.
 
 ```yaml

--- a/docs/references/web-ui-environment-variables.mdx
+++ b/docs/references/web-ui-environment-variables.mdx
@@ -4,7 +4,7 @@ title: Temporal Web UI environment variables reference
 sidebar_label: Web UI env vars
 description:
   Dynamically configure Temporal Web UI with environment variables in Docker for settings like TEMPORAL_ADDRESS,
-  authentication, TLS, OpenAPI, and more.
+  authentication, TLS, and more.
 toc_max_heading_level: 4
 tags:
   - Reference
@@ -53,7 +53,7 @@ described in more detail below.
 
 ## `TEMPORAL_ADDRESS`
 
-The [Frontend Service](/temporal-service/temporal-server#frontend-service) address for the Temporal Cluster. This
+The [Frontend Service](/temporal-service/temporal-server#frontend-service) address for the Temporal Service. This
 variable can be set [in the base configuration file](/references/web-ui-configuration#temporalgrpcaddress) using
 `temporalGrpcAddress`.
 
@@ -63,7 +63,7 @@ This variable is required for setting other environment variables.
 
 The port used by the Temporal WebUI Server and the HTTP API.
 
-This variable is needed for `TEMPORAL_OPENAPI_ENABLED` and all auth-related settings to work properly.
+This variable is needed for all auth-related settings to work properly.
 
 ## `TEMPORAL_UI_PUBLIC_PATH`
 
@@ -71,7 +71,7 @@ Stores a value such as "" or "/custom-path" that allows the UI to be served from
 
 ## `TEMPORAL_UI_ENABLED`
 
-Enables or disables the [browser UI](/references/web-ui-configuration#enableui) for the Temporal Cluster.
+Enables or disables the [browser UI](/references/web-ui-configuration#enableui) for the Temporal Service.
 
 Enabling the browser UI allows the Server to be accessed from your web browser. If disabled, the server cannot be viewed
 on the web, but the UI server APIs remain available for use.

--- a/docs/references/web-ui-environment-variables.mdx
+++ b/docs/references/web-ui-environment-variables.mdx
@@ -154,15 +154,17 @@ Specifies a set of scopes for auth. Typically, this is `openid`, `profile`, `ema
 
 The path for the Transport Layer Security (TLS) Certificate Authority file.
 
-In order to [configure TLS for your server](/references/web-ui-configuration#tls), you'll need a CA certificate issued
-by a trusted Certificate Authority. Set this variable to properly locate and use the file.
+In order to [configure TLS for the Web UI Server](/references/web-ui-configuration#tls), you'll need a CA certificate
+issued by a trusted Certificate Authority, used to verify the Temporal Service's Frontend when the Web UI Server
+connects to it. Set this variable to properly locate and use the file.
 
 ## `TEMPORAL_TLS_CERT`
 
 The path for the Transport Layer Security (TLS) Certificate.
 
-In order to [configure TLS for your server](/references/web-ui-configuration#tls), you'll need a self-signed
-certificate. Set the path to allow the environment to locate and use the certificate.
+In order to [configure TLS for the Web UI Server](/references/web-ui-configuration#tls), you'll need a self-signed
+certificate that identifies the Web UI Server as an mTLS client to the Temporal Service's Frontend. Set the path to
+allow the environment to locate and use the certificate.
 
 ## `TEMPORAL_TLS_KEY`
 


### PR DESCRIPTION
## Summary
- `web-ui-configuration.mdx`: fixes the `auth` section's description, which said it configures authorization for the Temporal Server when it actually controls who can access the Web UI itself. Fixes the `tls` section's description similarly — it's the Web UI Server's outbound connection to the Temporal Service's frontend, not the Temporal Service's own listener. Removes `notifyOnNewVersion` and `codec.decodeEventHistoryDownload`, both confirmed absent from current `temporalio/ui-server` source.
- `web-ui-environment-variables.mdx`: removes a dangling reference to `TEMPORAL_OPENAPI_ENABLED` (removed from `ui-server` about 19 months ago) and drops "OpenAPI" from the frontmatter description. Replaces "Temporal Cluster" with "Temporal Service" in body prose.

## Test plan
- [x] `vale --config .vale-ci.ini` on both changed pages: 0 errors, 0 warnings
- [x] `yarn build`: passes, 0 broken links/anchors