### PR TITLE
chore(rust): update docs to 1.0

### DIFF
--- a/docs/develop/rust/activities/timeouts.mdx
+++ b/docs/develop/rust/activities/timeouts.mdx
@@ -25,7 +25,7 @@ The following timeouts are available in Activity options:
 
 An Activity Execution must have either the Start-To-Close Timeout or the Schedule-To-Close Timeout set. Temporal strongly recommends setting a Start-To-Close Timeout because the service relies on it to detect lost Activity Tasks and trigger retries when appropriate.
 
-In Rust, these values are configured as part of the Activity options when scheduling an Activity from a Workflow. The Rust SDK is currently pre-release and its API is still evolving, so exact method names may change over time.
+In Rust, these values are configured as part of the Activity options when scheduling an Activity from a Workflow.
 
 Available timeout fields include:
 

--- a/docs/develop/rust/client/temporal-client.mdx
+++ b/docs/develop/rust/client/temporal-client.mdx
@@ -109,7 +109,7 @@ use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(Default::default())?;
     let connection = Connection::connect(conn_opts).await?;
@@ -243,7 +243,7 @@ use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
     let (conn_opts, client_opts) =
         ClientOptions::load_from_config(LoadClientConfigProfileOptions::default())?;
     let connection = Connection::connect(conn_opts).await?;

--- a/docs/develop/rust/nexus/feature-guide.mdx
+++ b/docs/develop/rust/nexus/feature-guide.mdx
@@ -15,6 +15,7 @@ tags:
 ## Call a Nexus Operation from a Workflow {/* #call-nexus-operation */}
 
 You can start a Nexus operation from a Workflow using `ctx.start_nexus_operation()`:
+Enable the `experimental` feature for the `temporalio-sdk` dependency to use this API.
 
 ```rust
 use std::time::Duration;

--- a/docs/develop/rust/quickstart.mdx
+++ b/docs/develop/rust/quickstart.mdx
@@ -60,11 +60,11 @@ edition = "2024"
 [dependencies]
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
-temporalio-client = "0.7.0"
-temporalio-common = "0.7.0"
-temporalio-macros = "0.7.0"
-temporalio-sdk = "0.7.0"
-temporalio-workflow = "0.7.0"
+temporalio-client = "1.0.0"
+temporalio-common = "1.0.0"
+temporalio-macros = "1.0.0"
+temporalio-sdk = "1.0.0"
+temporalio-workflow = "1.0.0"
 tokio = { version = "1", features = ["full"] }
 `}
 </CodeSnippet>
