### PR TITLE
rename of Encyclopedia to Concepts 

### DIFF
--- a/docs/best-practices/index.mdx
+++ b/docs/best-practices/index.mdx
@@ -13,7 +13,7 @@ tags:
 
 This section collects prescriptive, validated guidance for platform teams, architects, and developers establishing
 Temporal standards across an organization. Each page recommends a specific approach based on real-world deployments,
-rather than explaining how a feature works internally — for that, see [Encyclopedia](/temporal). Looking for a working
+rather than explaining how a feature works internally — for that, see [Concepts](/temporal). Looking for a working
 code example instead of a principle? See [Guides](/guides) for pattern-by-pattern implementations with runnable code.
 
 ## Namespace, tenancy, and capacity

--- a/docs/develop/dotnet/best-practices/data-handling/index.mdx
+++ b/docs/develop/dotnet/best-practices/data-handling/index.mdx
@@ -33,4 +33,4 @@ your application requires non-JSON types, encryption, or payload offloading.
 | **Purpose**               | Serialize application data to bytes                               | Transform encoded payloads (encrypt, compress)                |
 | **Default**               | JSON serialization                                                | None (passthrough)                                            |
 
-For a deeper conceptual explanation, see the [Data Conversion encyclopedia](/dataconversion) and [External Storage](/external-storage).
+For a deeper conceptual explanation, see the [Data Conversion concepts](/dataconversion) and [External Storage](/external-storage).

