### PR TITLE
Fix stale og:image URLs across Vercel preview/production environments

### DIFF
--- a/bin/validate-og-images.js
+++ b/bin/validate-og-images.js
@@ -16,14 +16,14 @@
 // pages, etc.) still falls back to the site-wide default, which remains the
 // Phase 1 regression floor for everything outside the plugin's reach.
 //
-// Generated-image expectations resolve against config.url directly. The
-// image path now comes from real front matter (injected by
-// plugins/og-image/remarkPlugin.js during MDX compilation) and is rendered
-// by Docusaurus's own metadata pipeline, which always resolves relative
-// image paths against config.url — there's no VERCEL_URL-based override for
-// preview deployments anymore (a known, accepted limitation of moving off
-// the old postBuild HTML-patch approach; see plugins/og-image/remarkPlugin.js
-// for why that approach had to change).
+// Generated-image expectations use ogImagePlugin.resolveImageOrigin(),
+// which substitutes VERCEL_URL on non-production Vercel deployments — see
+// the comment on that function in plugins/og-image/shared.js. The image
+// path itself comes from real front matter (injected by
+// plugins/og-image/remarkPlugin.js during MDX compilation, as a full
+// absolute URL for exactly this reason) and is rendered by Docusaurus's own
+// metadata pipeline, which leaves an already-absolute image URL untouched
+// rather than re-resolving it against config.url.
 
 const fs = require('fs');
 const path = require('path');
