### PR TITLE
Clarify Finance Admin assignment restrictions

### DIFF
--- a/docs/cloud/manage-access/roles-and-permissions.mdx
+++ b/docs/cloud/manage-access/roles-and-permissions.mdx
@@ -33,6 +33,10 @@ The following table provides a summary of the account-level roles and their prim
 | Finance Admin | Manages billing and payment information     | No                    | None                                    | Full billing, payments, and usage         |
 | Read-Only     | Views account configuration and resources   | No                    | None                                    | None                              |
 
+Account Owner is the only customer role that can assign Finance Admin. This applies to users, groups, and Service
+Accounts. Global Admin can create these principals but cannot assign Finance Admin. Global Admin has usage visibility,
+not billing or payment access. Finance Admin is not a substitute for Account Owner.
+
 Account-level roles don't govern day-to-day operations within a Namespace. Access to resources inside a Namespace, such
 as Workflows and Workflow Executions, is controlled by [Namespace-level permissions](#namespace-level-permissions).
 

--- a/docs/cloud/manage-access/users.mdx
+++ b/docs/cloud/manage-access/users.mdx
@@ -55,7 +55,7 @@ In addition, there are two roles that the Global Admin cannot assign:
 - **Finance Admin**
   - Has permissions to view [billing](/cloud/billing-and-usage) information and update payment information
   - Otherwise, has the same permissions as Account Read-only users
-  - Can be assigned to Service Accounts by a Global Admin, but otherwise can only be assigned by an Account Owner
+  - Only an Account Owner can assign Finance Admin to a user, group, or Service Account
 
 :::note Default Role
 


### PR DESCRIPTION
## Summary
- State that only Account Owners can assign Finance Admin to users, groups, or Service Accounts.
- Clarify that Global Admins can create those principals but cannot grant Finance Admin.
- Distinguish Global Admin usage visibility from Finance Admin billing and payment access.
- Remove the incorrect Service Account exception from the user roles page.

## Validation
- Confirmed the branch started from the latest `temporalio/documentation` `main`.
- Confirmed `git diff --check` passes.
- Local Vale was unavailable; PR CI will run the repository's Vale gate.

Made with [Cursor](https://cursor.com)