### PR TITLE
Fix frontmatter descriptions, tags, and heading style across /references

### DIFF
--- a/docs/evaluate/understanding-temporal.mdx
+++ b/docs/evaluate/understanding-temporal.mdx
@@ -81,7 +81,7 @@ Developers create Temporal applications by writing code, just like you would to 
 A Temporal SDK (software development kit) is an open-source library that developers add to their application to use Temporal.
 It provides everything needed to build Workflows, Activities, and various other Temporal features in a specific programming language.
 
-Temporal offers seven SDKs: .NET, Go, Java, PHP, Python, Ruby, TypeScript.
+Temporal offers eight SDKs: .NET, Go, Java, PHP, Python, Ruby, Rust, TypeScript.
 Since Temporal supports multiple programming languages, you can mix-and-match between languages for polyglot teams.
 You can easily add any Temporal SDK to your current projects without changing the tools you're already using to build and deploy.
 Temporal fits right into your existing tech stack.

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -1,12 +1,12 @@
 ---
 id: getting-started
 title: Getting started with Temporal
-description: Explore Temporal SDKs for .NET, Go, Java, PHP, Python, Ruby, TypeScript to build robust Temporal applications. Start with the Temporal SDK of your choice today!
+description: Explore Temporal SDKs for .NET, Go, Java, PHP, Python, Ruby, Rust, TypeScript to build robust Temporal applications. Start with the Temporal SDK of your choice today!
 sidebar_label: Get started
 ---
 
 Temporal offers a range of SDKs to help you build Temporal applications.
-The SDKs are available for .NET, Go, Java, PHP, Python, Ruby, TypeScript.
+The SDKs are available for .NET, Go, Java, PHP, Python, Ruby, Rust, TypeScript.
 
 ## Temporal Go SDK
 

--- a/docs/references/api-reference.mdx
+++ b/docs/references/api-reference.mdx
@@ -2,7 +2,7 @@
 id: api-reference
 title: API reference
 sidebar_label: API reference
-description: Includes links to all Temporal SDK API references for Go, Java, Python, TypeScript, .NET, PHP, and Ruby.
+description: Includes links to complete API references for all eight Temporal SDKs — Go, Java, Python, TypeScript, .NET, PHP, Ruby, and Rust.
 tags:
   - Reference
   - SDK
@@ -14,7 +14,7 @@ import PatternCards from '@site/src/components/PatternCards';
 
 Complete API documentation for all Temporal SDKs and server APIs.
 
-## SDK API References
+## SDK API references
 
 <PatternCards items={[
   {
@@ -67,7 +67,7 @@ Complete API documentation for all Temporal SDKs and server APIs.
   },
 ]} />
 
-## Server API References
+## Server API references
 
 <PatternCards items={[
   {
@@ -77,6 +77,6 @@ Complete API documentation for all Temporal SDKs and server APIs.
   },
 ]} />
 
