### PR TITLE
Document Serverless Worker network access

### DIFF
--- a/docs/encyclopedia/workers/serverless-workers/aws-lambda.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/aws-lambda.mdx
@@ -29,6 +29,7 @@ Sync match failure is the primary control signal, and backlog aids sizing.
 
 When the [WCI](/serverless-workers#worker-controller-instance) needs more capacity, it calls the Lambda `InvokeFunction` API to start new Workers.
 Each call is a discrete action ("invoke N more functions"), not a target state.
+Temporal calls that API from outside your network, so no inbound connection to the function is needed.
 The WCI does not manage a fleet of instances.
 
 ### Scale-out {/* #scale-out */}

--- a/docs/encyclopedia/workers/serverless-workers/cloud-run.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/cloud-run.mdx
@@ -54,6 +54,7 @@ It sizes the pool to a target utilization (80% by default), so there is room to 
 When Tasks are already waiting in the backlog, the WCI adds more instances on top to work through them faster.
 
 It applies the resulting count to the pool through the Cloud Run admin API, and keeps the count within a minimum and maximum bound.
+Temporal calls that API from outside your network, so no inbound connection to the pool is needed.
 
 ### Scale-out {/* #scale-out */}
 

--- a/docs/encyclopedia/workers/serverless-workers/index.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/index.mdx
@@ -143,15 +143,6 @@ it scales differ by provider. See [Autoscaling](#autoscaling).
 Whether a Worker handles a single burst of Tasks and exits, or stays running to process Tasks over a long lifetime,
 depends on the compute provider's execution model. See [Worker lifecycle](#worker-lifecycle).
 
-### Network access {/* #network-access */}
-
-The WCI starts and scales Workers through the compute provider's public API, not through a connection into your network.
-On AWS Lambda it assumes an IAM role in your account and calls the Lambda invoke API. On GCP Cloud Run it impersonates a
-service account in your project and calls the Cloud Run Admin API. Neither path reaches your Workers directly, so you do
-not need to open inbound ports, peer networks, or allow Temporal source addresses.
-
-Workers still need outbound access to your Temporal Service.
-
 ## Autoscaling {/* #autoscaling */}
 
 The [WCI](#worker-controller-instance) automatically scales Serverless Workers up and down based on Task Queue conditions, including sync match failures and Task Queue backlog.

--- a/docs/encyclopedia/workers/serverless-workers/index.mdx
+++ b/docs/encyclopedia/workers/serverless-workers/index.mdx
@@ -143,6 +143,15 @@ it scales differ by provider. See [Autoscaling](#autoscaling).
 Whether a Worker handles a single burst of Tasks and exits, or stays running to process Tasks over a long lifetime,
 depends on the compute provider's execution model. See [Worker lifecycle](#worker-lifecycle).
 
+### Network access {/* #network-access */}
+
+The WCI starts and scales Workers through the compute provider's public API, not through a connection into your network.
+On AWS Lambda it assumes an IAM role in your account and calls the Lambda invoke API. On GCP Cloud Run it impersonates a
+service account in your project and calls the Cloud Run Admin API. Neither path reaches your Workers directly, so you do
+not need to open inbound ports, peer networks, or allow Temporal source addresses.
+
+Workers still need outbound access to your Temporal Service.
+
 ## Autoscaling {/* #autoscaling */}
 
 The [WCI](#worker-controller-instance) automatically scales Serverless Workers up and down based on Task Queue conditions, including sync match failures and Task Queue backlog.

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda/index.mdx
@@ -537,8 +537,8 @@ your AWS account with a handful of Lambda permissions scoped to your Worker func
 includes an External ID condition to prevent
 [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks.
 
-Temporal calls the Lambda API with this role, and does not connect to your network. You do not need to open inbound
-ports. See [Network access](/serverless-workers#network-access).
+Temporal calls the Lambda API with this role and does not connect to your network, so you do not need to open inbound
+ports.
 
 The Temporal Cloud UI provides a **Launch Stack** button on the **Create Worker Deployment** page that opens the AWS CloudFormation console with the template and parameters pre-filled. Click it to create the role without downloading or configuring the template manually.
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/aws-lambda/index.mdx
@@ -537,6 +537,9 @@ your AWS account with a handful of Lambda permissions scoped to your Worker func
 includes an External ID condition to prevent
 [confused deputy](https://docs.aws.amazon.com/IAM/latest/UserGuide/confused-deputy.html) attacks.
 
+Temporal calls the Lambda API with this role, and does not connect to your network. You do not need to open inbound
+ports. See [Network access](/serverless-workers#network-access).
+
 The Temporal Cloud UI provides a **Launch Stack** button on the **Create Worker Deployment** page that opens the AWS CloudFormation console with the template and parameters pre-filled. Click it to create the role without downloading or configuring the template manually.
 
 You can also create the role using the templates below.

--- a/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
@@ -705,8 +705,8 @@ This section applies to Temporal Cloud. For self-hosted Temporal Service deploym
 [Self-hosted setup](/production-deployment/worker-deployments/serverless-workers/cloud-run/self-hosted-setup).
 
 Temporal Cloud scales the Worker Pool by [impersonating a service account](https://docs.cloud.google.com/docs/authentication/use-service-account-impersonation) you create, called the *invoker service account*. The invoker service account
-reads and scales the pool through the Cloud Run admin API. It does not run the pool. Temporal does not connect to your
-network, so you do not need to open inbound ports. See [Network access](/serverless-workers#network-access).
+reads and scales the pool through the Cloud Run admin API. It does not run the pool. Temporal calls that API from
+outside your network, so you do not need to open inbound ports.
 
 :::caution
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
@@ -705,7 +705,8 @@ This section applies to Temporal Cloud. For self-hosted Temporal Service deploym
 [Self-hosted setup](/production-deployment/worker-deployments/serverless-workers/cloud-run/self-hosted-setup).
 
 Temporal Cloud scales the Worker Pool by [impersonating a service account](https://docs.cloud.google.com/docs/authentication/use-service-account-impersonation) you create, called the *invoker service account*. The invoker service account
-reads and scales the pool through the Cloud Run admin API. It does not run the pool.
+reads and scales the pool through the Cloud Run admin API. It does not run the pool. Temporal does not connect to your
+network, so you do not need to open inbound ports. See [Network access](/serverless-workers#network-access).
 
 :::caution
 


### PR DESCRIPTION
## What

Adds a short `Network access` section to the Serverless Workers encyclopedia page stating that the Worker Controller Instance scales Workers through the provider's public API (Lambda invoke API, Cloud Run Admin API), so no inbound ports or network peering are needed. One-line pointers added to the AWS Lambda and Cloud Run permission steps.

Draft pending confirmation from the Serverless team that nothing else touches customer compute.