### PR TITLE
Document the batch Project access audit operations

### DIFF
--- a/docs/cloud/audit-logs.mdx
+++ b/docs/cloud/audit-logs.mdx
@@ -75,8 +75,11 @@ The `operation` field can contain the following event values:
   - `CreateProject`: Create Project
   - `DeleteProject`: Delete Project
   - `SetServiceAccountProjectAccess`: Set Service Account Project Access
+  - `SetServiceAccountProjectAccesses`: Set Service Account Project Accesses
   - `SetUserGroupProjectAccess`: Set User Group Project Access
+  - `SetUserGroupProjectAccesses`: Set User Group Project Accesses
   - `SetUserProjectAccess`: Set User Project Access
+  - `SetUserProjectAccesses`: Set User Project Accesses
   - `UpdateProject`: Update Project
 - Security
   - `SecretFound`: Detect Exposed API Key


### PR DESCRIPTION
## What does this PR do?

Adds the three batch Project access operations to the Audit Logs event reference: `SetUserProjectAccesses`, `SetServiceAccountProjectAccesses`, and `SetUserGroupProjectAccesses`.

## Notes to reviewers

Follow-on to #5194.

One thing worth your judgment: unlike the singular operations already listed, these three RPCs are UI-only — they are not part of the public Cloud Ops API, so customers cannot call them directly. They are emitted when someone changes Project access in bulk through the Cloud UI, and they do land in customer audit logs, so the `operation` value is visible to anyone reading or filtering their log. That is why I think they belong here. They would be the first UI-only operations in this list, so if you would rather scope the page to publicly callable APIs, I am happy to close this.

Operation values were compared character-for-character against the Control Plane's enabled audit operations. I wasn't able to run `vale` or `yarn build` locally, so I'm relying on CI for those.