@@ -122,7 +122,7 @@ async function main() {
       const hash = ogImagePlugin.hashFor(title, description, footerText);
       const expectedImage = new URL(
         path.posix.join(config.baseUrl, 'img/og', `${hash}.${ogImagePlugin.IMAGE_EXTENSION}`),
-        config.url,
+        ogImagePlugin.resolveImageOrigin(),
       ).toString();
       const expectedImagePath = path.join(BUILD_DIR, 'img', 'og', `${hash}.${ogImagePlugin.IMAGE_EXTENSION}`);
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -504,7 +504,34 @@ module.exports = async function createConfigAsync() {
     themes: ['@docusaurus/theme-mermaid'],
     future: {
       v4: true,
-      faster: true,
+      // `faster: true` turns on every Faster flag (SWC loader/minifier,
+      // lightningcss, rspack, mdxCrossCompilerCache, worker threads, eager
+      // VCS) at once. rspackPersistentCache is carved out and forced off:
+      // Vercel restores node_modules/** (including rspack's persistent
+      // cache) between builds, keyed in part by git branch — a brand-new
+      // preview branch's first build inherits the *last production
+      // deployment's* cache. Since plugins/og-image/remarkPlugin.js bakes
+      // an environment-dependent absolute og:image URL into each page's
+      // compiled front matter (see resolveImageOrigin() in
+      // plugins/og-image/shared.js), and that persistent cache's key
+      // doesn't account for VERCEL_ENV/VERCEL_URL, an unchanged page could
+      // silently keep serving a stale environment's resolved URL baked in
+      // at a previous build. Every other Faster flag is content-hash-keyed
+      // in a way that's safe to cache across environments; only this one
+      // needed to go. Confirmed empirically: two back-to-back local builds
+      // with different VERCEL_ENV/VERCEL_URL only picked up the new value
+      // once node_modules/.cache/rspack and .docusaurus were cleared.
+      faster: {
+        swcJsLoader: true,
+        swcJsMinimizer: true,
+        swcHtmlMinimizer: true,
+        lightningCssMinimizer: true,
+        mdxCrossCompilerCache: true,
+        rspackBundler: true,
+        rspackPersistentCache: false,
+        ssgWorkerThreads: true,
+        gitEagerVcs: true,
+      },
     },
   };
 

--- a/plugins/og-image/constants.js
+++ b/plugins/og-image/constants.js
@@ -15,4 +15,11 @@ const IMAGE_EXTENSION = 'jpg';
 // routeBasePath wherever a target is configured — see docusaurus.config.js.
 const DEFAULT_FOOTER_TEXT = 'DOCS.TEMPORAL.IO';
 
-module.exports = { TEMPLATE_VERSION, IMAGE_EXTENSION, DEFAULT_FOOTER_TEXT };
+// Matches docusaurus.config.js's `url`. Kept as its own literal rather than
+// importing that config module: this constant only needs the production
+// origin for og:image URLs, not the rest of the site config, and
+// docusaurus.config.js already pulls in enough of this plugin's tree that
+// requiring it back from here risks a cycle.
+const PRODUCTION_SITE_URL = 'https://docs.temporal.io';
+
+module.exports = { TEMPLATE_VERSION, IMAGE_EXTENSION, DEFAULT_FOOTER_TEXT, PRODUCTION_SITE_URL };

--- a/plugins/og-image/index.js
+++ b/plugins/og-image/index.js
@@ -3,7 +3,15 @@ const path = require('path');
 const matter = require('gray-matter');
 const { renderCard } = require('./render');
 const { walkDir, resolveUrlPath } = require('../shared/docsRouting');
-const { extractTitle, hasManualOverride, overrideImageFor, hashFor, IMAGE_EXTENSION, DEFAULT_FOOTER_TEXT } = require('./shared');
+const {
+  extractTitle,
+  hasManualOverride,
+  overrideImageFor,
+  hashFor,
+  resolveImageOrigin,
+  IMAGE_EXTENSION,
+  DEFAULT_FOOTER_TEXT,
+} = require('./shared');
 
 const CACHE_DIR = path.join(__dirname, '../../node_modules/.cache/og-images');
 
@@ -130,6 +138,7 @@ ogImagePlugin.extractTitle = extractTitle;
 ogImagePlugin.hashFor = hashFor;
 ogImagePlugin.hasManualOverride = hasManualOverride;
 ogImagePlugin.overrideImageFor = overrideImageFor;
+ogImagePlugin.resolveImageOrigin = resolveImageOrigin;
 ogImagePlugin.IMAGE_EXTENSION = IMAGE_EXTENSION;
 
 module.exports = ogImagePlugin;

--- a/plugins/og-image/remarkPlugin.js
+++ b/plugins/og-image/remarkPlugin.js
@@ -1,5 +1,13 @@
 const path = require('path');
-const { extractTitle, hasManualOverride, hashFor, stripFrontmatter, IMAGE_EXTENSION, DEFAULT_FOOTER_TEXT } = require('./shared');
+const {
+  extractTitle,
+  hasManualOverride,
+  hashFor,
+  resolveImageOrigin,
+  stripFrontmatter,
+  IMAGE_EXTENSION,
+  DEFAULT_FOOTER_TEXT,
+} = require('./shared');
 
 // This is what actually makes the generated og:image survive client-side
 // hydration. The previous approach patched og:image/twitter:image directly
@@ -15,10 +23,20 @@ const { extractTitle, hasManualOverride, hashFor, stripFrontmatter, IMAGE_EXTENS
 // component already renders correctly through both SSR and hydration (it's
 // the same mechanism a page uses to manually opt out — see
 // hasManualOverride below). So instead of patching HTML after the fact, this
-// injects that same front-matter field with the path the generated card
-// will actually be written to (by plugins/og-image/index.js's postBuild),
-// early enough — during MDX compilation — that it becomes genuine front
-// matter data. Docusaurus then renders it itself, identically, every time.
+// injects that same front-matter field with the URL the generated card will
+// actually be written to (by plugins/og-image/index.js's postBuild), early
+// enough — during MDX compilation — that it becomes genuine front matter
+// data. Docusaurus then renders it itself, identically, every time.
+//
+// The value is a full absolute URL (via resolveImageOrigin), not a
+// site-relative path — Docusaurus's own image-metadata resolution
+// (addBaseUrl in @docusaurus/core) leaves any URL that already has a
+// protocol untouched, so an absolute URL here is what actually reaches the
+// rendered og:image/twitter:image tags. A relative path would instead get
+// resolved against docusaurus.config.js's siteConfig.url, which is always
+// the production domain — on a Vercel preview build that would point
+// social-share scrapers at an image that only exists on this deployment,
+// not at docs.temporal.io.
 //
 // Registered in docusaurus.config.js's docs preset `remarkPlugins` (and, with
 // a `footerText` override, on the ai-cookbook docs plugin instance's own
@@ -51,7 +69,7 @@ function ogImageRemarkPlugin(options = {}) {
     // Mutating in place, not reassigning file.data.frontMatter — the mdx
     // loader holds the same object reference and serializes it into the
     // compiled module's `export const frontMatter = {...}` after this runs.
-    frontMatter.image = `/img/og/${hash}.${IMAGE_EXTENSION}`;
+    frontMatter.image = `${resolveImageOrigin()}/img/og/${hash}.${IMAGE_EXTENSION}`;
   };
 }
 

--- a/plugins/og-image/remarkPlugin.test.js
+++ b/plugins/og-image/remarkPlugin.test.js
@@ -14,23 +14,58 @@ function runTransform({ frontMatter, value, path: filePath = '/docs/example.mdx'
 
 describe('ogImageRemarkPlugin', () => {
   let originalNodeEnv;
+  let originalVercelEnv;
+  let originalVercelUrl;
 
   beforeEach(() => {
     originalNodeEnv = process.env.NODE_ENV;
+    originalVercelEnv = process.env.VERCEL_ENV;
+    originalVercelUrl = process.env.VERCEL_URL;
     process.env.NODE_ENV = 'production';
+    delete process.env.VERCEL_ENV;
+    delete process.env.VERCEL_URL;
   });
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
+    if (originalVercelEnv === undefined) delete process.env.VERCEL_ENV;
+    else process.env.VERCEL_ENV = originalVercelEnv;
+    if (originalVercelUrl === undefined) delete process.env.VERCEL_URL;
+    else process.env.VERCEL_URL = originalVercelUrl;
   });
 
-  it('injects the same hash-based path postBuild would render for a normal page', () => {
+  it('injects the same hash-based absolute URL postBuild would render for a normal page', () => {
     const frontMatter = runTransform({
       frontMatter: { title: 'Approval Pattern', description: 'Human-in-the-loop workflows.' },
       value: '---\ntitle: Approval Pattern\n---\n\nSome body content.',
     });
     const expectedHash = hashFor('Approval Pattern', 'Human-in-the-loop workflows.');
-    assert.strictEqual(frontMatter.image, `/img/og/${expectedHash}.jpg`);
+    assert.strictEqual(frontMatter.image, `https://docs.temporal.io/img/og/${expectedHash}.jpg`);
+  });
+
+  it('points at the Vercel preview origin instead of production on a non-production Vercel deployment', () => {
+    process.env.VERCEL_ENV = 'preview';
+    process.env.VERCEL_URL = 'documentation-git-my-branch.vercel.app';
+    const frontMatter = runTransform({
+      frontMatter: { title: 'Approval Pattern', description: 'Human-in-the-loop workflows.' },
+      value: '---\ntitle: Approval Pattern\n---\n\nSome body content.',
+    });
+    const expectedHash = hashFor('Approval Pattern', 'Human-in-the-loop workflows.');
+    assert.strictEqual(
+      frontMatter.image,
+      `https://documentation-git-my-branch.vercel.app/img/og/${expectedHash}.jpg`,
+    );
+  });
+
+  it('keeps the production origin when VERCEL_ENV is "production"', () => {
+    process.env.VERCEL_ENV = 'production';
+    process.env.VERCEL_URL = 'docs.temporal.io';
+    const frontMatter = runTransform({
+      frontMatter: { title: 'Approval Pattern', description: 'Human-in-the-loop workflows.' },
+      value: '---\ntitle: Approval Pattern\n---\n\nSome body content.',
+    });
+    const expectedHash = hashFor('Approval Pattern', 'Human-in-the-loop workflows.');
+    assert.strictEqual(frontMatter.image, `https://docs.temporal.io/img/og/${expectedHash}.jpg`);
   });
 
   it('does nothing outside a production build (yarn start)', () => {
@@ -71,14 +106,14 @@ Body.`;
       frontMatter: {},
       value: '---\n---\n\n# My Heading\n\nBody.',
     });
-    assert.strictEqual(withHeading.image, `/img/og/${hashFor('My Heading', undefined)}.jpg`);
+    assert.strictEqual(withHeading.image, `https://docs.temporal.io/img/og/${hashFor('My Heading', undefined)}.jpg`);
 
     const withNeither = runTransform({
       frontMatter: {},
       value: '---\n---\n\nBody with no heading.',
       path: '/docs/design-patterns/my-page.mdx',
     });
-    assert.strictEqual(withNeither.image, `/img/og/${hashFor('My Page', undefined)}.jpg`);
+    assert.strictEqual(withNeither.image, `https://docs.temporal.io/img/og/${hashFor('My Page', undefined)}.jpg`);
   });
 
   it('does nothing when frontMatter data is missing', () => {

--- a/plugins/og-image/shared.js
+++ b/plugins/og-image/shared.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto');
 const matter = require('gray-matter');
-const { TEMPLATE_VERSION, IMAGE_EXTENSION, DEFAULT_FOOTER_TEXT } = require('./constants');
+const { TEMPLATE_VERSION, IMAGE_EXTENSION, DEFAULT_FOOTER_TEXT, PRODUCTION_SITE_URL } = require('./constants');
 
 // Shared by plugins/og-image/index.js (postBuild: renders the actual image
 // bytes) and plugins/og-image/remarkPlugin.js (build-time MDX compilation:
@@ -60,6 +60,25 @@ function hashFor(title, description, footerText = DEFAULT_FOOTER_TEXT) {
     .slice(0, 16);
 }
 
+// The origin a generated og:image URL should point at. On a Vercel preview
+// (or branch) deployment, the rendered card only exists on that
+// deployment's own domain — production never has this build's images. If
+// the URL pointed at production anyway, a link-unfurler (Slack, etc.) that
+// fetches it while the page is only staged would 404, and that 404 gets
+// cached against the image URL itself, not the page URL. Because the hash
+// is derived from page content (title/description/footerText), production
+// mints the exact same image URL once the page ships unchanged — inheriting
+// whatever Slack already cached for it, with no new hash to bust that
+// cache. VERCEL_URL is Vercel's reachable hostname for the current
+// deployment; only substitute it for non-production deployments, so
+// production keeps resolving to the stable custom domain.
+function resolveImageOrigin() {
+  if (process.env.VERCEL_ENV && process.env.VERCEL_ENV !== 'production' && process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL}`;
+  }
+  return PRODUCTION_SITE_URL;
+}
+
 // The remark plugin gets raw MDX source straight from Docusaurus's compiler
 // (frontmatter block still attached), unlike postBuild/bin scripts which
 // read files directly through gray-matter and already have it split into
@@ -76,6 +95,7 @@ module.exports = {
   hasManualOverride,
   overrideImageFor,
   hashFor,
+  resolveImageOrigin,
   stripFrontmatter,
   IMAGE_EXTENSION,
   DEFAULT_FOOTER_TEXT,


### PR DESCRIPTION
## Summary
- Fixes a Slack-cache-poisoning bug: `plugins/og-image/remarkPlugin.js` now injects the og:image/twitter:image URL as an absolute URL resolved via a new `resolveImageOrigin()` helper (`plugins/og-image/shared.js`), instead of a relative path that Docusaurus resolved against the hardcoded production `siteConfig.url`. Previously, a staging/preview build and the eventual production build of an unchanged page minted the identical og:image URL. If that URL was shared to Slack before the page went live, Slack cached a 404 against the image URL itself (separate from, and stickier than, its page-level unfurl cache) — production then inherited the poisoned cache with no new hash to bust it.
- Also turns off Docusaurus Faster's rspack persistent build cache (`future.faster.rspackPersistentCache: false` in `docusaurus.config.js`). Found while verifying the fix above: that cache can serve a previous build's compiled MDX output — including the environment-baked og:image URL — across builds where only `VERCEL_ENV`/`VERCEL_URL` changed, since its cache key/version doesn't account for arbitrary `process.env` values a plugin reads. Every other Faster flag (SWC loader/minifier, lightningcss, rspack bundler, worker threads, eager VCS) stays enabled; the separate content-hash-only image-render cache (`node_modules/.cache/og-images`) is untouched and still avoids re-rendering unchanged cards.
- `bin/validate-og-images.js` updated to match the new resolution logic.

## Test plan
- [x] `yarn test`: 131/131 pass
- [x] `yarn build && yarn validate:og-images`: 777/777 pages correct
- [x] `yarn check:og-budget`: within budget
- [x] Confirmed on the live Vercel preview deployment of this branch: og:image/twitter:image resolve to the preview's own origin (not production), and the referenced image returns 200.
- [x] Confirmed two consecutive local builds under different `VERCEL_ENV`/`VERCEL_URL`, with no cache clearing in between, now pick up the correct origin immediately — previously a stale value from `node_modules/.cache/rspack`/`.docusaurus` persisted across builds.

## Notes to reviewers
- Known, separate follow-up (not in this PR): `src/pages/ai/cookbook.tsx`'s og:image tag has the same hardcoded-origin bug, on a fixed, non-content-hashed path — worse, since a single staging exposure would poison that URL's cache permanently.
- Worth watching after merge: the first production build's duration. Disabling the persistent cache means every build now recompiles MDX from scratch (locally this added roughly 15-18s wall time to a full 778-page build; Vercel's build machines will differ).