### PR TITLE
docs: update Cloud extension Homebrew command

### DIFF
--- a/docs/cli/setup-cli.mdx
+++ b/docs/cli/setup-cli.mdx
@@ -98,7 +98,7 @@ APIs and configuration may change before the stable release.
 :::
 
 ```bash
-brew install temporalio/prerelease/temporal-cloud
+brew install temporalio/brew/temporal-cloud
 ```
 
 ## Run a local development server


### PR DESCRIPTION
Updates the Temporal Cloud extension install command to use the `temporalio/brew` tap.

Draft until the new formula is published to the public Homebrew tap.