### PR TITLE
Fix small accuracy issues in Commands, Server options, and other references

### DIFF
--- a/docs/develop/go/platform/observability.mdx
+++ b/docs/develop/go/platform/observability.mdx
@@ -49,7 +49,7 @@ client.Options{
 }
 ```
 
-The Go SDK provides metrics handlers for [Tally](https://pkg.go.dev/go.temporal.io/sdk/contrib/tally) and [OpenTelemetry](https://pkg.go.dev/go.temporal.io/sdk/contrib/opentelemetry). Tally offers [extensible custom metrics reporting](https://github.com/uber-go/tally#report-your-metrics), which is exposed through the [`WithCustomMetricsReporter`](/references/server-options#withcustommetricsreporter) API.
+The Go SDK provides metrics handlers for [Tally](https://pkg.go.dev/go.temporal.io/sdk/contrib/tally) and [OpenTelemetry](https://pkg.go.dev/go.temporal.io/sdk/contrib/opentelemetry). Tally offers [extensible custom metrics reporting](https://github.com/uber-go/tally#report-your-metrics), which is exposed through the [`WithCustomMetricsHandler`](/references/server-options#withcustommetricshandler) API.
 
 For more information, see the [Go sample for metrics](https://github.com/temporalio/samples-go/tree/main/metrics).
 

--- a/docs/production-deployment/self-hosted-guide/security.mdx
+++ b/docs/production-deployment/self-hosted-guide/security.mdx
@@ -409,8 +409,8 @@ temporalServer, err := temporal.NewServer(
     temporal.WithClaimMapper(func(cfg *config.Config) authorization.ClaimMapper {
         logger := getYourLogger()
         return authorization.NewDefaultJWTClaimMapper(
-            authorization.NewDefaultTokenKeyProvider(cfg, logger),
-            cfg,
+            authorization.NewDefaultTokenKeyProvider(&cfg.Global.Authorization, logger),
+            &cfg.Global.Authorization,
             logger,
         )
     }),

--- a/docs/references/client-environment-configuration.mdx
+++ b/docs/references/client-environment-configuration.mdx
@@ -72,8 +72,8 @@ API key for authentication. When set, TLS is enabled by default.
 
 ### `TEMPORAL_CLIENT_AUTHORITY`
 
-Overrides the `:authority` gRPC header. This is a Go SDK extension with no equivalent in other clients and no CLI flag
-of its own.
+Overrides the `:authority` gRPC header. This is a Go SDK extension with no equivalent in other clients. The CLI has a
+global `--client-authority` flag, but it isn't wired into this environment variable/TOML config mechanism.
 
 - TOML key: `profile.<name>.authority`
 - CLI flag: none

--- a/docs/references/commands.mdx
+++ b/docs/references/commands.mdx
@@ -69,7 +69,7 @@ This Command is triggered by a call to request cancellation of another Workflow 
 - Awaitable: Yes, a Workflow Execution can await on the action resulting from this Command.
 - Corresponding Event: [RequestCancelExternalWorkflowExecutionInitiated](/references/events#requestcancelexternalworkflowexecutioninitiated)
 
-By default, you cannot have more than 2,000 pending Signals to other Workflows.
+By default, you cannot have more than 2,000 pending Cancellation Requests to other Workflows.
 
 ### ScheduleActivityTask
 
@@ -131,7 +131,7 @@ This Command is triggered by a call to execute a Nexus Operation in the caller W
 
 By default, you can't schedule more than 30 Nexus Operations concurrently, see [Limits](/workflow-execution/limits#workflow-execution-nexus-operation-limits) for details.
 
-### CancelNexusOperation
+### RequestCancelNexusOperation
 
 This Command is triggered by a call to request the cancellation of a Nexus Operation.
 

--- a/docs/references/operation-list.mdx
+++ b/docs/references/operation-list.mdx
@@ -14,7 +14,9 @@ import { OperationsTable } from '@site/src/components';
 
 # Operations
 
-Temporal Cloud [rate limits operations per second (OPS)](/cloud/limits#operations-per-second) per namespace. An operation is anything 1. a user does directly, or 2. Temporal does on behalf of the user in the background that results in load on Temporal Server. The exception is visibility queries: they do hit the Server (the query is passed from the server to the visibility store), but primarily the load is on the visibility system. Visibility rate limits are separate from OPS rate limits.
+Temporal Cloud rate limits Namespaces using three related measures. [Actions per second (APS)](/cloud/actions) is the primary limit and the one [Capacity Modes](/cloud/capacity-modes) are expressed in; Requests per second (RPS) and [operations per second (OPS)](/cloud/limits#operations-per-second) are lower-level measures that protect the underlying services. This page covers OPS specifically.
+
+An operation is anything 1. a user does directly, or 2. Temporal does on behalf of the user in the background that results in load on Temporal Server. The exception is visibility queries: they do hit the Server (the query is passed from the server to the visibility store), but primarily the load is on the visibility system. Visibility rate limits are separate from OPS rate limits.
 
 Below is the list of operations, including:
 - operation name

--- a/docs/references/server-options.mdx
+++ b/docs/references/server-options.mdx
@@ -58,7 +58,7 @@ The default can be used from the `go.temporal.io/server/temporal` package.
 
 ```go
 s, err := temporal.NewServer(
-    temporal.ForServices(temporal.Services),
+    temporal.ForServices(temporal.DefaultServices),
 )
 ```
 
@@ -107,8 +107,9 @@ s, err := temporal.NewServer(
   temporal.WithClaimMapper(func(cfg *config.Config) authorization.ClaimMapper {
       logger := getYourLogger() // Replace with how you retrieve or initialize your logger
     return authorization.NewDefaultJWTClaimMapper(
-      authorization.NewDefaultTokenKeyProvider(cfg, logger),
-      cfg
+      authorization.NewDefaultTokenKeyProvider(&cfg.Global.Authorization, logger),
+      &cfg.Global.Authorization,
+      logger,
     )
   }),
 )
@@ -125,14 +126,12 @@ s, err := temporal.NewServer(
 )
 ```
 
