### PR TITLE
Deep Agents: install from the released extra

### DIFF
--- a/docs/develop/python/integrations/deepagents.mdx
+++ b/docs/develop/python/integrations/deepagents.mdx
@@ -42,22 +42,19 @@ samples for the complete code.
 
 ## Install the plugin
 
-The plugin lives on the Temporal Python SDK's `main` branch and ships as the `temporalio[deepagents]` extra in the
-next SDK release. Until that release is on PyPI, install it from `main`:
+Install the Temporal Python SDK with Deep Agents support (`temporalio` 1.32.0 or later):
 
 ```bash
-uv add "temporalio[deepagents] @ git+https://github.com/temporalio/sdk-python.git"
+uv add "temporalio[deepagents]"
 ```
 
 or with pip:
 
 ```bash
-pip install "temporalio[deepagents] @ git+https://github.com/temporalio/sdk-python.git"
+pip install "temporalio[deepagents]"
 ```
 
-This builds the SDK from source, including its Rust core, so expect a few minutes on first install. Once the next
-release is available, a plain `uv add "temporalio[deepagents]"` (or `pip install "temporalio[deepagents]"`) is all
-you need.
+Requires Python 3.11 or newer, the same floor that `deepagents` sets.
 
 ## Hello World
 

--- a/docs/develop/python/integrations/deepagents.mdx
+++ b/docs/develop/python/integrations/deepagents.mdx
@@ -42,21 +42,21 @@ samples for the complete code.
 
 ## Install the plugin
 
-Install the Temporal Python SDK with Deep Agents support (`temporalio` 1.32.0 or later):
+Install the Temporal Python SDK with Deep Agents support:
 
 ```bash
-uv add "temporalio[deepagents]"
+uv add "temporalio[deepagents]>=1.32.0"
 ```
 
 or with pip:
 
 ```bash
-pip install "temporalio[deepagents]"
+pip install "temporalio[deepagents]>=1.32.0"
 ```
 
 Requires Python 3.11 or newer, the same floor that `deepagents` sets.
 
-## Hello World
+## Hello world
 
 A Deep Agent becomes durable without changing the agent code itself. The Workflow below builds a vanilla
 `create_deep_agent(...)` and drives it with `await agent.ainvoke(...)` — exactly the code you would write outside


### PR DESCRIPTION
## What

`temporalio` 1.32.0 shipped the `deepagents` extra, so the Deep Agents integration page's install section no longer needs the interim install-from-main instructions it published with (git URL install, source-build/Rust-core warning, and the transition sentence). The section now shows the plain `uv add "temporalio[deepagents]"` / `pip install "temporalio[deepagents]"` with the 1.32.0 floor and the Python ≥ 3.11 note.

Companion to temporalio/samples-python#363, which retires the same interim story from the samples suite the page's snippets source from.