### PR TITLE
Fix accuracy issues in the Errors, Failures, and Events references

### DIFF
--- a/docs/references/errors.mdx
+++ b/docs/references/errors.mdx
@@ -12,7 +12,7 @@ This reference lists possible [Workflow Task](/tasks#workflow-task) errors and h
 
 > For other types of errors, see [Temporal Failures](/references/failures).
 
-Each of the below errors corresponds with a [WorkflowTaskFailedCause](https://api-docs.temporal.io/#temporal.api.enums.v1.WorkflowTaskFailedCause), which appears in [Events](/workflow-execution/event#event) under `workflow_task_failed_event_attributes`.
+Most of the below errors correspond to a [WorkflowTaskFailedCause](https://api-docs.temporal.io/#temporal.api.enums.v1.WorkflowTaskFailedCause), which appears in [Events](/workflow-execution/event#event) under `workflow_task_failed_event_attributes`. The Resource Exhausted Cause errors are the exception: they correspond to a separate `ResourceExhaustedCause` value carried on a gRPC `RESOURCE_EXHAUSTED` response, not a Workflow Task failure event.
 
 ## Bad Cancel Timer Attributes {/* #bad-cancel-timer-attributes */}
 
@@ -89,7 +89,7 @@ A Child Workflow cannot perform both actions in the same Workflow Task.
 
 ## Bad Schedule Activity Attributes {/* #bad-schedule-activity-attributes */}
 
-This error indicates unset or invalid attributes for [`ScheduleActivityTask`](/references/commands#scheduleactivitytask) or [`CompleteWorkflowExecution`](/references/commands#completeworkflowexecution).
+This error indicates unset or invalid attributes for [`ScheduleActivityTask`](/references/commands#scheduleactivitytask).
 
 Reset any unset or empty attributes.
 Adjust the size of the received payload to stay within the given size limit.
@@ -147,9 +147,9 @@ This error indicates that the [Worker](/workers) deployment returned a bad binar
 
 {/* TODO: add link to Workflow Update page when written */}
 
-This error indicates that a [Workflow Execution](/workflow-execution) tried to complete before receiving an Update.
+This error indicates that a Workflow Update message (Acceptance, Rejection, or Response) has an invalid format or is missing required fields.
 
-`BadUpdate` can happen when a [Worker](/workers#worker) generates a [Workflow Task Completed](/references/events#workflowtaskcompleted) message with missing fields or an invalid Update response format.
+`WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE` can happen when a [Worker](/workers#worker) generates a malformed Update message.
 
 This error might indicate usage of an unsupported SDK.
 Make sure you're using a [supported SDK](/encyclopedia/architecture/temporal-sdks).

--- a/docs/references/events.mdx
+++ b/docs/references/events.mdx
@@ -359,7 +359,7 @@ This [Event](/workflow-execution/event#event) type indicates that a [Workflow](/
 | Field                            | Description                                                                                     |
 | -------------------------------- | ----------------------------------------------------------------------------------------------- |
 | workflow_task_completed_event_id | The Id of the [WorkflowTaskCompleted](#workflowtaskcompleted) that the Event was reported with. |
-| namespace                        | [Namespace](/namespaces) of the Workflow that`s going to be signaled for execution.             |
+| namespace                        | [Namespace](/namespaces) of the Workflow that's going to be signaled for execution.             |
 | workflow_execution               | Identifies the Workflow and the run of the [Workflow Execution](/workflow-execution).           |
 | child_workflow_only              | Set to true if this Workflow is a child of the Workflow which issued the cancelation request.   |
 | reason                           | Information provided by the user or client for Workflow cancelation.                            |
@@ -374,7 +374,7 @@ This is usually because the target Workflow could not be found.
 | workflow_task_completed_event_id | The Id of the [WorkflowTaskCompleted](#workflowtaskcompleted) that the Event was reported with. |
 | namespace                        | [Namespace](/namespaces) of the Workflow that failed to cancel.                                 |
 | workflow_execution               | Identifies the Workflow and the run of the [Workflow Execution](/workflow-execution).           |
-| initiated_event_id               | Id of the [RequestCancelExternalWorkflowExecutionInitiated] Event this failure corresponds to.  |
+| initiated_event_id               | Id of the [RequestCancelExternalWorkflowExecutionInitiated](#requestcancelexternalworkflowexecutioninitiated) Event this failure corresponds to.  |
 
 ### ExternalWorkflowExecutionCancelRequested
 
@@ -492,7 +492,7 @@ This would also cause the [WorkflowExecutionCanceled](#workflowexecutioncanceled
 ### ChildWorkflowExecutionTimedOut
 
 This Event type indicates that the [Child Workflow Execution](/child-workflows) has timed out by the [Temporal Server](/temporal-service/temporal-server).
-This would also cause the [WorkflowExecutionTimeOut](#workflowexecutiontimedout) to be recorded for the Workflow that timed out.
+This would also cause the [WorkflowExecutionTimedOut](#workflowexecutiontimedout) to be recorded for the Workflow that timed out.
 
 | Field              | Description                                                                                                              |
 | ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
@@ -578,7 +578,7 @@ This [Event](/workflow-execution/event#event) type indicates that a [Workflow Ex
 
 This Event type indicates that a Nexus Operation scheduled by a caller Workflow.
 The caller's [Nexus Machinery](/glossary#nexus-machinery) will attempt to start the Nexus Operation.
-This Event type contains Nexus Operation input and the Operation request ID.
+This Event type contains Nexus Operation input and the Operation request Id.
 
 | Field                            | Description                                                                                                                                                                                                                                                                                               |
 | :------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -588,9 +588,9 @@ This Event type contains Nexus Operation input and the Operation request ID.
 | input                            | Input for the operation. The server converts this into Nexus request content and the appropriate content headers internally when sending the StartOperation request. On the handler side, if it is also backed by Temporal, the content is transformed back to the original Payload stored in this event. |
 | schedule_to_close_timeout        | Schedule-to-close timeout for this operation. Indicates how long the caller is willing to wait for operation completion. Calls are retried internally by the server.                                                                                                                                      |
 | nexus_header                     | Header to attach to the Nexus request. Note these headers are not the same as Temporal headers on internal activities and child Workflows, these are transmitted to Nexus operations that may be external and are not traditional payloads.                                                               |
-| workflow_task_completed_event_id | The ID of the [WorkflowTaskCompleted](#workflowtaskcompleted) event that the corresponding ScheduleNexusOperation command was reported with.                                                                                                                                                              |
-| request_id                       | A unique ID generated by the History Service upon creation of this event. The ID will be transmitted with all Nexus StartOperation requests and is used as an idempotency key.                                                                                                                            |
-| endpoint_id                      | Endpoint ID as resolved in the endpoint registry at the time this event was generated. This is stored on the event and used internally by the server in case the endpoint is renamed from the time the event was originally scheduled.                                                                    |
+| workflow_task_completed_event_id | The Id of the [WorkflowTaskCompleted](#workflowtaskcompleted) event that the corresponding ScheduleNexusOperation command was reported with.                                                                                                                                                              |
+| request_id                       | A unique Id generated by the History Service upon creation of this event. The Id will be transmitted with all Nexus StartOperation requests and is used as an idempotency key.                                                                                                                            |
+| endpoint_id                      | Endpoint Id as resolved in the endpoint registry at the time this event was generated. This is stored on the event and used internally by the server in case the endpoint is renamed from the time the event was originally scheduled.                                                                    |
 
 ### NexusOperationStarted
 
@@ -600,9 +600,9 @@ The Event is not added to the caller's Event History for Synchronous Nexus Opera
 
 | Field              | Description                                                                                                                                       |
 | :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------ |
-| scheduled_event_id | The ID of the [NexusOperationScheduled](#nexusoperationscheduled) event this task corresponds to.                                                 |
+| scheduled_event_id | The Id of the [NexusOperationScheduled](#nexusoperationscheduled) event this task corresponds to.                                                 |
 | operation_token    | The operation token returned by the Nexus handler in the response to the StartOperation request. This token is used when canceling the operation. |
-| request_id         | The request ID allocated at schedule time.                                                                                                        |
+| request_id         | The request Id allocated at schedule time.                                                                                                        |
 
 ### NexusOperationCompleted
 
@@ -612,9 +612,9 @@ This Event type contains Nexus Operation results.
 
 | Field              | Description                                                                                                                                                          |
 | :----------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| scheduled_event_id | The ID of the [NexusOperationScheduled](#nexusoperationscheduled) event. Uniquely identifies this operation.                                                         |
+| scheduled_event_id | The Id of the [NexusOperationScheduled](#nexusoperationscheduled) event. Uniquely identifies this operation.                                                         |
 | result             | Serialized result of the Nexus operation. The response of the Nexus handler. Delivered either via a completion callback or as a response to a synchronous operation. |
-| request_id         | The request ID allocated at schedule time.                                                                                                                           |
+| request_id         | The request Id allocated at schedule time.                                                                                                                           |
 
 ### NexusOperationFailed
 
@@ -626,32 +626,35 @@ This Event type contains a Nexus Operation failure.
 
 | Field              | Description                                                                                                   |
 | :----------------- | :------------------------------------------------------------------------------------------------------------ |
-| scheduled_event_id | The ID of the [NexusOperationScheduled](#nexusoperationscheduled)` event. Uniquely identifies this operation. |
+| scheduled_event_id | The Id of the [NexusOperationScheduled](#nexusoperationscheduled) event. Uniquely identifies this operation. |
 | failure            | Failure details. A NexusOperationFailureInfo wrapping an ApplicationFailureInfo.                              |
-| request_id         | The request ID allocated at schedule time.                                                                    |
+| request_id         | The request Id allocated at schedule time.                                                                    |
 
 ### NexusOperationTimedOut
 
 This Event type indicates that a Nexus Operation has timed out according to the Temporal Server, due to one of these Nexus Operation timeouts: Schedule-to-Close Timeout.
+
 | Field | Description |
 | :---- | :---- |
-| scheduled_event_id | The ID of the [NexusOperationScheduled](#nexusoperationscheduled)` event. Uniquely identifies this operation. |
+| scheduled_event_id | The Id of the [NexusOperationScheduled](#nexusoperationscheduled) event. Uniquely identifies this operation. |
 | failure | Failure details. A NexusOperationFailureInfo wrapping a CanceledFailureInfo. |
-| request_id | The request ID allocated at schedule time. |
+| request_id | The request Id allocated at schedule time. |
 
 ### NexusOperationCancelRequested
 
 This Event type indicates that the Workflow that scheduled a Nexus Operation requested to cancel it.
+
 | Field | Description |
 | :---- | :---- |
-| scheduled_event_id | The id of the [NexusOperationScheduled](#nexusoperationscheduled)` event this cancel request corresponds to. |
-| workflow_task_completed_event_id | The [WorkflowTaskCompleted](#workflowtaskcompleted) event that the corresponding RequestCancelNexusOperation command was reported with. |
+| scheduled_event_id | The Id of the [NexusOperationScheduled](#nexusoperationscheduled) event this cancel request corresponds to. |
+| workflow_task_completed_event_id | The Id of the [WorkflowTaskCompleted](#workflowtaskcompleted) event that the corresponding RequestCancelNexusOperation command was reported with. |
 
 ### NexusOperationCanceled
 
 This Event type indicates that a Nexus Operation has resolved as canceled.
+
 | Field | Description |
 | :---- | :---- |
-| scheduled_event_id | The ID of the [NexusOperationScheduled](#nexusoperationscheduled)` event. Uniquely identifies this operation. |
+| scheduled_event_id | The Id of the [NexusOperationScheduled](#nexusoperationscheduled) event. Uniquely identifies this operation. |
 | failure | Cancellation details. |
-| request_id | The request ID allocated at schedule time. |
+| request_id | The request Id allocated at schedule time. |

--- a/docs/references/failures.mdx
+++ b/docs/references/failures.mdx
@@ -99,7 +99,7 @@ By default, errors are considered retryable, unless specified below:
 
 - Non retryable Application Failures
 - Unsuccessful Operation errors that can resolve an operation as either failed or canceled
-- [Handler errors](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors) with the following types: `BAD_REQUEST`, `UNAUTHENTICATED`, `UNAUTHORIZED`, `NOT_FOUND`, and `RESOURCE_EXHAUSTED`
+- [Handler errors](https://github.com/nexus-rpc/api/blob/main/SPEC.md#predefined-handler-errors) with the following types: `BAD_REQUEST`, `UNAUTHENTICATED`, `UNAUTHORIZED`, `NOT_FOUND`, and `NOT_IMPLEMENTED`
 
 #### Nexus Operation Task Failures
 
@@ -201,7 +201,6 @@ For example the Nexus Go SDK provides
 | :-------------------------------- | :-------------- |
 | HandlerErrorTypeResourceExhausted | false           |
 | HandlerErrorTypeInternal          | false           |
-| HandlerErrorTypeNotImplemented    | false           |
 | HandlerErrorTypeUnavailable       | false           |
 
 #### Non-retryable Nexus errors
@@ -212,6 +211,7 @@ For example the Nexus Go SDK provides
 | HandlerErrorTypeUnauthenticated | true            |
 | HandlerErrorTypeUnauthorized    | true            |
 | HandlerErrorTypeNotFound        | true            |
+| HandlerErrorTypeNotImplemented  | true            |
 | UnsuccessfulOperationError      | true            |
 
 ## Cancelled Failure


### PR DESCRIPTION
## Summary
- `errors.mdx`: clarifies that the five "Resource Exhausted Cause" errors are a separate `ResourceExhaustedCause` enum carried on gRPC `RESOURCE_EXHAUSTED` responses, not `WorkflowTaskFailedCause` values as the intro claimed. Fixes the Bad Update section's identifier and description to match the real cause (a malformed Update message, not "completed before receiving an Update"). Removes an incorrect `CompleteWorkflowExecution` reference from Bad Schedule Activity Attributes (that cause is specific to `ScheduleActivityTask`).
- `failures.mdx`: fixes Nexus handler error retryability, which had `RESOURCE_EXHAUSTED` and `NOT_IMPLEMENTED` swapped relative to the nexus-rpc spec this page itself links to (`RESOURCE_EXHAUSTED` is retryable, `NOT_IMPLEMENTED` is not).
- `events.mdx`: fixes a cluster of mechanical bugs confined to the Nexus Operation block — "ID" reverted to "Id" to match the rest of the page, four stray trailing backticks after Markdown links, a broken link missing its anchor, a mislabeled cross-reference (`WorkflowExecutionTimeOut` → `WorkflowExecutionTimedOut`), a backtick used as an apostrophe, and three tables that were missing the blank line Markdown needs to render them as tables at all (they were rendering as plain text).

## Test plan
- [x] `vale --config .vale-ci.ini` on all three pages: 0 errors, 0 warnings
- [x] `yarn build`: passes, 0 broken links/anchors
- [x] Verified in the browser against the built site that the three previously-broken Nexus tables in `events.mdx` now render as real tables, and the broken-link/cross-reference fixes display correctly