-### WithCustomMetricsReporter
+### WithCustomMetricsHandler
 
-Sets a custom tally metric reporter.
+Sets a custom implementation of the `metrics.Handler` interface for publishing metric events.
 
 ```go
 s, err := temporal.NewServer(
-    temporal.WithCustomMetricsReporter(myReporter),
+    temporal.WithCustomMetricsHandler(myHandler),
 )
 ```
-
-You can see the [Uber tally docs on custom reporter](https://github.com/uber-go/tally#report-your-metrics) and see a community implementation of [a reporter for Datadog's `dogstatsd` format](https://github.com/temporalio/temporal/pull/998#issuecomment-857884983).


### PR DESCRIPTION
## Summary
- `commands.mdx`: renames the `CancelNexusOperation` heading to `RequestCancelNexusOperation`, matching the real Command name and the page's own naming convention (`events.mdx` already used the correct name). Fixes a copy-pasted limit description under `RequestCancelExternalWorkflowExecution` — that Command is governed by the pending Cancellation Requests limit, not pending Signals.
- `server-options.mdx`: `WithCustomMetricsReporter` → `WithCustomMetricsHandler` (the correct name since server v1.19.0); fixes the `WithClaimMapper` code sample, which passed the wrong argument count and type to `NewDefaultJWTClaimMapper`/`NewDefaultTokenKeyProvider` and declared an unused `logger` variable; `temporal.Services` → `temporal.DefaultServices` in the `ForServices` example, matching the page's own description of "the default."
- `client-environment-configuration.mdx`: softens an overstated claim that the CLI has "no CLI flag of its own" for `TEMPORAL_CLIENT_AUTHORITY` — the CLI does have a global `--client-authority` flag, it's just not wired into this particular config/env-var mechanism.
- `operation-list.mdx`: adds the current Actions-Per-Second-primary framing for Temporal Cloud rate limiting (APS/RPS/OPS), linking to `/cloud/actions` and `/cloud/capacity-modes`, since the page previously described OPS in isolation.
- `observability.mdx` (Go dev guide): updates a cross-reference broken by the `WithCustomMetricsReporter` → `WithCustomMetricsHandler` rename above.

Every fix verified directly against the `temporalio/temporal`, `temporalio/api`, and `temporalio/cli` source.

## Test plan
- [x] `vale --config .vale-ci.ini` on all changed pages: 0 errors, 0 warnings
- [x] `yarn build`: passes, 0 broken links/anchors