@@ -255,7 +255,7 @@ use crate::activities::MyActivities;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
 
     // Set up client connection options, loading from config if available
     let (connection_options, client_options) = ClientOptions::load_from_config(

--- a/docs/develop/rust/workers/serverless-workers/cloud-run.mdx
+++ b/docs/develop/rust/workers/serverless-workers/cloud-run.mdx
@@ -20,8 +20,7 @@ import { ReleaseNoteHeader } from '@site/src/components';
   [sign up for updates](https://temporal.io/pages/serverless-workers-updates) to hear when Cloud Run reaches Public Preview.
 </ReleaseNoteHeader>
 
-The Rust SDK is in [Public Preview](/evaluate/development-production-features/release-stages#public-preview), and its API can change between releases.
-The code on this page is written against `temporalio-sdk` 0.7.0.
+The code on this page is written against `temporalio-sdk` 1.0.0.
 
 On a [GCP Cloud Run worker pool](https://cloud.google.com/run/docs/resource-model#worker-pools), you run a standard long-lived Temporal Worker.
 Register Workflows and Activities the same way you would with any other Rust Worker, and Temporal Cloud scales the pool up and down as work arrives and drains.
@@ -52,7 +51,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let namespace = std::env::var("TEMPORAL_NAMESPACE")?;
     let api_key = std::env::var("TEMPORAL_API_KEY")?;
 
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
 
     let connection_options = ConnectionOptions::new(Url::from_str(&format!("https://{address}"))?)
         .api_key(api_key)
@@ -63,10 +62,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let worker_options = WorkerOptions::new(std::env::var("TEMPORAL_TASK_QUEUE")?)
         .deployment_options(
-            WorkerDeploymentOptions::new(WorkerDeploymentVersion {
-                deployment_name: "my-app".to_owned(),
-                build_id: "build-1".to_owned(),
-            })
+            WorkerDeploymentOptions::new(
+                WorkerDeploymentVersion::builder()
+                    .deployment_name("my-app")
+                    .build_id("build-1")
+                    .build(),
+            )
             .use_worker_versioning(true)
             .default_versioning_behavior(VersioningBehavior::Pinned)
             .build(),
@@ -143,4 +144,4 @@ For how scale-in decisions are made, see [Serverless Workers on GCP Cloud Run](/
 ## Add observability {/* #add-observability */}
 
 A Cloud Run Worker emits the same traces and metrics as a Worker anywhere else.
-For how to configure metrics and telemetry, see the runtime options you pass to `Runtime::new_assume_tokio` and the [SDK metrics reference](/references/sdk-metrics).
+For how to configure metrics and telemetry, see the runtime options you pass to `Runtime::from_current_tokio` and the [SDK metrics reference](/references/sdk-metrics).

--- a/docs/develop/rust/workers/worker-process.mdx
+++ b/docs/develop/rust/workers/worker-process.mdx
@@ -10,8 +10,7 @@ tags:
   - Worker
 ---
 
-The Rust SDK is in [Public Preview](/evaluate/development-production-features/release-stages#public-preview), and its API can change between releases.
-The code on this page is written against `temporalio-sdk` 0.7.0.
+The code on this page is written against `temporalio-sdk` 1.0.0.
 
 ## Create and run a Worker {/* #run-a-dev-worker */}
 
@@ -20,11 +19,11 @@ The `#[workflow]` and `#[activities]` macros expand to code that refers to the `
 
 ```toml
 [dependencies]
-temporalio-sdk = "0.7.0"
-temporalio-client = "0.7.0"
-temporalio-common = "0.7.0"
-temporalio-macros = "0.7.0"
-temporalio-workflow = "0.7.0"
+temporalio-sdk = "1.0.0"
+temporalio-client = "1.0.0"
+temporalio-common = "1.0.0"
+temporalio-macros = "1.0.0"
+temporalio-workflow = "1.0.0"
 futures = "0.3"
 tokio = { version = "1", features = ["full"] }
 ```
@@ -40,7 +39,7 @@ use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
 
     let connection_options =
         ConnectionOptions::new(Url::from_str("http://localhost:7233")?).build();
@@ -105,10 +104,12 @@ use temporalio_common::worker::{
 
 let worker_options = WorkerOptions::new("my-task-queue")
     .deployment_options(
-        WorkerDeploymentOptions::new(WorkerDeploymentVersion {
-            deployment_name: "my-app".to_owned(),
-            build_id: "1.0".to_owned(),
-        })
+        WorkerDeploymentOptions::new(
+            WorkerDeploymentVersion::builder()
+                .deployment_name("my-app")
+                .build_id("1.0")
+                .build(),
+        )
         .use_worker_versioning(true)
         .default_versioning_behavior(VersioningBehavior::Pinned)
         .build(),

--- a/docs/develop/rust/workflows/child-workflows.mdx
+++ b/docs/develop/rust/workflows/child-workflows.mdx
@@ -86,7 +86,7 @@ impl GreetingWorkflow {
 
 ### Specify Child Workflow options
 
-Use [`ChildWorkflowOptions`](https://docs.rs/temporalio-sdk/0.7.0/temporalio_sdk/struct.ChildWorkflowOptions.html) to customize Child Workflow behavior.
+Use [`ChildWorkflowOptions`](https://docs.rs/temporalio-sdk/latest/temporalio_sdk/struct.ChildWorkflowOptions.html) to customize Child Workflow behavior.
 
 ### Execute multiple Child Workflows in parallel
 
@@ -131,7 +131,7 @@ A [Parent Close Policy](/parent-close-policy) determines what happens to a Child
 
 The default Parent Close Policy is set to terminate the Child Workflow Execution.
 
-Set Parent Close Policy using the [`parent_close_policy`](https://docs.rs/temporalio-sdk/0.7.0/temporalio_sdk/enum.ParentClosePolicy.html) field in `ChildWorkflowOptions`:
+Set Parent Close Policy using the [`parent_close_policy`](https://docs.rs/temporalio-sdk/latest/temporalio_sdk/enum.ParentClosePolicy.html) field in `ChildWorkflowOptions`:
 
 ```rust
 use temporalio_sdk::ParentClosePolicy;

--- a/docs/develop/rust/workflows/message-passing.mdx
+++ b/docs/develop/rust/workflows/message-passing.mdx
@@ -273,22 +273,14 @@ ctx.external_workflow("workflow-id-1", Some("run-id-1".into()))
 ### Signal-With-Start {/* #signal-with-start */}
 
 ```rust
-let signal_input = vec![ApproveInput {
-    name: "Ziggy".to_string(),
-}
-.as_json_payload()?]
-.into_payloads();
-
-let wf_handle = client.start_workflow(
+let wf_handle = client.signal_with_start_workflow(
     GreetingsWorkflow::run,
     (),
-    WorkflowStartOptions::new("my-task-queue", "greetings-workflow-10")
-        .start_signal(
-            WorkflowStartSignal::new("approve")
-                .maybe_input(signal_input)
-                .build(),
-        )
-        .build(),
+    GreetingsWorkflow::approve,
+    ApproveInput {
+        name: "Ziggy".to_string(),
+    },
+    WorkflowStartOptions::new("my-task-queue", "greetings-workflow-10").build(),
 ).await?;
 ```
 

--- a/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
+++ b/docs/production-deployment/worker-deployments/serverless-workers/cloud-run/index.mdx
@@ -402,7 +402,7 @@ use temporalio_sdk::{Runtime, Worker, WorkerOptions};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let address = std::env::var("TEMPORAL_ADDRESS")?;
 
-    let runtime = Runtime::new_assume_tokio(Default::default())?;
+    let runtime = Runtime::from_current_tokio(Default::default())?;
 
     let connection_options = ConnectionOptions::new(Url::from_str(&format!("https://{address}"))?)
         .api_key(std::env::var("TEMPORAL_API_KEY")?)


### PR DESCRIPTION
## What does this PR do?

Update docs for Rust SDK 1.0.0. GA hasn't been announced (planned 9/8), but the crate has been released. 

## Notes to reviewers

<!-- delete if n/a -->