--- a/docs/develop/dotnet/nexus/feature-guide.mdx
+++ b/docs/develop/dotnet/nexus/feature-guide.mdx
@@ -624,5 +624,5 @@ For **synchronous Nexus Operations** the following are reported in the caller's 
 ## Learn more
 
 - Read the high-level description of the [Temporal Nexus feature](/evaluate/nexus) and watch the [Nexus keynote and demo](https://youtu.be/qqc2vsv1mrU?feature=shared&t=2082).
-- Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and [Encyclopedia](/nexus).
+- Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and [Concepts](/nexus).
 - Deploy Nexus Endpoints in production with [Temporal Cloud](/cloud/nexus).

--- a/docs/develop/dotnet/workflows/versioning.mdx
+++ b/docs/develop/dotnet/workflows/versioning.mdx
@@ -174,7 +174,7 @@ This video provides an overview of how the `patched()` function works:
   </iframe>
 </div>
 <br/>
-For a more in-depth explanation, refer to the [Patching](/patching) Encyclopedia entry.
+For a more in-depth explanation, refer to the [Patching](/patching) concept page.
 
 ### Workflow cutovers
 

--- a/docs/develop/go/best-practices/data-handling/index.mdx
+++ b/docs/develop/go/best-practices/data-handling/index.mdx
@@ -34,4 +34,4 @@ your application requires non-JSON types, encryption, or payload offloading.
 | **Purpose**               | Serialize application data to bytes                           | Transform encoded payloads (encrypt, compress)            | Offload large payloads to external store                           |
 | **Default**               | JSON serialization                                            | None (passthrough)                                        | None (all payloads are stored in Event History)                  |
 
-For a deeper conceptual explanation, see the [Data Conversion encyclopedia](/dataconversion) and [External Storage](/external-storage).
+For a deeper conceptual explanation, see the [Data Conversion concepts](/dataconversion) and [External Storage](/external-storage).

--- a/docs/develop/go/nexus/feature-guide.mdx
+++ b/docs/develop/go/nexus/feature-guide.mdx
@@ -768,5 +768,5 @@ For **synchronous Nexus Operations** the following are reported in the caller's 
 ## Learn more
 
 - Read the high-level description of the [Temporal Nexus feature](/evaluate/nexus) and watch the [Nexus keynote and demo](https://youtu.be/qqc2vsv1mrU?feature=shared&t=2082).
-- Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and [Encyclopedia](/nexus).
+- Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and [Concepts](/nexus).
 - Deploy Nexus Endpoints in production with [Temporal Cloud](/cloud/nexus).

--- a/docs/develop/java/best-practices/data-handling/index.mdx
+++ b/docs/develop/java/best-practices/data-handling/index.mdx
@@ -33,4 +33,4 @@ your application requires non-JSON types, encryption, or payload offloading.
 | **Purpose**               | Serialize application data to bytes                               | Transform encoded payloads (encrypt, compress)                |
 | **Default**               | JSON serialization                                                | None (passthrough)                                            |
 
-For a deeper conceptual explanation, see the [Data Conversion encyclopedia](/dataconversion) and [External Storage](/external-storage).
+For a deeper conceptual explanation, see the [Data Conversion concepts](/dataconversion) and [External Storage](/external-storage).

--- a/docs/develop/java/nexus/feature-guide.mdx
+++ b/docs/develop/java/nexus/feature-guide.mdx
@@ -832,5 +832,5 @@ For **synchronous Nexus Operations** the following are reported in the caller's 
 - Read the high-level description of the [Temporal Nexus feature](/evaluate/nexus) and watch the
   [Nexus keynote and demo](https://youtu.be/qqc2vsv1mrU?feature=shared&t=2082).
 - Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and
-  [Encyclopedia](/nexus).
+  [Concepts](/nexus).
 - Deploy Nexus Endpoints in production with [Temporal Cloud](/cloud/nexus).

--- a/docs/develop/python/best-practices/data-handling/index.mdx
+++ b/docs/develop/python/best-practices/data-handling/index.mdx
@@ -34,4 +34,4 @@ your application requires non-JSON types, encryption, or payload offloading.
 | **Purpose**               | Serialize application data to bytes                               | Transform encoded payloads (encrypt, compress)                | Offload large payloads to external store                               |
 | **Default**               | JSON serialization                                                | None (passthrough)                                            | None (all payloads are stored in Event History)                      |
 
-For a deeper conceptual explanation, see the [Data Conversion encyclopedia](/dataconversion) and [External Storage](/external-storage).
+For a deeper conceptual explanation, see the [Data Conversion concepts](/dataconversion) and [External Storage](/external-storage).

--- a/docs/develop/python/nexus/feature-guide.mdx
+++ b/docs/develop/python/nexus/feature-guide.mdx
@@ -468,5 +468,5 @@ For **synchronous Nexus Operations** the following are reported in the caller's 
 ## Learn more
 
 - Read the high-level description of the [Temporal Nexus feature](/evaluate/nexus) and watch the [Nexus keynote and demo](https://youtu.be/qqc2vsv1mrU?feature=shared&t=2082).
-- Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and [Encyclopedia](/nexus).
+- Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and [Concepts](/nexus).
 - Deploy Nexus Endpoints in production with [Temporal Cloud](/cloud/nexus).

--- a/docs/develop/python/workflows/versioning.mdx
+++ b/docs/develop/python/workflows/versioning.mdx
@@ -195,7 +195,7 @@ This video provides an overview of how the `patched()` function works:
   </iframe>
 </div>
 <br/>
-For a more in-depth explanation, refer to the [Patching](/patching) Encyclopedia entry.
+For a more in-depth explanation, refer to the [Patching](/patching) concept page.
 
 ### Workflow cutovers
 

--- a/docs/develop/ruby/best-practices/data-handling/index.mdx
+++ b/docs/develop/ruby/best-practices/data-handling/index.mdx
@@ -33,4 +33,4 @@ your application requires non-JSON types, encryption, or payload offloading.
 | **Purpose**               | Serialize application data to bytes                               | Transform encoded payloads (encrypt, compress)                |
 | **Default**               | JSON serialization                                                | None (passthrough)                                            |
 
-For a deeper conceptual explanation, see the [Data Conversion encyclopedia](/dataconversion) and [External Storage](/external-storage).
+For a deeper conceptual explanation, see the [Data Conversion concepts](/dataconversion) and [External Storage](/external-storage).

--- a/docs/develop/typescript/best-practices/data-handling/index.mdx
+++ b/docs/develop/typescript/best-practices/data-handling/index.mdx
@@ -33,4 +33,4 @@ your application requires non-JSON types, encryption, or payload offloading.
 | **Purpose**               | Serialize application data to bytes                               | Transform encoded payloads (encrypt, compress)                | Offload large payloads to external store                               |
 | **Default**               | JSON serialization                                                | None (passthrough)                                            | None (all payloads are stored in Event History)                      |
 
-For a deeper conceptual explanation, see the [Data Conversion encyclopedia](/dataconversion) and [External Storage](/external-storage).
+For a deeper conceptual explanation, see the [Data Conversion concepts](/dataconversion) and [External Storage](/external-storage).

--- a/docs/develop/typescript/nexus/feature-guide.mdx
+++ b/docs/develop/typescript/nexus/feature-guide.mdx
@@ -498,5 +498,5 @@ For custom interceptor logic beyond tracing (for example, logging, authorization
 ## Learn more
 
 - Read the high-level description of the [Temporal Nexus feature](/evaluate/nexus) and watch the [Nexus keynote and demo](https://youtu.be/qqc2vsv1mrU?feature=shared&t=2082).
-- Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and [Encyclopedia](/nexus).
+- Learn how Nexus works in the [Nexus deep dive talk](https://www.youtube.com/watch?v=izR9dQ_eIe4) and [Concepts](/nexus).
 - Deploy Nexus Endpoints in production with [Temporal Cloud](/cloud/nexus).

--- a/docs/encyclopedia/index.mdx
+++ b/docs/encyclopedia/index.mdx
@@ -1,13 +1,13 @@
 ---
 id: index
-title: Temporal Encyclopedia
+title: Temporal concepts
 description: Discover the key concepts, components, and features of Temporal for building scalable and reliable applications. Learn about Temporal SDKs, Workflows, Activities, Workers, and more.
-sidebar_label: Encyclopedia
+sidebar_label: Concepts
 ---
 
 [Temporal](/evaluate/why-temporal) provides developers a suite of effective tools for building reliable applications at scale.
 
-The following Encyclopedia pages describe the concepts, components, and features of Temporal in detail:
+The following concept pages describe how Temporal works in detail:
 
 - [Temporal](/temporal)
 - [Temporal architecture](/encyclopedia/architecture/temporal-architecture)

--- a/docs/encyclopedia/workflow/patching.mdx
+++ b/docs/encyclopedia/workflow/patching.mdx
@@ -2,7 +2,7 @@
 id: patching
 title: Patching
 sidebar_label: Patching
-description: This Encyclopedia page provides an in-depth explanation of what happens during Workflow Patching
+description: This concept page provides an in-depth explanation of what happens during Workflow Patching
 slug: /patching
 toc_max_heading_level: 4
 tags:

--- a/docs/evaluate/development-production-features/core-application.mdx
+++ b/docs/evaluate/development-production-features/core-application.mdx
@@ -41,7 +41,7 @@ Or jump straight to a Temporal SDK feature guide:
   <RelatedReadItem path="/develop/typescript" text="TypeScript SDK Core application feature guide" archetype="feature-guide" />
 </RelatedReadContainer>
 
-For a deep dive into Temporal Workflows, Activities, and Workers, visit the following Temporal Encyclopedia pages or enroll in one of [our courses](https://learn.temporal.io/courses/).
+For a deep dive into Temporal Workflows, Activities, and Workers, visit the following Temporal concept pages or enroll in one of [our courses](https://learn.temporal.io/courses/).
 
 - [Temporal Workflows](/workflows)
 - [Temporal Activities](/activities)

--- a/docs/evaluate/development-production-features/failure-detection.mdx
+++ b/docs/evaluate/development-production-features/failure-detection.mdx
@@ -1,7 +1,7 @@
 ---
 id: failure-detection
 title: Failure detection - Temporal feature
-description: Explore Temporal's robust timeout and Retry Policy features for Workflows and Activities. Start with our tutorials or dive deep with our SDK guides and Encyclopedia resources.
+description: Explore Temporal's robust timeout and Retry Policy features for Workflows and Activities. Start with our tutorials or dive deep with our SDK guides and concept pages.
 sidebar_label: Failure detection
 tags:
   - Workflows
@@ -43,7 +43,7 @@ Or jump straight to a Temporal SDK feature guide.
   <RelatedReadItem path="/develop/typescript/activities/timeouts" text="Set Activity timeouts and Retry Policies using the TypeScript SDK" archetype="feature-guide" />
 </RelatedReadContainer>
 
-For a deep dive into timeouts and Retry Policies visit the following Temporal Encyclopedia pages or enroll in one of [our courses](https://learn.temporal.io/courses/).
+For a deep dive into timeouts and Retry Policies visit the following Temporal concept pages or enroll in one of [our courses](https://learn.temporal.io/courses/).
 
 <RelatedReadContainer>
     <RelatedReadItem path="/encyclopedia/detecting-workflow-failures" text="Detecting Workflow failures" archetype="encyclopedia" />

--- a/docs/evaluate/development-production-features/throughput-composability.mdx
+++ b/docs/evaluate/development-production-features/throughput-composability.mdx
@@ -31,4 +31,4 @@ See the SDK feature guides for implementation details:
   <RelatedReadItem path="/develop/rust/workflows/child-workflows" text="Rust SDK Child Workflow feature guide" archetype="feature-guide" />
 </RelatedReadContainer>
 
-For a deep dive into Child Workflows see the [Child Workflows Encyclopedia page](/child-workflows).
+For a deep dive into Child Workflows see the [Child Workflows concept page](/child-workflows).

--- a/docs/evaluate/temporal-cloud/limits.mdx
+++ b/docs/evaluate/temporal-cloud/limits.mdx
@@ -353,13 +353,13 @@ A single Workflow Execution can have a maximum of 2000 total Callbacks.
 
 These limits may be exceeded when [multiple Nexus callers attach to the same handler Workflow](/nexus/operations#attaching-multiple-nexus-callers).
 
-See the Nexus Encyclopedia entry for [additional details](/workflow-execution/limits#workflow-execution-callback-limits).
+See the Nexus concept page for [additional details](/workflow-execution/limits#workflow-execution-callback-limits).
 
 ### Per Workflow Nexus Operation limits {/* #per-workflow-nexus-operation-limits */}
 
 A single Workflow Execution can have a maximum of 30 in-flight Nexus Operations.
 
-See the Nexus Encyclopedia entry for [additional details](/workflow-execution/limits#workflow-execution-nexus-operation-limits).
+See the Nexus concept page for [additional details](/workflow-execution/limits#workflow-execution-nexus-operation-limits).
 
 ### Nexus Operation request timeout {/* #nexus-operation-request-timeout */}
 

--- a/docs/evaluate/understanding-temporal.mdx
+++ b/docs/evaluate/understanding-temporal.mdx
@@ -158,7 +158,7 @@ Temporal uses the Event History to record every step taken along the way. Each t
 
 A Command is a requested action issued by a Worker to the Temporal Service after a Workflow Task Execution completes. The Temporal Service will act on these Commands such as scheduling an Activity or scheduling a timer. These Commands are then mapped to Events which are persisted in case of failure. For example, if the Worker crashes, the Worker uses the Event History to replay the code and recreate the state of the Workflow Execution to what it was immediately before the crash. It then resumes progress from the point of failure as if the failure never occurred.
 
-For a deep dive into the Event History or Commands, visit the Temporal [Encyclopedia page](/encyclopedia/event-history) or enroll in one of [our courses](https://learn.temporal.io/courses/).
+For a deep dive into the Event History or Commands, visit the Temporal [concept page](/encyclopedia/event-history) or enroll in one of [our courses](https://learn.temporal.io/courses/).
 
 ## Reliable as Gravity
 

--- a/readme/COMPONENTS.md
+++ b/readme/COMPONENTS.md
@@ -328,7 +328,7 @@ Usage:
 ```
 
 Archetypes:
-- encyclopedia
+- `encyclopedia` (displayed as **concepts**)
 - feature-guide
 - feature-summary
 

--- a/readme/INFORMATION-ARCHITECTURE.md
+++ b/readme/INFORMATION-ARCHITECTURE.md
@@ -16,7 +16,7 @@ This document describes the purpose, audience, and content type for each top-lev
     - Temporal's value proposition, feature inventory, use cases
     - Temporal Cloud's operational characteristics (pricing, SLA, regions, limits).
 
-    Content here should help the reader make a decision, not build something. Avoid code examples beyond brief illustrations. Link to Develop for implementation details and to Encyclopedia for conceptual details.
+    Content here should help the reader make a decision, not build something. Avoid code examples beyond brief illustrations. Link to Develop for implementation details and to Concepts for conceptual details.
 
 ## Develop
 
@@ -24,7 +24,7 @@ This document describes the purpose, audience, and content type for each top-lev
 - **Content type:** How-to
 - **Description:** Each SDK section follows a consistent structure: installation, Workflows, Activities, Workers, Clients, message passing, testing, observability, and Nexus. Pages should show how to accomplish specific tasks with working code.
 
-    Cross-link to Encyclopedia for conceptual depth, but keep each page focused on "how do I do X in language Y."
+    Cross-link to Concepts for conceptual depth, but keep each page focused on "how do I do X in language Y."
 
     Use canonical verb as headings. If you find yourself having to group headings together using topics/nouns, consider breaking up the page.
 
@@ -74,7 +74,7 @@ This document describes the purpose, audience, and content type for each top-lev
 - **Content type:** Mostly explanation with some how-to content.
 - **Description:** Prescriptive guidance and validated patterns. They recommend specific approaches based on real-world deployments.
 
-## Encyclopedia
+## Concepts
 
 - **Audience:** Architects, advanced developers, and anyone who needs deep understanding of Temporal's internals and design.
 - **Content type:** Explanations.
@@ -83,6 +83,8 @@ This document describes the purpose, audience, and content type for each top-lev
     Link here from Develop when a concept needs more explanation than a how-to page should carry. These pages should be heavy on text and diagrams, and light on code.
 
     Nouns as headings are not discouraged in this section.
+
+    Content lives under `docs/encyclopedia/`; URLs use clean slugs (for example, `/workflows`) rather than a `/concepts` prefix.
 
 ## Glossary
 
@@ -120,7 +122,7 @@ This document describes the purpose, audience, and content type for each top-lev
   knowledge.
 - **Features:** A catalog of 17+ feature pages (core application, failure detection, Nexus, message passing, schedules,
   serverless, etc.) that each describe what a feature does and why it matters. Each page links out to Develop for
-  implementation and Encyclopedia for conceptual depth.
+  implementation and Concepts for conceptual depth.
 - **Temporal Cloud (evaluation):** Positioning content for the managed offering: pricing, SLA, regions, limits, security
   model, and support tiers. Helps readers decide between Cloud and self-hosted.
 - **Use cases and design patterns:** Real-world examples (Stripe, Coinbase, Netflix, etc.) and architectural patterns
@@ -208,11 +210,11 @@ These cross-cutting pages live outside any SDK folder:
   content is distinct (self-hosted configuration vs. Cloud configuration), but the structural echo can confuse readers
   looking for "how do I set up namespaces."
 
-## Encyclopedia: internal structure and issues
+## Concepts: internal structure and issues
 
 ### Internal structure
 
-The Encyclopedia contains roughly 75 pages organized into these concept groups:
+The Concepts section contains roughly 75 pages organized into these topic groups:
 
 - **Temporal / Temporal SDKs** — Top-level overviews of the platform and SDK architecture.
 - **Workflows** (8 pages) — Definitions, execution model, WorkflowID/RunID, continue-as-new, limits, timers, dynamic
@@ -237,12 +239,10 @@ The Encyclopedia contains roughly 75 pages organized into these concept groups:
 ### Issues
 
 - **Event History has SDK-specific pages.** The Go, Java, .NET, Python, and TypeScript Event History pages are
-  walkthroughs tied to specific SDKs. This is the only place in Encyclopedia where content is language-specific. These
-  pages could belong in Develop instead, or they could link from Develop into Encyclopedia. Currently they sit alongside
+  walkthroughs tied to specific SDKs. This is the only place in Concepts where content is language-specific. These
+  pages could belong in Develop instead, or they could link from Develop into Concepts. Currently they sit alongside
   the language-agnostic concept page.
 - **Overlap with Evaluate.** Both sections explain what Workflows, Activities, and Workers are. Evaluate does it at a
-  high level for decision-makers. Encyclopedia does it in depth for builders. The separation is reasonable, but some
-  Encyclopedia pages (like `temporal.mdx`) cover similar ground to `evaluate/understanding-temporal.mdx`. A reader
+  high level for decision-makers. Concepts does it in depth for builders. The separation is reasonable, but some
+  Concepts pages (like `temporal.mdx`) cover similar ground to `evaluate/understanding-temporal.mdx`. A reader
   arriving from search could land on either without context about which one they want.
-- **"Encyclopedia" as a name** does not follow common documentation conventions. Readers unfamiliar with the site would
-  not know to look here for conceptual documentation. "Concepts" or "Architecture" might be more discoverable.

--- a/readme/ZOOMABLE_IMAGES.md
+++ b/readme/ZOOMABLE_IMAGES.md
@@ -167,7 +167,7 @@ Pages that did **not** previously have any zoom but contain raster images ≥ 80
 - [/develop/typescript/nexus/feature-guide](https://docs.temporal.io/develop/typescript/nexus/feature-guide) — _max 3542px_
 - [/develop/typescript/best-practices/debugging](https://docs.temporal.io/develop/typescript/best-practices/debugging) — _max 2702px_
 
-#### Encyclopedia
+#### Concepts
 
 - [/nexus/operations](https://docs.temporal.io/nexus/operations) — _max 3304px_
 - [/handling-messages](https://docs.temporal.io/handling-messages) — _max 2006px_

--- a/sidebars.js
+++ b/sidebars.js
@@ -1908,7 +1908,7 @@ module.exports = {
     },
     {
       type: 'category',
-      label: 'Encyclopedia',
+      label: 'Concepts',
       collapsed: true,
       link: {
         type: 'doc',

--- a/src/components/elements/RelatedRead/RelatedRead.js
+++ b/src/components/elements/RelatedRead/RelatedRead.js
@@ -6,6 +6,11 @@ import { v4 as uuidv4 } from "uuid";
 import { LANGUAGE_SVGS } from "../../../constants/sdkLanguages";
 import styles from "./RelatedRead.module.css";
 
+const archetypeLabels = {
+  encyclopedia: "concepts",
+  "feature-guide": "feature-guide",
+  "feature-summary": "feature-summary",
+};
 const archetypeClasses = {
   encyclopedia: "archetype-tag-encyclopedia-article",
   "feature-guide": "archetype-tag-feature-guide",
@@ -55,7 +60,11 @@ export function RelatedReadItem({ path, text, archetype }) {
         {languageIcon && <img src={languageIcon} alt="" className={styles.languageIcon} />}
         {text}
       </Link>
-      {tagClass && <span className={clsx(styles.archetypeTag, styles[tagClass])}>{archetype}</span>}
+      {tagClass && (
+        <span className={clsx(styles.archetypeTag, styles[tagClass])}>
+          {archetypeLabels[archetype] ?? archetype}
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What does this PR do?
Renames the Encyclopedia sidebar section to Concepts. Most of this section contains SDK-agnostic explanations of Temporal's major concepts.  

## Notes to reviewers
urls PR will be needed 



<!-- delete if n/a -->
