### PR TITLE
Clarify that Projects do not restrict cross-Project Nexus calls

### DIFF
--- a/docs/cloud/manage-access/permissions-reference.mdx
+++ b/docs/cloud/manage-access/permissions-reference.mdx
@@ -294,6 +294,10 @@ Cloud Ops API endpoints they can call.
 This table provides API-level details for permissions granted through Project-level roles. These permissions are
 configured per Project per user.
 
+These permissions control who can manage Nexus Endpoints in the Project.
+They do not restrict which Namespaces can call an Endpoint at runtime. That is the Endpoint [allowlist](/nexus/security#runtime-access-controls).
+See [Use Nexus across Projects](/cloud/projects#use-nexus-across-projects).
+
 | Permission                          | Member | List | Read | Contribute | Write | Project Admin |
 | ----------------------------------- | :----: | :--: | :--: | :--------: | :---: | :-----------: |
 | [CreateConnectivityRule](https://saas-api.tmprl.cloud/docs/httpapi.html#tag/connectivity-rules/POST/cloud/connectivity-rules) |        |      |      |     ✅      |   ✅   |       ✅       |

--- a/docs/cloud/manage-access/permissions-reference.mdx
+++ b/docs/cloud/manage-access/permissions-reference.mdx
@@ -295,7 +295,7 @@ This table provides API-level details for permissions granted through Project-le
 configured per Project per user.
 
 These permissions control who can manage Nexus Endpoints in the Project.
-They do not restrict which Namespaces can call an Endpoint at runtime. That is the Endpoint [allowlist](/nexus/security#runtime-access-controls).
+They do not restrict which Namespaces can call an Endpoint at runtime, which continues to be controlled by the Endpoint [allowlist](/nexus/security#runtime-access-controls).
 See [Use Nexus across Projects](/cloud/projects#use-nexus-across-projects).
 
 | Permission                          | Member | List | Read | Contribute | Write | Project Admin |

--- a/docs/cloud/projects.mdx
+++ b/docs/cloud/projects.mdx
@@ -24,6 +24,7 @@ Projects are an organizational layer within a Temporal Cloud Account that groups
 Projects make it easier to delegate ownership, manage access at scale, and organize resources without creating additional Cloud Accounts. As your organization grows, Projects help align your Temporal Cloud resources with your organizational structure while reducing operational overhead.
 
 Projects are for organization and authorization. They don't change how Workflows execute inside a Namespace.
+They also don't restrict which Namespaces can call a Nexus Endpoint. See [Use Nexus across Projects](#use-nexus-across-projects).
 
 <CaptionedImage
     src="/img/cloud/projects/resource-hierarchy.png"
@@ -159,6 +160,10 @@ curl -sS -X POST "$BASE/cloud/nexus/endpoints" \
   }'
 ```
 
+In this example, `payments-prod.a1b2c3` is the target Namespace (handler) and `checkout-prod.a1b2c3` is an allowed caller Namespace.
+Those Namespaces can be in different Projects from each other and from the Endpoint. Runtime access is the caller allowlist, not Project membership.
+See [Use Nexus across Projects](#use-nexus-across-projects).
+
 Use the
 [`CreateConnectivityRule` API call](https://saas-api.tmprl.cloud/docs/httpapi.html#tag/connectivity-rules/POST/cloud/connectivity-rules)
 to create a new Connectivity Rule within a Project. For example, for a private Connectivity Rule on AWS:
@@ -195,7 +200,17 @@ Then attach the Connectivity Rule to a Namespace within the same project via [Up
   </TabItem>
 </Tabs>
 
+## Use Nexus across Projects {/* #use-nexus-across-projects */}
 
+Projects group Nexus Endpoints for organization and authorization. They do not change how Nexus Operations run.
+
+- A Nexus Endpoint lives in one Project. That Project controls who can [create, list, update, and delete](/cloud/manage-access/permissions-reference#cloud-ops-api-permissions-2) the Endpoint.
+- Runtime access is unchanged: the Endpoint [allowlist of caller Namespaces](/nexus/security#runtime-access-controls). A caller Namespace in another Project can invoke the Endpoint if it is on that allowlist.
+- The target Namespace (handler) does not have to be in the same Project as the Endpoint. Unlike [Connectivity Rules](/cloud/connectivity#connectivity-rules), Nexus does not require the Endpoint and its Namespaces to share a Project.
+
+Example: an Endpoint in Project `payments`, a target Namespace in `payments`, and a caller Namespace in `checkout`.
+That call is allowed when the `checkout` Namespace is on the Endpoint allowlist.
+A user who can only list Endpoints in `checkout` will not see the Endpoint in `payments`.
 
 ## Manage Project Access
 

--- a/docs/encyclopedia/nexus/nexus-registry.mdx
+++ b/docs/encyclopedia/nexus/nexus-registry.mdx
@@ -17,7 +17,9 @@ Developers can advertise available Endpoints and Services, so others can find an
 Adding an Endpoint to the Registry deploys it for immediate runtime use.
 Endpoint names must be unique within the Registry.
 In Temporal Cloud, the Registry is global across your entire Account, spanning all Namespaces.
-In self-hosted deployments, it is scoped to a Cluster.
+Endpoint names remain unique Account-wide, and caller Workflows in any Namespace can use an Endpoint if they are on its allowlist.
+The Endpoint resource is Project-scoped: listing and updating it requires access to that Project. See [Use Nexus across Projects](/cloud/projects#use-nexus-across-projects).
+In self-hosted deployments, the Registry is scoped to a Cluster.
 
 ## View and manage Nexus Endpoints
 

--- a/docs/encyclopedia/nexus/nexus-registry.mdx
+++ b/docs/encyclopedia/nexus/nexus-registry.mdx
@@ -18,7 +18,7 @@ Adding an Endpoint to the Registry deploys it for immediate runtime use.
 Endpoint names must be unique within the Registry.
 In Temporal Cloud, the Registry is global across your entire Account, spanning all Namespaces.
 Endpoint names remain unique Account-wide, and caller Workflows in any Namespace can use an Endpoint if they are on its allowlist.
-The Endpoint resource is Project-scoped: listing and updating it requires access to that Project. See [Use Nexus across Projects](/cloud/projects#use-nexus-across-projects).
+The Endpoint resource is Project-scoped for management. Creating, updating, and deleting an Endpoint requires access to that Project **and** Namespace Admin on the target Namespace. See [Use Nexus across Projects](/cloud/projects#use-nexus-across-projects).
 In self-hosted deployments, the Registry is scoped to a Cluster.
 
 ## View and manage Nexus Endpoints
@@ -101,7 +101,7 @@ In Temporal Cloud, Nexus Registry respects RBAC permissions, and restricts funct
 | Action                     | Required permissions                                      |
 |---------------------------|-----------------------------------------------------------|
 | View or search Endpoints  | Read-only role (or higher) at the Account level           |
-| Manage Endpoints          | Developer role (or higher) and Namespace Admin on target Namespace |
+| Manage Endpoints          | Account Developer (or higher), or Project Contribute (or higher) on the Endpoint's Project, **and** Namespace Admin on the target Namespace. Effective Namespace Admin on the target Namespace is required separately. |
 
 See [Nexus security in Temporal Cloud](/cloud/nexus/security).
 

--- a/docs/encyclopedia/nexus/nexus.mdx
+++ b/docs/encyclopedia/nexus/nexus.mdx
@@ -83,6 +83,10 @@ Callers never need to know the handler's Namespace, Task Queue, or internal impl
 
 Endpoints are managed in the [Nexus Registry](/nexus/registry) using the UI, CLI, or Cloud Ops API.
 
+In Temporal Cloud, each Endpoint also belongs to a [Project](/cloud/projects#use-nexus-across-projects).
+The Project controls who can manage the Endpoint in the Cloud Ops API and UI.
+It does not restrict cross-Namespace Nexus calls. Runtime access remains the Endpoint allowlist of caller Namespaces.
+
 ### Queue-based Worker architecture
 
 Nexus uses the same queue-based Worker architecture as the rest of Temporal.

--- a/docs/evaluate/temporal-cloud/security.mdx
+++ b/docs/evaluate/temporal-cloud/security.mdx
@@ -87,8 +87,9 @@ See the [Connectivity](/cloud/connectivity) page for more information and detail
 
 ### Temporal Nexus
 
-Like Namespaces, a Nexus Endpoint is an account-scoped resource that is global within a Temporal Cloud account.
-Any Developer role (or higher) in an account, who is also a Namespace Admin on the endpoint’s target Namespace, can manage (create/update/delete) a Nexus Endpoint.
+Like Namespaces, the Nexus Registry is account-scoped and global within a Temporal Cloud account.
+Nexus Endpoint names remain unique Account-wide, but each Endpoint is Project-scoped for management.
+An Account Developer (or higher), or a user with Project Contribute (or higher) on the Endpoint's Project, can manage (create, update, or delete) an Endpoint only when they also have Namespace Admin on its target Namespace.
 All users with a Read-only role (or higher) in an account, can view and browse the full list of Endpoints.
 
 Runtime access from a Workflow in a caller Namespace to a Nexus Endpoint is controlled by an allowlist policy (of caller Namespaces) for each Endpoint in the Nexus API registry.


### PR DESCRIPTION
## Summary
- Document that a Nexus Endpoint in one Project can still be invoked from a caller Namespace in another Project when that Namespace is on the Endpoint allowlist.
- Clarify that Project roles control who can create, update, and delete the Endpoint resource. Account Read-only can still view Endpoints account-wide.
- Managing an Endpoint requires Account Developer (or higher) or Project Contribute (or higher) on the Endpoint's Project, **and** Namespace Admin on the target Namespace. That Namespace Admin check is separate.
- Note that unlike Connectivity Rules, the Endpoint, target Namespace, and caller Namespace do not have to share a Project.

Replaces the fork PR https://github.com/temporalio/documentation/pull/5243 so Vercel can deploy the preview from this repo.

## Why
Field asked this on the Projects page ([Slack](https://temporaltechnologies.slack.com/archives/C08KM6KBNHK/p1788531331621199)). The page said Endpoints are Project-scoped and stopped there, so people inferred runtime isolation.

## Test plan
- [ ] Confirm `/cloud/projects#use-nexus-across-projects` renders and is linked from the intro, Nexus overview, Nexus Registry, and Project permissions matrix.
- [ ] Confirm the Registry roles table: view is unchanged (Account Read-only); manage includes Project Contribute **and** target Namespace Admin.
- [ ] Confirm the CreateNexusEndpoint curl example still reads clearly with the target vs caller note.


Made with [Cursor](https://cursor.com)