### PR TITLE
docs: update TS Worker Docker images from EOL Debian bullseye to bookworm

### DIFF
--- a/docs/develop/typescript/workers/run-process.mdx
+++ b/docs/develop/typescript/workers/run-process.mdx
@@ -255,10 +255,10 @@ Workers based on the TypeScript SDK can be deployed and run as Docker containers
 Use an LTS Node.js release such as 18, 20, 22, or 24. Both `amd64` and `arm64` architectures are supported. A
 glibc-based image is required; musl-based images are _not_ supported (see below).
 
-The most direct way to deploy a TypeScript SDK Worker on Docker is to start with the `node:20-bullseye` image. For example:
+The most direct way to deploy a TypeScript SDK Worker on Docker is to start with the `node:20-bookworm` image. For example:
 
 ```dockerfile
-FROM node:20-bullseye
+FROM node:20-bookworm
 
 # For better cache utilization, copy package.json and lock file first and install the dependencies before copying the
 # rest of the application and building.
@@ -273,7 +273,7 @@ CMD ["npm", "start"]
 ```
 
 For smaller images and/or more secure deployments, it is also possible to use `-slim` Docker image variants (like
-`node:20-bullseye-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs20-debian11`) with the
+`node:20-bookworm-slim`) or `distroless/nodejs` Docker images (like `gcr.io/distroless/nodejs20-debian12`) with the
 following caveats.
 
 ### Using `node:slim` images
@@ -285,7 +285,7 @@ The requirement holds even when you connect to a local Temporal Service, and whe
 TLS. Install the package when you build the image:
 
 ```dockerfile
-FROM node:20-bullseye-slim
+FROM node:20-bookworm-slim
 
 RUN apt-get update \
     && apt-get install -y ca-certificates \
@@ -311,7 +311,7 @@ Use a multi-step Dockerfile instead:
 ```dockerfile
 # -- BUILD STEP --
 
-FROM node:20-bullseye AS builder
+FROM node:20-bookworm AS builder
 
 COPY . /app
 WORKDIR /app
@@ -321,7 +321,7 @@ RUN npm install --only=production \
 
 # -- RESULTING IMAGE --
 
-FROM gcr.io/distroless/nodejs20-debian11
+FROM gcr.io/distroless/nodejs20-debian12
 
 COPY --from=builder /app /app
 WORKDIR /app


### PR DESCRIPTION
## Summary

Update the TypeScript SDK Worker Docker guide to stop recommending Debian `bullseye`-based images and use `bookworm` instead.

Changes in `docs/develop/typescript/workers/run-process.mdx`:

- `node:20-bullseye` -> `node:20-bookworm`
- `node:20-bullseye-slim` -> `node:20-bookworm-slim`
- `gcr.io/distroless/nodejs20-debian11` -> `gcr.io/distroless/nodejs20-debian12`

## Why

Debian 11 (`bullseye`) has reached end-of-life for standard support, so the docs should point readers at a currently supported base image. Debian 12 (`bookworm`) is the current stable release. The `node:20-bookworm`, `node:20-bookworm-slim`, and `gcr.io/distroless/nodejs20-debian12` tags are official, published, and drop-in replacements, so the surrounding guidance (glibc requirement, `ca-certificates` on slim images, distroless multi-stage build) stays accurate.

## Testing

- Docs-only change limited to code blocks and inline references; no prose/structure changes.
- Verified no other `bullseye`/`debian11` references remain in the file.

## Risks

Low. The guidance and Dockerfile structure are unchanged; only the base image tags are updated to their supported equivalents.