### PR TITLE
Add asia-southeast1 to documentation

### DIFF
--- a/docs/cloud/references/regions/gcpregions.md
+++ b/docs/cloud/references/regions/gcpregions.md
@@ -82,3 +82,14 @@
   - None
 - **Multi-Cloud Replication**:
   - None
+
+### Asia Pacific - Sydney (`australia-southeast1`)
+
+- **Cloud API Code**: `gcp-australia-southeast1`
+- **Regional Endpoint**: `gcp-australia-southeast1.region.tmprl.cloud`
+- **Private Service Connect Service Attachment URI**: `projects/prod-gy3tvq4cr4rh7sp5dh4472tyf/regions/australia-southeast1/serviceAttachments/pl-4pca7`
+- **Same Region Replication**:  Not Available
+- **Multi-Region Replication**:
+  - None
+- **Multi-Cloud Replication**:
+  - None

--- a/docs/cloud/references/regions/private-service.md
+++ b/docs/cloud/references/regions/private-service.md
@@ -1,6 +1,7 @@
-| Region                 | Private Service Connect Service Name                                                          |
-| ---------------------- | ----------------------------------------------------------------------------------------------|
-| `asia-south1`          | `projects/prod-d5spc2sfeshws33bg33vwdef7/regions/asia-south1/serviceAttachments/pl-7w7tw`     |
-| `asia-southeast2`      | `projects/prod-bsbyrfwqqq885qkcr3s43y524/regions/asia-southeast2/serviceAttachments/pl-c3ayi` |
-| `us-central1`          | `projects/prod-d9ch6v2ybver8d2a8fyf7qru9/regions/us-central1/serviceAttachments/pl-5xzn`      |
-| `us-west1   `          | `projects/prod-rbe76zxxzydz4cbdz2xt5b59q/regions/us-west1/serviceAttachments/pl-94w0x`        |
+| Region                 | Private Service Connect Service Name                                                              |
+| ---------------------- | --------------------------------------------------------------------------------------------------|
+| `asia-south1`          | `projects/prod-d5spc2sfeshws33bg33vwdef7/regions/asia-south1/serviceAttachments/pl-7w7tw`         |
+| `asia-southeast2`      | `projects/prod-bsbyrfwqqq885qkcr3s43y524/regions/asia-southeast2/serviceAttachments/pl-c3ayi`     |
+| `australia-southeast1` | `projects/prod-gy3tvq4cr4rh7sp5dh4472tyf/regions/australia-southeast1/serviceAttachments/pl-4pca7`|
+| `us-central1`          | `projects/prod-d9ch6v2ybver8d2a8fyf7qru9/regions/us-central1/serviceAttachments/pl-5xzn`          |
+| `us-west1   `          | `projects/prod-rbe76zxxzydz4cbdz2xt5b59q/regions/us-west1/serviceAttachments/pl-94w0x`            |


### PR DESCRIPTION
## What does this PR do?

Adds GCP Sydney (`australia-southeast1`) to the docs.

## Notes to reviewers
Hold off on merging until we're sure we're ready to launch this region.