-## Need Help?
+## Need help?
 
 For questions about specific APIs, use the **Ask AI** button in the top navigation for instant answers, connect our [Model Context Protocol server](/with-ai) to AI tools for real-time documentation access, or visit our [Community Forum](https://community.temporal.io/) and [Slack](https://temporal.io/slack) for community support.

--- a/docs/references/client-environment-configuration.mdx
+++ b/docs/references/client-environment-configuration.mdx
@@ -2,9 +2,10 @@
 id: client-environment-configuration
 title: Environment configuration
 sidebar_label: Environment configuration
-description: Reference for the environment variables that configure Temporal Clients, including the Temporal CLI.
+description: Reference for every environment variable that configures a Temporal Client or the Temporal CLI, including TOML keys and CLI flag equivalents.
 toc_max_heading_level: 3
 tags:
+  - Reference
   - Temporal Client
   - Configuration
   - Environment Variables

--- a/docs/references/cluster-metrics.mdx
+++ b/docs/references/cluster-metrics.mdx
@@ -2,7 +2,7 @@
 id: cluster-metrics
 title: OSS Temporal Service metrics reference
 sidebar_label: Temporal Service metrics
-description: A Temporal Service emits metrics helping operators monitor performance and set alerts. Metrics like service requests, latencies, and errors are tracked. Use metric_defs.go for more.
+description: Reference for the metrics a self-hosted Temporal Service emits, covering request rates, latencies, errors, and Nexus Operation activity.
 toc_max_heading_level: 4
 tags:
   - Reference
@@ -268,12 +268,12 @@ Number of Workflows that timed out before completing execution.
 
 These metrics pertain to Nexus Operations.
 
-### Nexus Machinery in the History Service
+### Nexus machinery in the History Service
 
 See [architecture document](https://github.com/temporalio/temporal/blob/main/docs/architecture/nexus.md#scheduler)
 for more info.
 
-#### In-Memory Buffer
+#### In-memory buffer
 
 `dynamic_worker_pool_scheduler_enqueued_tasks`: A counter that is incremented when a task is enqueued to the buffer.
 
@@ -284,20 +284,20 @@ task is rejected.
 
 `dynamic_worker_pool_scheduler_buffer_size`: A gauge that periodically samples the size of the buffer.
 
-### Concurrency Limiter
+### Concurrency limiter
 
 `dynamic_worker_pool_scheduler_active_workers`: A gauge that periodically samples the number of running goroutines.
 
-#### Rate Limiter
+#### Rate limiter
 
 `rate_limited_task_runnable_wait_time`: A histogram representing the time a task spends waiting for the rate limiter.
 
-#### Circuit Breaker
+#### Circuit breaker
 
 `circuit_breaker_executable_blocked`: A counter that is incremented every time a task execution is blocked by the
 circuit breaker.
 
-#### Task Executors
+#### Task executors
 
 `nexus_outbound_requests`: A counter representing the number of Nexus outbound requests made by the history service.
 
@@ -309,7 +309,7 @@ service.
 `callback_outbound_latency`: A histogram representing the latency histogram of outbound callback requests made by the
 history service.
 
-### Nexus Machinery on the Frontend Service
+### Nexus machinery on the Frontend Service
 
 #### `nexus_requests`
 

--- a/docs/references/commands.mdx
+++ b/docs/references/commands.mdx
@@ -2,7 +2,7 @@
 id: commands
 title: Temporal Commands reference
 sidebar_label: Commands
-description: Discover the range of Commands Workers can issue to the Temporal Service after Workflow Task Execution, from Completing Workflow Execution to Start Timer and Signal External Workflow Execution.
+description: Reference for every Command a Worker can issue to the Temporal Service after completing a Workflow Task, including its corresponding Event.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/configuration.mdx
+++ b/docs/references/configuration.mdx
@@ -2,7 +2,7 @@
 id: configuration
 title: Temporal Service configuration reference
 sidebar_label: Service configuration
-description: Configure a Temporal Service using the development.yaml file to set global parameters, metrics, security, persistence, and service roles, ensuring a streamlined setup and management process.
+description: Reference for the development.yaml file that configures a Temporal Service, covering global settings, persistence, service roles, and archival.
 toc_max_heading_level: 4
 tags:
   - Reference
@@ -200,7 +200,7 @@ global:
 
 **Note:** In the case that client authentication is enabled, the `internode.server` certificate is used as the client certificate among services. This adds the following requirements:
 
-- The `internode.server` certificate must be specified on all roles, even for a frontend-only configuration.
+- The `internode.server` certificate must be specified on all roles, even for a Frontend-only configuration.
 - Internode server certificates must be minted with either **no** Extended Key Usages or **both** ServerAuth and ClientAuth EKUs.
 - If your Certificate Authorities are untrusted, such as in the previous example, the internode server Ca will need to be specified in the following places:
 
@@ -324,7 +324,7 @@ Please ensure you set this value appropriately high enough to scale with the wor
 
 ### defaultStore
 
-_Required_ - The name of the data store definition that should be used by the Temporal server.
+_Required_ - The name of the data store definition that should be used by the Temporal Server.
 
 ### visibilityStore
 
@@ -369,7 +369,7 @@ A `sql` data store definition can contain the following values:
   - _Valid values_: `tcp` or `unix`
 - `connectAttributes` - an optional map of key-value attributes to be sent as part of connect `data_source_name` url.
   - `cache`: This is a standard parameter to set the SQLite shared-cache mode. `private` means each database connection uses its own private cache (as opposed to "shared", where connections share a cache). This is the recommended setting for Temporal's SQLite usage.
-  - `setup`: Instructs the Temporal server to automatically initialize a SQLite database schema on startup.
+  - `setup`: Instructs the Temporal Server to automatically initialize a SQLite database schema on startup.
 - `maxConns` - the max number of connections to this data store.
 - `maxIdleConns` - the max number of idle connections to this data store
 - `maxConnLifetime` - is the maximum time a connection can be alive.
@@ -422,7 +422,7 @@ clusterMetadata:
 - `enableGlobalNamespace` - _Default:_ `false`.
 - `replicationConsumer` - determines which method to use to consume replication tasks. The type may be either `kafka` or `rpc`.
 - `failoverVersionIncrement` - the increment of each cluster version when failover happens.
-- `masterClusterName` - the master cluster name, only the master cluster can register/update namespace. All clusters can do namespace failover.
+- `masterClusterName` - the master cluster name, only the master cluster can register/update Namespace. All clusters can do Namespace failover.
 - `clusterInformation` - contains the local cluster name to `ClusterInformation` definition. The local cluster name should be consistent with `currentClusterName`. `ClusterInformation` sections consist of:
   - `enabled` - _boolean_ - whether a remote cluster is enabled for replication.
   - `initialFailoverVersion`

--- a/docs/references/dynamic-configuration.mdx
+++ b/docs/references/dynamic-configuration.mdx
@@ -2,7 +2,7 @@
 id: dynamic-configuration
 title: Temporal Service dynamic configuration reference
 sidebar_label: Dynamic configuration
-description: Temporal Service offers dynamic configuration keys that you can update on the fly to optimize performance without service interruption. Customize these settings to meet specific Workflow, Activity, Namespace, or Task Queue requirements, and test thoroughly before deploying to production. For more details, visit the Temporal GitHub repository.
+description: Reference for the dynamic configuration keys that tune a Temporal Service's rate limits, size limits, and retry defaults without a restart.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/errors.mdx
+++ b/docs/references/errors.mdx
@@ -2,7 +2,7 @@
 id: errors
 title: Errors
 sidebar_label: Errors
-description: This reference outlines possible Workflow Task errors, causes, and resolution steps in Temporal. It covers various error scenarios such as attribute failures, size limits, and system resource issues.
+description: Reference for every Workflow Task error in Temporal, including the cause and resolution steps for attribute, size-limit, and resource errors.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/events.mdx
+++ b/docs/references/events.mdx
@@ -2,7 +2,7 @@
 id: events
 title: Temporal Events reference
 sidebar_label: Events
-description: Events in a Temporal Service respond to external occurrences and Workflow Commands. Workflow Execution Event History includes WorkflowExecutionStarted, WorkflowExecutionCompleted, WorkflowExecutionFailed, and many more.
+description: Reference for every Event that can appear in a Workflow Execution's history, from WorkflowExecutionStarted to Nexus Operation events.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/failures.mdx
+++ b/docs/references/failures.mdx
@@ -2,7 +2,7 @@
 id: failures
 title: Temporal Failures reference
 sidebar_label: Failures
-description: A Failure in Temporal represents different types of errors in the system, categorized and managed uniquely within SDKs and protobuf messages, impacting Workflow and Activity operations.
+description: Reference for Temporal's Failure types, covering Workflow, Activity, and Nexus Operation errors and each SDK's corresponding class or exception.
 toc_max_heading_level: 4
 tags:
   - Reference
@@ -186,7 +186,7 @@ By default, Application Failures thrown from a Nexus Operation handler will be m
 | false (default) | HandlerErrorTypeInternal   | 500 Internal Server Error |
 | true            | UnsuccessfulOperationError | 424 Failed Dependency     |
 
-#### Use Nexus Errors directly
+#### Use Nexus errors directly
 
 For improved semantics and mapping to HTTP status codes for external Nexus callers (when supported), we recommend that Nexus Operation handlers throw a Nexus Error directly, which includes the list below with associated retry semantics.
 

--- a/docs/references/failures.mdx
+++ b/docs/references/failures.mdx
@@ -2,7 +2,7 @@
 id: failures
 title: Temporal Failures reference
 sidebar_label: Failures
-description: Reference for Temporal's Failure types, covering Workflow, Activity, and Nexus Operation errors and each SDK's corresponding class or exception.
+description: Reference for Temporal's Failure types, covering Workflow, Activity, and Nexus Operation errors and their corresponding SDK class or exception.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/index.mdx
+++ b/docs/references/index.mdx
@@ -3,18 +3,24 @@ id: index
 title: Temporal Platform references
 sidebar_label: References
 description:
-  Explore comprehensive references for SDK Metrics, Commands, Events, Web UI environment variables, Temporal Service and
-  Web UI configurations, and API guides for Go, Java, Python, TypeScript, .NET, and PHP.
+  Index of every Temporal reference page, covering SDK and Server APIs, Commands, Events, metrics, and Service and Web
+  UI configuration.
 tags:
   - Reference
 ---
 
 - [API reference](/references/api-reference)
-- [SDK metrics reference](/references/sdk-metrics)
+- [Temporal Service metrics reference](/references/cluster-metrics)
 - [Commands reference](/references/commands)
-- [Events reference](/references/events)
-- [Web UI environment variables reference](/references/web-ui-environment-variables)
 - [Temporal Service configuration reference](/references/configuration)
-- [Temporal Web UI configuration reference](/references/web-ui-configuration)
+- [Dynamic configuration reference](/references/dynamic-configuration)
+- [Errors reference](/references/errors)
+- [Events reference](/references/events)
+- [Environment configuration reference](/references/client-environment-configuration)
+- [Failures reference](/references/failures)
 - [Temporal Cloud Operation reference](/references/operation-list)
+- [SDK metrics reference](/references/sdk-metrics)
+- [Server options reference](/references/server-options)
+- [Temporal Web UI configuration reference](/references/web-ui-configuration)
+- [Web UI environment variables reference](/references/web-ui-environment-variables)
 - [Glossary](/glossary)

--- a/docs/references/operation-list.mdx
+++ b/docs/references/operation-list.mdx
@@ -2,12 +2,11 @@
 id: operation-list
 title: Operations
 sidebar_label: Operations
-description: Temporal Cloud limits the number of operations per second per namespace to keep the service reliable. This page lists all those operations.
+description: Reference for the operations Temporal Cloud rate-limits per second (OPS) per Namespace, including each operation's priority and throttling effect.
 toc_max_heading_level: 4
 tags:
-  - limits
-  - operations
-  - rate limiting
+  - Reference
+  - Limits
 ---
 
 import { OperationsTable } from '@site/src/components';
@@ -16,7 +15,7 @@ import { OperationsTable } from '@site/src/components';
 
 Temporal Cloud rate limits Namespaces using three related measures. [Actions per second (APS)](/cloud/actions) is the primary limit and the one [Capacity Modes](/cloud/capacity-modes) are expressed in; Requests per second (RPS) and [operations per second (OPS)](/cloud/limits#operations-per-second) are lower-level measures that protect the underlying services. This page covers OPS specifically.
 
-An operation is anything 1. a user does directly, or 2. Temporal does on behalf of the user in the background that results in load on Temporal Server. The exception is visibility queries: they do hit the Server (the query is passed from the server to the visibility store), but primarily the load is on the visibility system. Visibility rate limits are separate from OPS rate limits.
+An operation is anything 1. a user does directly, or 2. Temporal does on behalf of the user in the background that results in load on Temporal Server. The exception is visibility queries: they do hit the Server (the query is passed from the Server to the visibility store), but primarily the load is on the visibility system. Visibility rate limits are separate from OPS rate limits.
 
 Below is the list of operations, including:
 - operation name

--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -2,7 +2,7 @@
 id: sdk-metrics
 title: Temporal SDK metrics reference
 sidebar_label: SDK metrics
-description: Every metric emitted by Temporal Client and Worker processes across SDKs, including each metric's type, availability, and tags.
+description: Reference for the SDK metrics with guaranteed, defined behavior across Temporal Clients and Workers, including each metric's type and availability.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/sdk-metrics.mdx
+++ b/docs/references/sdk-metrics.mdx
@@ -2,7 +2,7 @@
 id: sdk-metrics
 title: Temporal SDK metrics reference
 sidebar_label: SDK metrics
-description: Reference for the metrics that Temporal SDKs emit from Client usage and Worker Processes.
+description: Every metric emitted by Temporal Client and Worker processes across SDKs, including each metric's type, availability, and tags.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/server-options.mdx
+++ b/docs/references/server-options.mdx
@@ -2,7 +2,7 @@
 id: server-options
 title: Temporal Server options reference
 sidebar_label: Server options
-description: Run the Temporal Server as a Go application by incorporating the package go.temporal.io/server/temporal. Customize server options like Config, Authorization, and TLS.
+description: Reference for the ServerOptions used to embed and run the Temporal Server as a Go application, including auth, TLS, and metrics options.
 toc_max_heading_level: 4
 tags:
   - Reference
@@ -30,7 +30,7 @@ Source code for parameter reference is here: https://github.com/temporalio/tempo
 
 ### WithConfig
 
-To launch a Temporal server, a configuration file is required. The server automatically searches for this configuration
+To launch a Temporal Server, a configuration file is required. The server automatically searches for this configuration
 in the default location ./config/development.yaml when starting. If you need to use a custom configuration, you can
 specify it through the server's configuration option. For comprehensive details about configuration parameters and
 structure, refer to the [official configuration documentation](https://pkg.go.dev/go.temporal.io/server/common/config).
@@ -53,7 +53,7 @@ s, err := temporal.NewServer(
 
 ### ForServices
 
-Sets the list of all valid temporal services.
+Sets the list of all valid Temporal services.
 The default can be used from the `go.temporal.io/server/temporal` package.
 
 ```go

--- a/docs/references/web-ui-configuration.mdx
+++ b/docs/references/web-ui-configuration.mdx
@@ -2,7 +2,7 @@
 id: web-ui-configuration
 title: Temporal Web UI configuration reference
 sidebar_label: Web UI config
-description:  Manage your Temporal Web UI Server efficiently with development.yaml. Set parameters for Auth, TLS, ports, and more.
+description: Reference for the development.yaml settings that configure the Temporal Web UI Server, including Auth, TLS, and Cloud UI options.
 toc_max_heading_level: 4
 tags:
   - Reference

--- a/docs/references/web-ui-environment-variables.mdx
+++ b/docs/references/web-ui-environment-variables.mdx
@@ -61,7 +61,7 @@ This variable is required for setting other environment variables.
 
 ## `TEMPORAL_UI_PORT`
 
-The port used by the Temporal WebUI Server and the HTTP API.
+The port used by the Temporal Web UI Server and the HTTP API.
 
 This variable is needed for all auth-related settings to work properly.
 

--- a/vale/styles/Temporal/Headings.yml
+++ b/vale/styles/Temporal/Headings.yml
@@ -30,6 +30,8 @@ exceptions:
   - VS
   - Windows
   - JSON
+  - QPS
+  - RPS
   # Temporal primitives and proper nouns
   - Activity
   - Activities


### PR DESCRIPTION
## Summary
- `index.mdx`: links all 14 sub-pages instead of 8 — six pages (`errors`, `failures`, `dynamic-configuration`, `cluster-metrics`, `server-options`, `client-environment-configuration`) had no path in from the landing page at all — and rewrites the description to stop enumerating specific SDKs, which had already gone stale.
- `api-reference.mdx`: fixes the description's SDK count (7 → 8, Rust was missing) and sentence-cases the three headings Vale flags ("SDK API References" → "SDK API references", etc).
- Rewrites every remaining description in the section to be a single sentence in the 120-155 character target, dropping banned openers ("Discover", "This reference outlines"), vague filler ("streamlined", "Use metric_defs.go for more"), and reversed/incomplete claims (`events.mdx`'s agency reversal, `failures.mdx` omitting Nexus, `configuration`/`dynamic-configuration` running 190–344 characters across 2–3 sentences).
- `operation-list.mdx`: fixes its tags (lowercase, missing the `Reference` base tag other reference pages use) and two Server/server capitalization slips.
- `client-environment-configuration.mdx`: adds the missing `Reference` base tag, matching every other page in this section.
- `cluster-metrics.mdx`: sentence-cases the 7 Nexus subsection headings that were in Title Case (`Nexus Machinery in the History Service`, etc).
- `failures.mdx`: sentence-cases `Use Nexus Errors directly`.
- `configuration.mdx`, `server-options.mdx`, `web-ui-environment-variables.mdx`: fixes stray lowercase/malformed Temporal proper nouns (namespace, Temporal server, temporal services, frontend-only, WebUI).

Two Vale suggestions remain in `dynamic-configuration.mdx` (RPS/QPS headings) — these are acronym-whitelist gaps in `vale/styles/Temporal/Headings.yml`, not prose mistakes, and out of scope for a content-only pass.

## Test plan
- [x] `vale --config .vale-ci.ini docs/references/`: 0 errors, 0 warnings (2 pre-existing acronym-related suggestions, unrelated to this change)
- [x] `yarn build`: passes, 0 broken links/anchors (confirms the 11 heading renames have no dangling inbound references)
- [x] `yarn check:orphans`: clean, now confirmed by the landing page actually linking every page