### PR TITLE
activity section audit 

### DIFF
--- a/docs/develop/dotnet/activities/asynchronous-activity.mdx
+++ b/docs/develop/dotnet/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity Completion - .NET SDK
-sidebar_label: Asynchronous Activity Completion
+title: Asynchronous Activity completion - .NET SDK
+sidebar_label: Asynchronous Activity completion
 description: Asynchronously complete an Activity in Temporal. Follow simple steps to allow an Activity Function to return without the Activity Execution completing.
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/dotnet/activities/asynchronous-activity.mdx
+++ b/docs/develop/dotnet/activities/asynchronous-activity.mdx
@@ -1,12 +1,12 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity completion - .NET SDK
-sidebar_label: Asynchronous Activity completion
+title: Asynchronous Activity Completion - .NET SDK
+sidebar_label: Asynchronous Activity Completion
 description: Asynchronously complete an Activity in Temporal. Follow simple steps to allow an Activity Function to return without the Activity Execution completing.
 toc_max_heading_level: 4
 tags:
   - Activities
-  - .Net SDK
+  - .NET SDK
   - Temporal SDKs
 ---
 

--- a/docs/develop/dotnet/activities/basics.mdx
+++ b/docs/develop/dotnet/activities/basics.mdx
@@ -2,7 +2,7 @@
 id: basics
 title: Activity basics - .NET SDK
 sidebar_label: Activity basics
-description: Define an Activity with the Temporal .NET SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
+description: This section explains Activity basics with the .NET SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/dotnet/activities/basics.mdx
+++ b/docs/develop/dotnet/activities/basics.mdx
@@ -2,9 +2,10 @@
 id: basics
 title: Activity basics - .NET SDK
 sidebar_label: Activity basics
-description: This section explains Activity basics with the .NET SDK
+description: Define an Activity with the Temporal .NET SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - .NET SDK
   - Temporal SDKs
 ---

--- a/docs/develop/dotnet/activities/benign-exceptions.mdx
+++ b/docs/develop/dotnet/activities/benign-exceptions.mdx
@@ -2,7 +2,7 @@
 id: benign-exceptions
 title: Benign exceptions - .NET SDK
 sidebar_label: Benign exceptions
-description: Mark expected or non-severe Activity errors as benign to reduce noise in logs, metrics, and OpenTelemetry traces.
+description: Mark expected or non-severe Activity errors as benign in .NET to reduce noise in logs, metrics, and OpenTelemetry traces.
 toc_max_heading_level: 2
 tags:
   - Activities

--- a/docs/develop/dotnet/activities/dynamic-activity.mdx
+++ b/docs/develop/dotnet/activities/dynamic-activity.mdx
@@ -2,7 +2,7 @@
 id: dynamic-activity
 title: Dynamic Activity - .NET SDK
 sidebar_label: Dynamic Activity
-description: Register a Dynamic Activity with the Temporal .NET SDK to handle Activity Types that no other registered Activity implementation matches.
+description: This section explains Dynamic Activities with the .NET SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/dotnet/activities/dynamic-activity.mdx
+++ b/docs/develop/dotnet/activities/dynamic-activity.mdx
@@ -2,9 +2,10 @@
 id: dynamic-activity
 title: Dynamic Activity - .NET SDK
 sidebar_label: Dynamic Activity
-description: This section explains Dynamic Activities with the .NET SDK
+description: Register a Dynamic Activity with the Temporal .NET SDK to handle Activity Types that no other registered Activity implementation matches.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - .NET SDK
   - Temporal SDKs
 ---

--- a/docs/develop/dotnet/activities/execution.mdx
+++ b/docs/develop/dotnet/activities/execution.mdx
@@ -1,14 +1,14 @@
 ---
 id: execution
 title: Activity execution - .NET SDK
-description: Shows how to perform Activity execution with the .NET SDK
+description: Spawn an Activity Execution from a Workflow with the Temporal .NET SDK, set the required Activity Timeouts, and get the Activity's result.
 sidebar_label: Activity execution
 slug: /develop/dotnet/activities/execution
 toc_max_heading_level: 3
 tags:
+  - Activities
   - .NET SDK
   - Temporal SDKs
-  - Activity
 ---
 
 ## Start Activity Execution {/* #activity-execution */}

--- a/docs/develop/dotnet/activities/execution.mdx
+++ b/docs/develop/dotnet/activities/execution.mdx
@@ -1,7 +1,7 @@
 ---
 id: execution
 title: Activity execution - .NET SDK
-description: Spawn an Activity Execution from a Workflow with the Temporal .NET SDK, set the required Activity Timeouts, and get the Activity's result.
+description: Shows how to perform Activity execution with the .NET SDK
 sidebar_label: Activity execution
 slug: /develop/dotnet/activities/execution
 toc_max_heading_level: 3

--- a/docs/develop/dotnet/activities/index.mdx
+++ b/docs/develop/dotnet/activities/index.mdx
@@ -2,7 +2,7 @@
 id: index
 title: Activities - .NET SDK
 sidebar_label: Activities
-description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in .NET.
+description: This section explains how to implement Activities with the .NET SDK
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -23,8 +23,8 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/dotnet/activities/basics)
 - [Activity execution](/develop/dotnet/activities/execution)
 - [Standalone Activities Quickstart](/develop/dotnet/activities/standalone-activities-quickstart)
-- [Standalone Activities](/develop/dotnet/activities/standalone-activities)
+- [Standalone Activities Feature Guide](/develop/dotnet/activities/standalone-activities)
 - [Timeouts](/develop/dotnet/activities/timeouts)
-- [Asynchronous Activity Completion](/develop/dotnet/activities/asynchronous-activity)
+- [Asynchronous Activity completion](/develop/dotnet/activities/asynchronous-activity)
 - [Dynamic Activity](/develop/dotnet/activities/dynamic-activity)
 - [Benign exceptions](/develop/dotnet/activities/benign-exceptions)

--- a/docs/develop/dotnet/activities/index.mdx
+++ b/docs/develop/dotnet/activities/index.mdx
@@ -2,9 +2,10 @@
 id: index
 title: Activities - .NET SDK
 sidebar_label: Activities
-description: This section explains how to implement Activities with the .NET SDK
+description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in .NET.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - .NET SDK
   - Temporal SDKs
 ---
@@ -22,8 +23,8 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/dotnet/activities/basics)
 - [Activity execution](/develop/dotnet/activities/execution)
 - [Standalone Activities Quickstart](/develop/dotnet/activities/standalone-activities-quickstart)
-- [Standalone Activities Feature Guide](/develop/dotnet/activities/standalone-activities)
+- [Standalone Activities](/develop/dotnet/activities/standalone-activities)
 - [Timeouts](/develop/dotnet/activities/timeouts)
-- [Asynchronous Activity completion](/develop/dotnet/activities/asynchronous-activity)
+- [Asynchronous Activity Completion](/develop/dotnet/activities/asynchronous-activity)
 - [Dynamic Activity](/develop/dotnet/activities/dynamic-activity)
 - [Benign exceptions](/develop/dotnet/activities/benign-exceptions)

--- a/docs/develop/dotnet/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/dotnet/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities .NET Quickstart
+title: Standalone Activities Quickstart - .NET SDK
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal .NET SDK without writing a Workflow.
 tags:

--- a/docs/develop/dotnet/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/dotnet/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Quickstart - .NET SDK
+title: Standalone Activities .NET Quickstart
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal .NET SDK without writing a Workflow.
 tags:

--- a/docs/develop/dotnet/activities/standalone-activities.mdx
+++ b/docs/develop/dotnet/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities Feature Guide
+title: Standalone Activities - .NET SDK
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/dotnet/activities/standalone-activities.mdx
+++ b/docs/develop/dotnet/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities - .NET SDK
+title: Standalone Activities Feature Guide
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/dotnet/activities/timeouts.mdx
+++ b/docs/develop/dotnet/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - .NET SDK
 sidebar_label: Timeouts
-description: Set Activity Timeouts and a Retry Policy with the Temporal .NET SDK, override the next retry delay, and Heartbeat long-running Activities.
+description: Set the Schedule-To-Close, Start-To-Close, and Heartbeat Timeouts on a .NET Activity, tune its Retry Policy, and override the next retry delay.
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/dotnet/activities/timeouts.mdx
+++ b/docs/develop/dotnet/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - .NET SDK
 sidebar_label: Timeouts
-description: Optimize Workflow Execution with Temporal .NET SDK - Set Activity Timeouts and Retry Policies efficiently.
+description: Set Activity Timeouts and a Retry Policy with the Temporal .NET SDK, override the next retry delay, and Heartbeat long-running Activities.
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -57,7 +57,7 @@ return await Workflow.ExecuteActivityAsync(
     });
 ```
 
-### Override the Retry interval with `nextRetryDelay` {/* #next-retry-delay */}
+### Override the retry interval with `nextRetryDelay` {/* #next-retry-delay */}
 
 When you throw an [Application Failure](/references/failures#application-failure) and assign the `nextRetryDelay` field, its value replaces and overrides the Retry interval defined in the active Retry Policy.
 

--- a/docs/develop/go/activities/asynchronous-activity.mdx
+++ b/docs/develop/go/activities/asynchronous-activity.mdx
@@ -1,6 +1,6 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity completion - Go SDK
+title: Asynchronous Activity Completion - Go SDK
 sidebar_label: Asynchronous Activity Completion
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/go/activities/asynchronous-activity.mdx
+++ b/docs/develop/go/activities/asynchronous-activity.mdx
@@ -1,6 +1,6 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity Completion - Go SDK
+title: Asynchronous Activity completion - Go SDK
 sidebar_label: Asynchronous Activity Completion
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/go/activities/basics.mdx
+++ b/docs/develop/go/activities/basics.mdx
@@ -2,7 +2,7 @@
 id: basics
 title: Activity basics - Go SDK
 sidebar_label: Activity basics
-description: Define an Activity with the Temporal Go SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
+description: This section explains Activity basics with the Go SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/go/activities/basics.mdx
+++ b/docs/develop/go/activities/basics.mdx
@@ -2,14 +2,15 @@
 id: basics
 title: Activity basics - Go SDK
 sidebar_label: Activity basics
-description: This section explains Activity basics with the Go SDK
+description: Define an Activity with the Temporal Go SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Go SDK
   - Temporal SDKs
 ---
 
-## How to develop an Activity Definition in Go {/* #activity-definition */}
+## Develop an Activity Definition {/* #activity-definition */}
 
 In the Temporal Go SDK programming model, an Activity Definition is an exportable function or a `struct` method.
 
@@ -71,7 +72,7 @@ func (a *YourActivityObject) YourActivityDefinition(ctx context.Context, param Y
 }
 ```
 
-### How to develop Activity Parameters {/* #activity-parameters */}
+### Develop Activity parameters {/* #activity-parameters */}
 
 There is no explicit limit to the total number of parameters that an [Activity Definition](/activity-definition) may support.
 However, there is a limit to the total size of the data that ends up encoded into a gRPC message Payload.
@@ -122,7 +123,7 @@ func (a *YourActivityObject) YourActivityDefinition(ctx context.Context, param Y
 }
 ```
 
-### How to define Activity return values {/* #activity-return-values */}
+### Define Activity return values {/* #activity-return-values */}
 
 All data returned from an Activity must be serializable.
 
@@ -155,7 +156,7 @@ func (a *YourActivityObject) YourActivityDefinition(ctx context.Context, param Y
 }
 ```
 
-### How to customize Activity Type in Go {/* #customize-activity-type */}
+### Customize Activity Type {/* #customize-activity-type */}
 
 To customize the Activity Type, set the `Name` parameter with `RegisterOptions` when registering your Activity with a Worker.
 

--- a/docs/develop/go/activities/benign-exceptions.mdx
+++ b/docs/develop/go/activities/benign-exceptions.mdx
@@ -2,7 +2,7 @@
 id: benign-exceptions
 title: Benign exceptions - Go SDK
 sidebar_label: Benign exceptions
-description: Mark expected or non-severe Activity errors as benign to reduce noise in logs, metrics, and OpenTelemetry traces.
+description: Mark expected or non-severe Activity errors as benign in Go to reduce noise in logs, metrics, and OpenTelemetry traces.
 toc_max_heading_level: 2
 tags:
   - Activities

--- a/docs/develop/go/activities/dynamic-activity.mdx
+++ b/docs/develop/go/activities/dynamic-activity.mdx
@@ -2,7 +2,7 @@
 id: dynamic-activity
 title: Dynamic Activity - Go SDK
 sidebar_label: Dynamic Activity
-description: Register a Dynamic Activity with the Temporal Go SDK to handle Activity Types that no other registered Activity implementation matches.
+description: This section explains Dynamic Activities with the Go SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/go/activities/dynamic-activity.mdx
+++ b/docs/develop/go/activities/dynamic-activity.mdx
@@ -2,9 +2,10 @@
 id: dynamic-activity
 title: Dynamic Activity - Go SDK
 sidebar_label: Dynamic Activity
-description: This section explains Dynamic Activities with the Go SDK
+description: Register a Dynamic Activity with the Temporal Go SDK to handle Activity Types that no other registered Activity implementation matches.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Go SDK
   - Temporal SDKs
 ---

--- a/docs/develop/go/activities/execution.mdx
+++ b/docs/develop/go/activities/execution.mdx
@@ -1,8 +1,8 @@
 ---
 id: execution
 title: Activity execution - Go SDK
-description: Spawn an Activity Execution from a Go Workflow, get its result, and set every ActivityOptions field, from Timeouts and Task Queue to Retry Policy.
-sidebar_label: Activity execution
+description: Shows how to perform Activity execution with the Go SDK
+sidebar_label: Activity Execution
 slug: /develop/go/activities/execution
 toc_max_heading_level: 3
 tags:

--- a/docs/develop/go/activities/execution.mdx
+++ b/docs/develop/go/activities/execution.mdx
@@ -1,17 +1,17 @@
 ---
 id: execution
 title: Activity execution - Go SDK
-description: Shows how to perform Activity execution with the Go SDK
-sidebar_label: Activity Execution
+description: Spawn an Activity Execution from a Go Workflow, get its result, and set every ActivityOptions field, from Timeouts and Task Queue to Retry Policy.
+sidebar_label: Activity execution
 slug: /develop/go/activities/execution
 toc_max_heading_level: 3
 tags:
+  - Activities
   - Go SDK
   - Temporal SDKs
-  - Activity
 ---
 
-## How to start an Activity Execution {/* #activity-execution */}
+## Start an Activity Execution {/* #activity-execution */}
 
 Calls to spawn [Activity Executions](/activity-execution) are written within a [Workflow Definition](/workflow-definition).
 The call to spawn an Activity Execution generates the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command.
@@ -56,7 +56,7 @@ func YourWorkflowDefinition(ctx workflow.Context, param YourWorkflowParam) (*You
 }
 ```
 
-### How to set the required Activity Timeouts {/* #required-timeout */}
+### Set the required Activity Timeouts {/* #required-timeout */}
 
 Activity Execution semantics rely on several parameters.
 The only required value that needs to be set is either a [Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout) or a [Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout).
@@ -288,7 +288,7 @@ if err != nil {
 }
 ```
 
-### How to get the results of an Activity Execution {/* #get-activity-results */}
+### Get the results of an Activity Execution {/* #get-activity-results */}
 
 The call to spawn an [Activity Execution](/activity-execution) generates the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command and provides the Workflow with an Awaitable.
 Workflow Executions can either block progress until the result is available through the Awaitable or continue progressing, making use of the result when it becomes available.

--- a/docs/develop/go/activities/index.mdx
+++ b/docs/develop/go/activities/index.mdx
@@ -2,9 +2,10 @@
 id: index
 title: Activities - Go SDK
 sidebar_label: Activities
-description: This section explains how to implement Activities with the Go SDK
+description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in Go.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Go SDK
   - Temporal SDKs
 ---
@@ -22,8 +23,8 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/go/activities/basics)
 - [Activity execution](/develop/go/activities/execution)
 - [Standalone Activities Quickstart](/develop/go/activities/standalone-activities-quickstart)
-- [Standalone Activities Feature Guide](/develop/go/activities/standalone-activities)
+- [Standalone Activities](/develop/go/activities/standalone-activities)
 - [Timeouts](/develop/go/activities/timeouts)
-- [Asynchronous Activity completion](/develop/go/activities/asynchronous-activity)
+- [Asynchronous Activity Completion](/develop/go/activities/asynchronous-activity)
 - [Dynamic Activity](/develop/go/activities/dynamic-activity)
 - [Benign exceptions](/develop/go/activities/benign-exceptions)

--- a/docs/develop/go/activities/index.mdx
+++ b/docs/develop/go/activities/index.mdx
@@ -2,7 +2,7 @@
 id: index
 title: Activities - Go SDK
 sidebar_label: Activities
-description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in Go.
+description: This section explains how to implement Activities with the Go SDK
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -23,8 +23,8 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/go/activities/basics)
 - [Activity execution](/develop/go/activities/execution)
 - [Standalone Activities Quickstart](/develop/go/activities/standalone-activities-quickstart)
-- [Standalone Activities](/develop/go/activities/standalone-activities)
+- [Standalone Activities Feature Guide](/develop/go/activities/standalone-activities)
 - [Timeouts](/develop/go/activities/timeouts)
-- [Asynchronous Activity Completion](/develop/go/activities/asynchronous-activity)
+- [Asynchronous Activity completion](/develop/go/activities/asynchronous-activity)
 - [Dynamic Activity](/develop/go/activities/dynamic-activity)
 - [Benign exceptions](/develop/go/activities/benign-exceptions)

--- a/docs/develop/go/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/go/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Go Quickstart
+title: Standalone Activities Quickstart - Go SDK
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal Go SDK without writing a Workflow.
 tags:

--- a/docs/develop/go/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/go/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Quickstart - Go SDK
+title: Standalone Activities Go Quickstart
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal Go SDK without writing a Workflow.
 tags:

--- a/docs/develop/go/activities/standalone-activities.mdx
+++ b/docs/develop/go/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities Feature Guide
+title: Standalone Activities - Go SDK
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/go/activities/standalone-activities.mdx
+++ b/docs/develop/go/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities - Go SDK
+title: Standalone Activities Feature Guide
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/go/activities/timeouts.mdx
+++ b/docs/develop/go/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Go SDK
 sidebar_label: Timeouts
-description: Optimize Workflow Execution with Temporal Go SDK - Set Activity Timeouts and Retry Policies efficiently.
+description: Set Activity Timeouts and a Retry Policy with the Temporal Go SDK, override the next retry delay, and Heartbeat long-running Activities.
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -13,7 +13,7 @@ tags:
   - Temporal SDKs
 ---
 
-## How to set Activity timeouts {/* #activity-timeouts */}
+## Set Activity timeouts {/* #activity-timeouts */}
 
 Each Activity timeout controls the maximum duration of a different aspect of an Activity Execution.
 
@@ -89,7 +89,7 @@ if err != nil {
 }
 ```
 
-### Overriding the retry interval with Next Retry Delay {/* #next-retry-delay */}
+### Override the retry interval with `NextRetryDelay` {/* #next-retry-delay */}
 
 You may return an [Application Failure](/references/failures#application-failure) with the `NextRetryDelay` field set.
 This value will replace and override whatever the Retry interval would be on the Retry Policy.

--- a/docs/develop/go/activities/timeouts.mdx
+++ b/docs/develop/go/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Go SDK
 sidebar_label: Timeouts
-description: Set Activity Timeouts and a Retry Policy with the Temporal Go SDK, override the next retry delay, and Heartbeat long-running Activities.
+description: Set the Schedule-To-Close, Start-To-Close, and Heartbeat Timeouts on a Go Activity, tune its Retry Policy, and override the next retry delay.
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/java/activities/asynchronous-activity.mdx
+++ b/docs/develop/java/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity completion - Java SDK
-sidebar_label: Asynchronous Activity completion
+title: Asynchronous Activity Completion - Java SDK
+sidebar_label: Asynchronous Activity Completion
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/java/activities/asynchronous-activity.mdx
+++ b/docs/develop/java/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity Completion - Java SDK
-sidebar_label: Asynchronous Activity Completion
+title: Asynchronous Activity completion - Java SDK
+sidebar_label: Asynchronous Activity completion
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/java/activities/basics.mdx
+++ b/docs/develop/java/activities/basics.mdx
@@ -2,9 +2,10 @@
 id: basics
 title: Activity basics - Java SDK
 sidebar_label: Activity basics
-description: This section explains how to implement Activities with the Java SDK
+description: Define an Activity with the Temporal Java SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Java SDK
   - Temporal SDKs
 ---
@@ -157,7 +158,7 @@ public interface GreetingActivities {
 - Method Name: `composeGreeting`
 - Activity Type: `ComposeGreeting`
 
-### Custom Prefix
+### Custom prefix
 
 Using the `namePrefix` parameter in the `@ActivityInterface` annotation adds a prefix to each Activity Type name mentioned in the interface, unless the prefix is specifically overridden:
 
@@ -178,7 +179,7 @@ public interface GreetingActivities {
 
 The Activity Type is capitalized, even when using a prefix.
 
-### Custom Name
+### Custom name
 
 To override the default name and any inherited prefixes, use the `name` parameter in the `@ActivityMethod` annotation:
 

--- a/docs/develop/java/activities/basics.mdx
+++ b/docs/develop/java/activities/basics.mdx
@@ -2,7 +2,7 @@
 id: basics
 title: Activity basics - Java SDK
 sidebar_label: Activity basics
-description: Define an Activity with the Temporal Java SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
+description: This section explains Activity basics with the Java SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/java/activities/benign-exceptions.mdx
+++ b/docs/develop/java/activities/benign-exceptions.mdx
@@ -2,7 +2,7 @@
 id: benign-exceptions
 title: Benign exceptions - Java SDK
 sidebar_label: Benign exceptions
-description: Mark expected or non-severe Activity errors as benign to reduce noise in logs, metrics, and OpenTelemetry traces.
+description: Mark expected or non-severe Activity errors as benign in Java to reduce noise in logs, metrics, and OpenTelemetry traces.
 toc_max_heading_level: 2
 tags:
   - Activities

--- a/docs/develop/java/activities/execution.mdx
+++ b/docs/develop/java/activities/execution.mdx
@@ -1,8 +1,8 @@
 ---
 id: execution
 title: Activity execution - Java SDK
-description: Invoke Activities synchronously or asynchronously from a Java Workflow, set ActivityOptions and Timeouts, and read the ActivityExecutionContext.
-sidebar_label: Activity execution
+description: Shows how to perform Activity execution with the Java SDK
+sidebar_label: Activity Execution
 slug: /develop/java/activities/execution
 toc_max_heading_level: 3
 tags:
@@ -292,9 +292,6 @@ This or `StartToCloseTimeout` must be set.
 - Default: Unlimited.
   Note that if `WorkflowRunTimeout` and/or `WorkflowExecutionTimeout` are defined in the Workflow, all Activity retries will stop when either or both of these timeouts are reached.
 
-You can set Activity Options using an `ActivityStub` within a Workflow implementation, or per-Activity using `WorkflowImplementationOptions` within a Worker.
-Note that if you define options per-Activity Type options with `WorkflowImplementationOptions.setActivityOptions()`, setting them again specifically with `ActivityStub` in a Workflow will override this setting.
-
 - With `ActivityStub`
 
   ```java
@@ -324,9 +321,6 @@ To set a [Schedule-To-Start Timeout](/encyclopedia/detecting-activity-failures#s
 
 - Type: `Duration`
 - Default: Unlimited. This timeout is non-retryable.
-
-You can set Activity Options using an `ActivityStub` within a Workflow implementation, or per-Activity using `WorkflowImplementationOptions` within a Worker.
-Note that if you define options per-Activity Type options with `WorkflowImplementationOptions.setActivityOptions()`, setting them again specifically with `ActivityStub` in a Workflow will override this setting.
 
 - With `ActivityStub`
 
@@ -363,9 +357,6 @@ This or `ScheduleToClose` must be set.
 - Type: `Duration`
 - Default: Defaults to [`ScheduleToCloseTimeout`](#scheduletoclosetimeout) value
 
-You can set Activity Options using an `ActivityStub` within a Workflow implementation, or per-Activity using `WorkflowImplementationOptions` within a Worker.
-Note that if you define options per-Activity Type options with `WorkflowImplementationOptions.setActivityOptions()`, setting them again specifically with `ActivityStub` in a Workflow will override this setting.
-
 - With `ActivityStub`
 
   ```java
@@ -396,9 +387,6 @@ To set a [Heartbeat Timeout](/encyclopedia/detecting-activity-failures#heartbeat
 
 - Type: `Duration`
 - Default: None
-
-You can set Activity Options using an `ActivityStub` within a Workflow implementation, or per-Activity using `WorkflowImplementationOptions` within a Worker.
-Note that if you define options per-Activity Type options with `WorkflowImplementationOptions.setActivityOptions()`, setting them again specifically with `ActivityStub` in a Workflow will override this setting.
 
 - With `ActivityStub`
 

--- a/docs/develop/java/activities/execution.mdx
+++ b/docs/develop/java/activities/execution.mdx
@@ -1,14 +1,14 @@
 ---
 id: execution
 title: Activity execution - Java SDK
-description: Shows how to perform Activity execution with the Java SDK
-sidebar_label: Activity Execution
+description: Invoke Activities synchronously or asynchronously from a Java Workflow, set ActivityOptions and Timeouts, and read the ActivityExecutionContext.
+sidebar_label: Activity execution
 slug: /develop/java/activities/execution
 toc_max_heading_level: 3
 tags:
+  - Activities
   - Java SDK
   - Temporal SDKs
-  - Activity
 ---
 
 ## Start an Activity Execution {/* #activity-execution */}
@@ -46,7 +46,7 @@ Calling a method on the Activity interface schedules the Activity invocation wit
 
 Activities can be invoked synchronously or asynchronously.
 
-### Invoking Activities Synchronously
+### Invoke Activities synchronously
 
 In the following example, we use the type-safe `Workflow.newActivityStub` within the "FileProcessingWorkflow" Workflow implementation to create a client-side stub of the `FileProcessingActivities` class. We also define `ActivityOptions` and set `setStartToCloseTimeout` option to one hour.
 
@@ -118,7 +118,7 @@ This is useful when the Activity type is not known at compile time, or to invoke
     activity.execute("ComposeGreeting", String.class, "Hello World", "Spanish");
 ```
 
-### Invoking Activities Asynchronously
+### Invoke Activities asynchronously
 
 Sometimes Workflows need to perform certain operations in parallel.
 The Temporal Java SDK provides the `Async` class which includes static methods used to invoke any Activity asynchronously.
@@ -179,7 +179,7 @@ The following example shows how to call two Activity methods, "download" and "up
   }
 ```
 
-### Activity Execution Context
+### ActivityExecutionContext
 
 `ActivityExecutionContext` is a context object passed to each Activity implementation by default.
 You can access it in your Activity implementations via `Activity.getExecutionContext()`.

--- a/docs/develop/java/activities/index.mdx
+++ b/docs/develop/java/activities/index.mdx
@@ -2,9 +2,10 @@
 id: index
 title: Activities - Java SDK
 sidebar_label: Activities
-description: This section explains how to implement Activities with the Java SDK
+description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in Java.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Java SDK
   - Temporal SDKs
 ---
@@ -22,7 +23,7 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/java/activities/basics)
 - [Activity execution](/develop/java/activities/execution)
 - [Standalone Activities Quickstart](/develop/java/activities/standalone-activities-quickstart)
-- [Standalone Activities Feature Guide](/develop/java/activities/standalone-activities)
+- [Standalone Activities](/develop/java/activities/standalone-activities)
 - [Timeouts](/develop/java/activities/timeouts)
 - [Asynchronous Activity Completion](/develop/java/activities/asynchronous-activity)
 - [Benign exceptions](/develop/java/activities/benign-exceptions)

--- a/docs/develop/java/activities/index.mdx
+++ b/docs/develop/java/activities/index.mdx
@@ -2,7 +2,7 @@
 id: index
 title: Activities - Java SDK
 sidebar_label: Activities
-description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in Java.
+description: This section explains how to implement Activities with the Java SDK
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -23,7 +23,7 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/java/activities/basics)
 - [Activity execution](/develop/java/activities/execution)
 - [Standalone Activities Quickstart](/develop/java/activities/standalone-activities-quickstart)
-- [Standalone Activities](/develop/java/activities/standalone-activities)
+- [Standalone Activities Feature Guide](/develop/java/activities/standalone-activities)
 - [Timeouts](/develop/java/activities/timeouts)
 - [Asynchronous Activity Completion](/develop/java/activities/asynchronous-activity)
 - [Benign exceptions](/develop/java/activities/benign-exceptions)

--- a/docs/develop/java/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/java/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Quickstart - Java SDK
+title: Standalone Activities Java Quickstart
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal Java SDK without writing a Workflow.
 tags:

--- a/docs/develop/java/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/java/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Java Quickstart
+title: Standalone Activities Quickstart - Java SDK
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal Java SDK without writing a Workflow.
 tags:

--- a/docs/develop/java/activities/standalone-activities.mdx
+++ b/docs/develop/java/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities - Java SDK
+title: Standalone Activities Feature Guide
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/java/activities/standalone-activities.mdx
+++ b/docs/develop/java/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities Feature Guide
+title: Standalone Activities - Java SDK
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/java/activities/timeouts.mdx
+++ b/docs/develop/java/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Java SDK
 sidebar_label: Timeouts
-description: Set Activity Timeouts and a Retry Policy with the Temporal Java SDK, override the next retry delay, and Heartbeat long-running Activities.
+description: This section explains how to set Activity Timeouts with the Java SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/java/activities/timeouts.mdx
+++ b/docs/develop/java/activities/timeouts.mdx
@@ -2,9 +2,13 @@
 id: timeouts
 title: Activity Timeouts - Java SDK
 sidebar_label: Timeouts
-description: This section explains how to set Activity Timeouts with the Java SDK
+description: Set Activity Timeouts and a Retry Policy with the Temporal Java SDK, override the next retry delay, and Heartbeat long-running Activities.
 toc_max_heading_level: 4
 tags:
+  - Activities
+  - Workflows
+  - Errors
+  - Failures
   - Java SDK
   - Temporal SDKs
 ---

--- a/docs/develop/php/activities/asynchronous-activity.mdx
+++ b/docs/develop/php/activities/asynchronous-activity.mdx
@@ -13,7 +13,7 @@ description:
   facilitating parallel operations in Workflows.
 ---
 
-## How to asynchronously complete an Activity {/* #asynchronous-activity-completion */}
+## Asynchronously complete an Activity {/* #asynchronous-activity-completion */}
 
 [Asynchronous Activity Completion](/activity-execution#asynchronous-activity-completion) enables the Activity Function
 to return without the Activity Execution completing.

--- a/docs/develop/php/activities/basics.mdx
+++ b/docs/develop/php/activities/basics.mdx
@@ -1,15 +1,16 @@
 ---
 id: basics
-title: Activity Basics - PHP SDK
-sidebar_label: Activity Basics
-description: This section explains Activity Basics with the PHP SDK
+title: Activity basics - PHP SDK
+sidebar_label: Activity basics
+description: Define an Activity with the Temporal PHP SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - PHP SDK
   - Temporal SDKs
 ---
 
-## How to develop a basic Activity {/* #develop-activities */}
+## Develop a basic Activity {/* #develop-activities */}
 
 One of the primary things that Workflows do is orchestrate the execution of Activities.
 An Activity is a normal function or method execution that's intended to execute a single, well-defined action (either short or long-running), such as querying a database, calling a third-party API, or transcoding a media file.
@@ -36,7 +37,7 @@ interface FileProcessingActivities
 }
 ```
 
-### How to develop Activity Parameters {/* #activity-parameters */}
+### Develop Activity parameters {/* #activity-parameters */}
 
 There is no explicit limit to the total number of parameters that an [Activity Definition](/activity-definition) may support.
 However, there is a limit to the total size of the data that ends up encoded into a gRPC message Payload.
@@ -59,7 +60,7 @@ A single Workflow can use more than one Activity interface and call more than on
 The only requirement is that Activity method arguments and return values are serializable to a byte array using the provided [DataConverter](https://github.com/temporalio/sdk-php/blob/master/src/DataConverter/DataConverterInterface.php) interface.
 The default implementation uses a JSON serializer, but an alternative implementation can be easily configured.
 
-### How to define Activity return values {/* #activity-return-values */}
+### Define Activity return values {/* #activity-return-values */}
 
 All data returned from an Activity must be serializable.
 
@@ -91,7 +92,7 @@ class GreetingActivity implements GreetingActivityInterface
 }
 ```
 
-### How to customize your Activity Type {/* #activity-type */}
+### Customize your Activity Type {/* #activity-type */}
 
 Activities have a Type that are referred to as the Activity name.
 The following examples demonstrate how to set a custom name for your Activity Type.

--- a/docs/develop/php/activities/basics.mdx
+++ b/docs/develop/php/activities/basics.mdx
@@ -2,7 +2,7 @@
 id: basics
 title: Activity basics - PHP SDK
 sidebar_label: Activity basics
-description: Define an Activity with the Temporal PHP SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
+description: This section explains Activity basics with the PHP SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/php/activities/execution.mdx
+++ b/docs/develop/php/activities/execution.mdx
@@ -1,8 +1,8 @@
 ---
 id: execution
 title: Activity execution - PHP SDK
-description: Spawn an Activity Execution from a Workflow with the Temporal PHP SDK, set the required Activity Timeouts, and get the Activity's result.
-sidebar_label: Activity execution
+description: Shows how to perform Activity execution with the PHP SDK
+sidebar_label: Activity Execution
 slug: /develop/php/activities/execution
 toc_max_heading_level: 3
 tags:

--- a/docs/develop/php/activities/execution.mdx
+++ b/docs/develop/php/activities/execution.mdx
@@ -1,17 +1,17 @@
 ---
 id: execution
 title: Activity execution - PHP SDK
-description: Shows how to perform Activity execution with the PHP SDK
-sidebar_label: Activity Execution
+description: Spawn an Activity Execution from a Workflow with the Temporal PHP SDK, set the required Activity Timeouts, and get the Activity's result.
+sidebar_label: Activity execution
 slug: /develop/php/activities/execution
 toc_max_heading_level: 3
 tags:
+  - Activities
   - PHP SDK
   - Temporal SDKs
-  - Activity
 ---
 
-## How to start an Activity Execution {/* #activity-execution */}
+## Start an Activity Execution {/* #activity-execution */}
 
 Calls to spawn [Activity Executions](/activity-execution) are written within a [Workflow Definition](/workflow-definition).
 The call to spawn an Activity Execution generates the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command.
@@ -83,13 +83,13 @@ class FileProcessingActivitiesImpl implements FileProcessingActivities {
 }
 ```
 
-### How to set the required Activity Timeouts {/* #required-timeout */}
+### Set the required Activity Timeouts {/* #required-timeout */}
 
 Activity Execution semantics rely on several parameters.
 The only required value that needs to be set is either a [Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout) or a [Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout).
 These values are set in the Activity Options.
 
-### How to get the results of an Activity Execution {/* #get-activity-results */}
+### Get the results of an Activity Execution {/* #get-activity-results */}
 
 The call to spawn an [Activity Execution](/activity-execution) generates the [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command and provides the Workflow with an Awaitable.
 Workflow Executions can either block progress until the result is available through the Awaitable or continue progressing, making use of the result when it becomes available.

--- a/docs/develop/php/activities/index.mdx
+++ b/docs/develop/php/activities/index.mdx
@@ -2,9 +2,10 @@
 id: index
 title: Activities - PHP SDK
 sidebar_label: Activities
-description: This section explains how to implement Activities with the PHP SDK
+description: Define Activities, spawn Activity Executions from a Workflow, set Activity Timeouts and Retry Policies, and complete Activities asynchronously in PHP.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - PHP SDK
   - Temporal SDKs
 ---
@@ -19,7 +20,7 @@ import * as Components from '@site/src/components';
 
 ## Activities
 
-- [Activity Basics](/develop/php/activities/basics)
-- [Activity Execution](/develop/php/activities/execution)
+- [Activity basics](/develop/php/activities/basics)
+- [Activity execution](/develop/php/activities/execution)
 - [Timeouts](/develop/php/activities/timeouts)
 - [Asynchronous Activity Completion](/develop/php/activities/asynchronous-activity)

--- a/docs/develop/php/activities/index.mdx
+++ b/docs/develop/php/activities/index.mdx
@@ -2,7 +2,7 @@
 id: index
 title: Activities - PHP SDK
 sidebar_label: Activities
-description: Define Activities, spawn Activity Executions from a Workflow, set Activity Timeouts and Retry Policies, and complete Activities asynchronously in PHP.
+description: This section explains how to implement Activities with the PHP SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/php/activities/timeouts.mdx
+++ b/docs/develop/php/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - PHP SDK
 sidebar_label: Timeouts
-description: Optimize Workflow Execution with Temporal PHP SDK - Set Activity Timeouts and Retry Policies efficiently.
+description: Set Activity Timeouts and a Retry Policy with the Temporal PHP SDK, override the next retry delay, and Heartbeat long-running Activities.
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -13,7 +13,7 @@ tags:
   - Temporal SDKs
 ---
 
-## How to set Activity timeouts {/* #activity-timeouts */}
+## Set Activity timeouts {/* #activity-timeouts */}
 
 Each Activity timeout controls the maximum duration of a different aspect of an Activity Execution.
 
@@ -44,7 +44,7 @@ $this->greetingActivity = Workflow::newActivityStub(
 );
 ```
 
-### How to set an Activity Retry Policy {/* #activity-retries */}
+### Set an Activity Retry Policy {/* #activity-retries */}
 
 A Retry Policy works in cooperation with the timeouts to provide fine controls to optimize the execution experience.
 
@@ -70,13 +70,13 @@ $this->greetingActivity = Workflow::newActivityStub(
 
 For an executable code sample, see [ActivityRetry sample](https://github.com/temporalio/samples-php/tree/master/app/src/ActivityRetry) in the PHP samples repository.
 
-### How to set the required Activity Timeouts {/* #required-timeout */}
+### Set the required Activity Timeouts {/* #required-timeout */}
 
 Activity Execution semantics rely on several parameters.
 The only required value that needs to be set is either a [Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout) or a [Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout).
 These values are set in the Activity Options.
 
-## Activity next Retry delay {/* #activity-next-retry-delay */}
+## Activity next retry delay {/* #activity-next-retry-delay */}
 
 **How to override the next Retry delay following an Activity failure using the Temporal PHP SDK**
 
@@ -96,7 +96,7 @@ throw new \Temporal\Exception\Failure\ApplicationFailure(
 );
 ```
 
-## How to Heartbeat an Activity {/* #activity-heartbeats */}
+## Heartbeat an Activity {/* #activity-heartbeats */}
 
 An [Activity Heartbeat](/encyclopedia/detecting-activity-failures#activity-heartbeat) is a ping from the [Worker Process](/workers#worker-process) that is executing the Activity to the [Temporal Service](/temporal-service).
 Each Heartbeat informs the Temporal Service that the [Activity Execution](/activity-execution) is making progress and the Worker has not crashed.
@@ -151,7 +151,7 @@ class FileProcessingActivitiesImpl implements FileProcessingActivities
 }
 ```
 
-#### How to set a Heartbeat Timeout {/* #heartbeat-timeout */}
+#### Set a Heartbeat Timeout {/* #heartbeat-timeout */}
 
 A [Heartbeat Timeout](/encyclopedia/detecting-activity-failures#heartbeat-timeout) works in conjunction with [Activity Heartbeats](/encyclopedia/detecting-activity-failures#activity-heartbeat).
 

--- a/docs/develop/php/activities/timeouts.mdx
+++ b/docs/develop/php/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - PHP SDK
 sidebar_label: Timeouts
-description: Set Activity Timeouts and a Retry Policy with the Temporal PHP SDK, override the next retry delay, and Heartbeat long-running Activities.
+description: Set the Schedule-To-Close, Start-To-Close, and Heartbeat Timeouts on a PHP Activity, tune its Retry Policy, and override the next retry delay.
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -151,7 +151,7 @@ class FileProcessingActivitiesImpl implements FileProcessingActivities
 }
 ```
 
-#### Set a Heartbeat Timeout {/* #heartbeat-timeout */}
+### Set a Heartbeat Timeout {/* #heartbeat-timeout */}
 
 A [Heartbeat Timeout](/encyclopedia/detecting-activity-failures#heartbeat-timeout) works in conjunction with [Activity Heartbeats](/encyclopedia/detecting-activity-failures#activity-heartbeat).
 

--- a/docs/develop/python/activities/asynchronous-activity.mdx
+++ b/docs/develop/python/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity completion - Python SDK
-sidebar_label: Asynchronous Activity completion
+title: Asynchronous Activity Completion - Python SDK
+sidebar_label: Asynchronous Activity Completion
 description: Asynchronously complete an Activity using the Temporal Python SDK. Follow three steps for Activity completion and use the Temporal Client for Heartbeat and updates.
 toc_max_heading_level: 2
 tags:

--- a/docs/develop/python/activities/asynchronous-activity.mdx
+++ b/docs/develop/python/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity Completion - Python SDK
-sidebar_label: Asynchronous Activity Completion
+title: Asynchronous Activity completion - Python SDK
+sidebar_label: Asynchronous Activity completion
 description: Asynchronously complete an Activity using the Temporal Python SDK. Follow three steps for Activity completion and use the Temporal Client for Heartbeat and updates.
 toc_max_heading_level: 2
 tags:

--- a/docs/develop/python/activities/basics.mdx
+++ b/docs/develop/python/activities/basics.mdx
@@ -2,9 +2,10 @@
 id: basics
 title: Activity basics - Python SDK
 sidebar_label: Activity basics
-description: This section explains Activity Basics with the Python SDK
+description: Define an Activity with the Temporal Python SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Python SDK
   - Temporal SDKs
 ---
@@ -56,7 +57,7 @@ async def your_activity(input: YourParams) -> str:
     return f"{input.greeting}, {input.name}!"
 ```
 
-### Develop Activity Parameters {/* #activity-parameters */}
+### Develop Activity parameters {/* #activity-parameters */}
 
 There is no explicit limit to the total number of parameters that an [Activity Definition](/activity-definition) may
 support. However, there is a limit to the total size of the data that ends up encoded into a gRPC message Payload.

--- a/docs/develop/python/activities/basics.mdx
+++ b/docs/develop/python/activities/basics.mdx
@@ -2,7 +2,7 @@
 id: basics
 title: Activity basics - Python SDK
 sidebar_label: Activity basics
-description: Define an Activity with the Temporal Python SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
+description: This section explains Activity basics with the Python SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/python/activities/benign-exceptions.mdx
+++ b/docs/develop/python/activities/benign-exceptions.mdx
@@ -2,7 +2,7 @@
 id: benign-exceptions
 title: Benign exceptions - Python SDK
 sidebar_label: Benign exceptions
-description: Mark expected or non-severe Activity errors as benign to reduce noise in logs, metrics, and OpenTelemetry traces.
+description: Mark expected or non-severe Activity errors as benign in Python to reduce noise in logs, metrics, and OpenTelemetry traces.
 toc_max_heading_level: 2
 tags:
   - Activities

--- a/docs/develop/python/activities/execution.mdx
+++ b/docs/develop/python/activities/execution.mdx
@@ -1,7 +1,7 @@
 ---
 id: execution
 title: Activity execution - Python SDK
-description: Spawn an Activity Execution from a Workflow with the Temporal Python SDK, set the required Activity Timeouts, and get the Activity's result.
+description: Shows how to perform Activity execution with the Python SDK
 sidebar_label: Activity execution
 slug: /develop/python/activities/execution
 toc_max_heading_level: 3

--- a/docs/develop/python/activities/execution.mdx
+++ b/docs/develop/python/activities/execution.mdx
@@ -1,14 +1,14 @@
 ---
 id: execution
 title: Activity execution - Python SDK
-description: Shows how to perform Activity execution with the Python SDK
+description: Spawn an Activity Execution from a Workflow with the Temporal Python SDK, set the required Activity Timeouts, and get the Activity's result.
 sidebar_label: Activity execution
 slug: /develop/python/activities/execution
 toc_max_heading_level: 3
 tags:
+  - Activities
   - Python SDK
   - Temporal SDKs
-  - Activity
 ---
 
 ## Start an Activity Execution {/* #activity-execution */}

--- a/docs/develop/python/activities/index.mdx
+++ b/docs/develop/python/activities/index.mdx
@@ -2,7 +2,7 @@
 id: index
 title: Activities - Python SDK
 sidebar_label: Activities
-description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in Python.
+description: This section explains how to implement Activities with the Python SDK
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -23,7 +23,7 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/python/activities/basics)
 - [Activity execution](/develop/python/activities/execution)
 - [Standalone Activities Quickstart](/develop/python/activities/standalone-activities-quickstart)
-- [Standalone Activities](/develop/python/activities/standalone-activities)
+- [Standalone Activities Feature Guide](/develop/python/activities/standalone-activities)
 - [Timeouts](/develop/python/activities/timeouts)
-- [Asynchronous Activity Completion](/develop/python/activities/asynchronous-activity)
+- [Asynchronous Activity completion](/develop/python/activities/asynchronous-activity)
 - [Benign exceptions](/develop/python/activities/benign-exceptions)

--- a/docs/develop/python/activities/index.mdx
+++ b/docs/develop/python/activities/index.mdx
@@ -2,9 +2,10 @@
 id: index
 title: Activities - Python SDK
 sidebar_label: Activities
-description: This section explains how to implement Activities with the Python SDK
+description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in Python.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Python SDK
   - Temporal SDKs
 ---
@@ -22,7 +23,7 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/python/activities/basics)
 - [Activity execution](/develop/python/activities/execution)
 - [Standalone Activities Quickstart](/develop/python/activities/standalone-activities-quickstart)
-- [Standalone Activities Feature Guide](/develop/python/activities/standalone-activities)
+- [Standalone Activities](/develop/python/activities/standalone-activities)
 - [Timeouts](/develop/python/activities/timeouts)
-- [Asynchronous Activity completion](/develop/python/activities/asynchronous-activity)
+- [Asynchronous Activity Completion](/develop/python/activities/asynchronous-activity)
 - [Benign exceptions](/develop/python/activities/benign-exceptions)

--- a/docs/develop/python/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/python/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Quickstart - Python SDK
+title: Standalone Activities Python Quickstart
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal Python SDK without writing a Workflow.
 tags:

--- a/docs/develop/python/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/python/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Python Quickstart
+title: Standalone Activities Quickstart - Python SDK
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal Python SDK without writing a Workflow.
 tags:

--- a/docs/develop/python/activities/standalone-activities.mdx
+++ b/docs/develop/python/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities - Python SDK
+title: Standalone Activities Feature Guide
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/python/activities/standalone-activities.mdx
+++ b/docs/develop/python/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities Feature Guide
+title: Standalone Activities - Python SDK
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/python/activities/timeouts.mdx
+++ b/docs/develop/python/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Python SDK
 sidebar_label: Timeouts
-description: Optimize Workflow Execution with Temporal Python SDK - Set Activity Timeouts and Retry Policies efficiently.
+description: Set Activity Timeouts and a Retry Policy with the Temporal Python SDK, override the next retry delay, and Heartbeat long-running Activities.
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/python/activities/timeouts.mdx
+++ b/docs/develop/python/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Python SDK
 sidebar_label: Timeouts
-description: Set Activity Timeouts and a Retry Policy with the Temporal Python SDK, override the next retry delay, and Heartbeat long-running Activities.
+description: Set the Schedule-To-Close, Start-To-Close, and Heartbeat Timeouts on a Python Activity, tune its Retry Policy, and override the next retry delay.
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -144,7 +144,7 @@ async def your_activity_definition() -> str:
 In addition to obtaining cancellation information, Heartbeats also support detail data that persists on the server for retrieval during Activity retry.
 If an Activity calls `heartbeat(123, 456)` and then fails and is retried, `heartbeat_details` returns an iterable containing `123` and `456` on the next Run.
 
-#### Set a Heartbeat Timeout {/* #heartbeat-timeout */}
+### Set a Heartbeat Timeout {/* #heartbeat-timeout */}
 
 A [Heartbeat Timeout](/encyclopedia/detecting-activity-failures#heartbeat-timeout) works in conjunction with [Activity Heartbeats](/encyclopedia/detecting-activity-failures#activity-heartbeat).
 

--- a/docs/develop/ruby/activities/asynchronous-activity.mdx
+++ b/docs/develop/ruby/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity completion - Ruby SDK
-sidebar_label: Asynchronous Activity completion
+title: Asynchronous Activity Completion - Ruby SDK
+sidebar_label: Asynchronous Activity Completion
 description: Asynchronously complete an Activity in Temporal using the Ruby SDK. Follow simple steps to allow an Activity Function to return without the Activity Execution completing.
 toc_max_heading_level: 4
 tags:
@@ -10,7 +10,7 @@ tags:
   - Temporal SDKs
 ---
 
-## How to asynchronously complete an Activity {/* #asynchronous-activity-completion */}
+## Asynchronously complete an Activity {/* #asynchronous-activity-completion */}
 
 This page describes how to asynchronously complete an Activity.
 

--- a/docs/develop/ruby/activities/asynchronous-activity.mdx
+++ b/docs/develop/ruby/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity Completion - Ruby SDK
-sidebar_label: Asynchronous Activity Completion
+title: Asynchronous Activity completion - Ruby SDK
+sidebar_label: Asynchronous Activity completion
 description: Asynchronously complete an Activity in Temporal using the Ruby SDK. Follow simple steps to allow an Activity Function to return without the Activity Execution completing.
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/ruby/activities/basics.mdx
+++ b/docs/develop/ruby/activities/basics.mdx
@@ -2,7 +2,7 @@
 id: basics
 title: Activity basics - Ruby SDK
 sidebar_label: Activity basics
-description: Define an Activity with the Temporal Ruby SDK, pass a single parameter object, and choose the thread pool or fiber executor that runs it.
+description: This section explains Activity basics with the Ruby SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/ruby/activities/basics.mdx
+++ b/docs/develop/ruby/activities/basics.mdx
@@ -2,9 +2,10 @@
 id: basics
 title: Activity basics - Ruby SDK
 sidebar_label: Activity basics
-description: This section explains Activity basics with the Ruby SDK
+description: Define an Activity with the Temporal Ruby SDK, pass a single parameter object, and choose the thread pool or fiber executor that runs it.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Ruby SDK
   - Temporal SDKs
 ---
@@ -47,7 +48,7 @@ This is so that you can change what data is passed to the Activity without break
 The `execute` method in your Activity can technically accept multiple parameters of any data type that Temporal can convert.
 However, Temporal strongly encourages using a single parameter object to simplify versioning and maintainability.
 
-### Activity Concurrency and Executors {/* #activity-concurrency-and-executors */}
+### Activity concurrency and executors {/* #activity-concurrency-and-executors */}
 
 :::note
 

--- a/docs/develop/ruby/activities/benign-exceptions.mdx
+++ b/docs/develop/ruby/activities/benign-exceptions.mdx
@@ -2,7 +2,7 @@
 id: benign-exceptions
 title: Benign exceptions - Ruby SDK
 sidebar_label: Benign exceptions
-description: Mark expected or non-severe Activity errors as benign to reduce noise in logs, metrics, and OpenTelemetry traces.
+description: Mark expected or non-severe Activity errors as benign in Ruby to reduce noise in logs, metrics, and OpenTelemetry traces.
 toc_max_heading_level: 2
 tags:
   - Activities

--- a/docs/develop/ruby/activities/dynamic-activity.mdx
+++ b/docs/develop/ruby/activities/dynamic-activity.mdx
@@ -1,8 +1,8 @@
 ---
 id: dynamic-activity
-title: Dynamic Activity - Ruby SDK
-sidebar_label: Dynamic Activity
-description: Register a Dynamic Activity with the Temporal Ruby SDK to handle Activity Types that no other registered Activity implementation matches.
+title: Dynamic Activities - Ruby SDK
+sidebar_label: Dynamic Activities
+description: This section explains Dynamic Activities with the Ruby SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/ruby/activities/dynamic-activity.mdx
+++ b/docs/develop/ruby/activities/dynamic-activity.mdx
@@ -1,10 +1,11 @@
 ---
 id: dynamic-activity
-title: Dynamic Activities - Ruby SDK
-sidebar_label: Dynamic Activities
-description: This section explains Dynamic Activities with the Ruby SDK
+title: Dynamic Activity - Ruby SDK
+sidebar_label: Dynamic Activity
+description: Register a Dynamic Activity with the Temporal Ruby SDK to handle Activity Types that no other registered Activity implementation matches.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Ruby SDK
   - Temporal SDKs
 ---

--- a/docs/develop/ruby/activities/execution.mdx
+++ b/docs/develop/ruby/activities/execution.mdx
@@ -1,14 +1,14 @@
 ---
 id: execution
 title: Activity execution - Ruby SDK
-description: Shows how to perform Activity execution with the Ruby SDK
+description: Spawn an Activity Execution from a Workflow with the Temporal Ruby SDK, set the required Activity Timeouts, and get the Activity's result.
 sidebar_label: Activity execution
 slug: /develop/ruby/activities/execution
 toc_max_heading_level: 3
 tags:
+  - Activities
   - Ruby SDK
   - Temporal SDKs
-  - Activity
 ---
 
 ## Start Activity Execution {/* #activity-execution */}

--- a/docs/develop/ruby/activities/execution.mdx
+++ b/docs/develop/ruby/activities/execution.mdx
@@ -1,7 +1,7 @@
 ---
 id: execution
 title: Activity execution - Ruby SDK
-description: Spawn an Activity Execution from a Workflow with the Temporal Ruby SDK, set the required Activity Timeouts, and get the Activity's result.
+description: Shows how to perform Activity execution with the Ruby SDK
 sidebar_label: Activity execution
 slug: /develop/ruby/activities/execution
 toc_max_heading_level: 3

--- a/docs/develop/ruby/activities/index.mdx
+++ b/docs/develop/ruby/activities/index.mdx
@@ -2,7 +2,7 @@
 id: index
 title: Activities - Ruby SDK
 sidebar_label: Activities
-description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in Ruby.
+description: This section explains how to implement Activities with the Ruby SDK
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -23,8 +23,8 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/ruby/activities/basics)
 - [Activity execution](/develop/ruby/activities/execution)
 - [Standalone Activities Quickstart](/develop/ruby/activities/standalone-activities-quickstart)
-- [Standalone Activities](/develop/ruby/activities/standalone-activities)
+- [Standalone Activities Feature Guide](/develop/ruby/activities/standalone-activities)
 - [Timeouts](/develop/ruby/activities/timeouts)
-- [Asynchronous Activity Completion](/develop/ruby/activities/asynchronous-activity)
+- [Asynchronous Activity completion](/develop/ruby/activities/asynchronous-activity)
 - [Dynamic Activity](/develop/ruby/activities/dynamic-activity)
 - [Benign exceptions](/develop/ruby/activities/benign-exceptions)

--- a/docs/develop/ruby/activities/index.mdx
+++ b/docs/develop/ruby/activities/index.mdx
@@ -2,9 +2,10 @@
 id: index
 title: Activities - Ruby SDK
 sidebar_label: Activities
-description: This section explains how to implement Activities with the Ruby SDK
+description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in Ruby.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Ruby SDK
   - Temporal SDKs
 ---
@@ -22,8 +23,8 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/ruby/activities/basics)
 - [Activity execution](/develop/ruby/activities/execution)
 - [Standalone Activities Quickstart](/develop/ruby/activities/standalone-activities-quickstart)
-- [Standalone Activities Feature Guide](/develop/ruby/activities/standalone-activities)
+- [Standalone Activities](/develop/ruby/activities/standalone-activities)
 - [Timeouts](/develop/ruby/activities/timeouts)
-- [Asynchronous Activity completion](/develop/ruby/activities/asynchronous-activity)
+- [Asynchronous Activity Completion](/develop/ruby/activities/asynchronous-activity)
 - [Dynamic Activity](/develop/ruby/activities/dynamic-activity)
 - [Benign exceptions](/develop/ruby/activities/benign-exceptions)

--- a/docs/develop/ruby/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/ruby/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Quickstart - Ruby SDK
+title: Standalone Activities Ruby Quickstart
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal Ruby SDK without writing a Workflow.
 tags:

--- a/docs/develop/ruby/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/ruby/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Ruby Quickstart
+title: Standalone Activities Quickstart - Ruby SDK
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal Ruby SDK without writing a Workflow.
 tags:

--- a/docs/develop/ruby/activities/standalone-activities.mdx
+++ b/docs/develop/ruby/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities Feature Guide
+title: Standalone Activities - Ruby SDK
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/ruby/activities/standalone-activities.mdx
+++ b/docs/develop/ruby/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities - Ruby SDK
+title: Standalone Activities Feature Guide
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/ruby/activities/timeouts.mdx
+++ b/docs/develop/ruby/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Ruby SDK
 sidebar_label: Timeouts
-description: Optimize Workflow Execution with Temporal Ruby SDK - Set Activity Timeouts and Retry Policies efficiently.
+description: Set Activity Timeouts and a Retry Policy with the Temporal Ruby SDK, override the next retry delay, and Heartbeat long-running Activities.
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/ruby/activities/timeouts.mdx
+++ b/docs/develop/ruby/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Ruby SDK
 sidebar_label: Timeouts
-description: Set Activity Timeouts and a Retry Policy with the Temporal Ruby SDK, override the next retry delay, and Heartbeat long-running Activities.
+description: Set the Schedule-To-Close, Start-To-Close, and Heartbeat Timeouts on a Ruby Activity, tune its Retry Policy, and override the next retry delay.
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/rust/activities/basics.mdx
+++ b/docs/develop/rust/activities/basics.mdx
@@ -2,7 +2,7 @@
 id: basics
 title: Activity basics - Rust SDK
 sidebar_label: Activity basics
-description: Define an Activity with the Temporal Rust SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
+description: This section explains Activity basics with the Rust SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/rust/activities/basics.mdx
+++ b/docs/develop/rust/activities/basics.mdx
@@ -2,9 +2,10 @@
 id: basics
 title: Activity basics - Rust SDK
 sidebar_label: Activity basics
-description: This section explains how to implement Activities with the Rust SDK
+description: Define an Activity with the Temporal Rust SDK, pass a single parameter object within Payload size limits, and customize the Activity Type name.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Rust SDK
   - Temporal SDKs
 ---

--- a/docs/develop/rust/activities/execution.mdx
+++ b/docs/develop/rust/activities/execution.mdx
@@ -1,7 +1,7 @@
 ---
 id: execution
 title: Activity execution - Rust SDK
-description: Spawn an Activity Execution from a Workflow with the Temporal Rust SDK, set the required Activity Timeouts, and get the Activity's result.
+description: Shows how to perform Activity execution with the Rust SDK
 sidebar_label: Activity execution
 slug: /develop/rust/activities/execution
 toc_max_heading_level: 3

--- a/docs/develop/rust/activities/execution.mdx
+++ b/docs/develop/rust/activities/execution.mdx
@@ -1,14 +1,14 @@
 ---
 id: execution
 title: Activity execution - Rust SDK
-description: Shows how to perform Activity execution with the Rust SDK
+description: Spawn an Activity Execution from a Workflow with the Temporal Rust SDK, set the required Activity Timeouts, and get the Activity's result.
 sidebar_label: Activity execution
 slug: /develop/rust/activities/execution
 toc_max_heading_level: 3
 tags:
+  - Activities
   - Rust SDK
   - Temporal SDKs
-  - Activity
 ---
 
 ## Start an Activity Execution {/* #activity-execution */}

--- a/docs/develop/rust/activities/index.mdx
+++ b/docs/develop/rust/activities/index.mdx
@@ -2,10 +2,10 @@
 id: index
 title: Activities - Rust SDK
 sidebar_label: Activities
-description:
-  This section explains how to implement Activities with the Rust SDK
+description: Define Activities, spawn Activity Executions from a Workflow, and set Activity Timeouts, Retry Policies, and Heartbeats with the Temporal Rust SDK.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - Rust SDK
   - Temporal SDKs
 ---

--- a/docs/develop/rust/activities/index.mdx
+++ b/docs/develop/rust/activities/index.mdx
@@ -2,7 +2,8 @@
 id: index
 title: Activities - Rust SDK
 sidebar_label: Activities
-description: Define Activities, spawn Activity Executions from a Workflow, and set Activity Timeouts, Retry Policies, and Heartbeats with the Temporal Rust SDK.
+description:
+  This section explains how to implement Activities with the Rust SDK
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/rust/activities/timeouts.mdx
+++ b/docs/develop/rust/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Rust SDK
 sidebar_label: Timeouts
-description: Optimize Workflow Execution with the Temporal Rust SDK by configuring Activity Timeouts, Retry Policies, and Heartbeats.
+description: Set Activity Timeouts and a Retry Policy with the Temporal Rust SDK, override the next retry delay, and Heartbeat long-running Activities.
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -103,7 +103,7 @@ impl TestGreetActivities {
 
 An [Activity Heartbeat](/encyclopedia/detecting-activity-failures#activity-heartbeat) is a signal from the [Worker Process](/workers#worker-process) executing the Activity to the [Temporal Service](/temporal-service). Each heartbeat tells the service that the [Activity Execution](/activity-execution) is still making progress and that the Worker has not crashed. If the service does not receive a heartbeat within the configured [Heartbeat Timeout](/encyclopedia/detecting-activity-failures#heartbeat-timeout), the Activity can time out and be retried according to its Retry Policy.
 
-Heartbeats may be throttled by the Worker, so not every heartbeat call is necessarily sent immediately to the Temporal Service. Activity cancellation is also delivered through heartbeat processing, which means Activities that don't heartbeat cannot receive cancellation promptly. ([Temporal Docs][3])
+Heartbeats may be throttled by the Worker, so not every heartbeat call is necessarily sent immediately to the Temporal Service. Activity cancellation is also delivered through heartbeat processing, which means Activities that don't heartbeat cannot receive cancellation promptly.
 
 Heartbeats can include `details` that describe current progress. If the Activity fails and is retried, the retried attempt can retrieve the details from the most recently recorded heartbeat. The Rust SDK exposes activity context support for heartbeat details.
 

--- a/docs/develop/rust/activities/timeouts.mdx
+++ b/docs/develop/rust/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - Rust SDK
 sidebar_label: Timeouts
-description: Set Activity Timeouts and a Retry Policy with the Temporal Rust SDK, override the next retry delay, and Heartbeat long-running Activities.
+description: Set the Schedule-To-Close, Start-To-Close, and Heartbeat Timeouts on a Rust Activity, tune its Retry Policy, and override the next retry delay.
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/typescript/activities/asynchronous-activity.mdx
+++ b/docs/develop/typescript/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity - TypeScript SDK
-sidebar_label: Asynchronous Activity
+title: Asynchronous Activity Completion - TypeScript SDK
+sidebar_label: Asynchronous Activity Completion
 slug: /develop/typescript/activities/asynchronous-activity
 toc_max_heading_level: 2
 tags:
@@ -11,7 +11,7 @@ tags:
 description: Asynchronously complete an Activity in Temporal by enabling the Activity Function to return before the Activity Execution finishes, using AsyncCompletionClient.
 ---
 
-## How to asynchronously complete an Activity {/* #asynchronous-activity-completion */}
+## Asynchronously complete an Activity {/* #asynchronous-activity-completion */}
 
 [Asynchronous Activity Completion](/activity-execution#asynchronous-activity-completion) enables the Activity Function to return without the Activity Execution completing.
 

--- a/docs/develop/typescript/activities/asynchronous-activity.mdx
+++ b/docs/develop/typescript/activities/asynchronous-activity.mdx
@@ -1,7 +1,7 @@
 ---
 id: asynchronous-activity
-title: Asynchronous Activity Completion - TypeScript SDK
-sidebar_label: Asynchronous Activity Completion
+title: Asynchronous Activity - TypeScript SDK
+sidebar_label: Asynchronous Activity
 slug: /develop/typescript/activities/asynchronous-activity
 toc_max_heading_level: 2
 tags:

--- a/docs/develop/typescript/activities/basics.mdx
+++ b/docs/develop/typescript/activities/basics.mdx
@@ -1,7 +1,7 @@
 ---
 id: basics
 title: Activity basics - TypeScript SDK
-description: Define an Activity with the Temporal TypeScript SDK, choose parameters and return values, and share dependencies across Activity functions.
+description: Shows how to create an Activity with the TypeScript SDK
 sidebar_label: Activity basics
 slug: /develop/typescript/activities/basics
 toc_max_heading_level: 3

--- a/docs/develop/typescript/activities/basics.mdx
+++ b/docs/develop/typescript/activities/basics.mdx
@@ -1,17 +1,17 @@
 ---
 id: basics
 title: Activity basics - TypeScript SDK
-description: Shows how to create an Activity with the TypeScript SDK
+description: Define an Activity with the Temporal TypeScript SDK, choose parameters and return values, and share dependencies across Activity functions.
 sidebar_label: Activity basics
 slug: /develop/typescript/activities/basics
 toc_max_heading_level: 3
 tags:
+  - Activities
   - TypeScript SDK
   - Temporal SDKs
-  - Activity
 ---
 
-## How to develop an Activity {/* #develop-activities */}
+## Develop an Activity {/* #develop-activities */}
 
 One of the primary things that Workflows do is orchestrate the execution of Activities. An Activity is a normal function
 or method execution that's intended to execute a single, well-defined action (either short or long-running), such as
@@ -38,7 +38,7 @@ export async function greet(name: string): Promise<string> {
 ```
 <!--SNIPEND-->
 
-## How to develop Activity Parameters {/* #activity-parameters */}
+## Develop Activity parameters {/* #activity-parameters */}
 
 There is no explicit limit to the total number of parameters that an [Activity Definition](/activity-definition) may
 support. However, there is a limit to the total size of the data that ends up encoded into a gRPC message Payload.
@@ -69,7 +69,7 @@ export async function greet(name: string): Promise<string> {
 ```
 <!--SNIPEND-->
 
-## How to define Activity return values {/* #activity-return-values */}
+## Define Activity return values {/* #activity-return-values */}
 
 All data returned from an Activity must be serializable.
 
@@ -88,7 +88,7 @@ export async function greet(name: string): Promise<string> {
 }
 ```
 
-## How to customize your Activity Type {/* #activity-type */}
+## Customize your Activity Type {/* #activity-type */}
 
 Activities have a Type that are referred to as the Activity name. The following examples demonstrate how to set a custom
 name for your Activity Type.

--- a/docs/develop/typescript/activities/benign-exceptions.mdx
+++ b/docs/develop/typescript/activities/benign-exceptions.mdx
@@ -2,7 +2,7 @@
 id: benign-exceptions
 title: Benign exceptions - TypeScript SDK
 sidebar_label: Benign exceptions
-description: Mark expected or non-severe Activity errors as benign to reduce noise in logs, metrics, and OpenTelemetry traces.
+description: Mark expected or non-severe Activity errors as benign in TypeScript to reduce noise in logs, metrics, and OpenTelemetry traces.
 toc_max_heading_level: 2
 tags:
   - Activities

--- a/docs/develop/typescript/activities/execution.mdx
+++ b/docs/develop/typescript/activities/execution.mdx
@@ -1,7 +1,7 @@
 ---
 id: execution
 title: Activity execution - TypeScript SDK
-description: Spawn an Activity Execution from a Workflow with the Temporal TypeScript SDK, set the required Activity Timeouts, and get the Activity's result.
+description: Shows how to perform Activity execution with the TypeScript SDK
 sidebar_label: Activity execution
 slug: /develop/typescript/activities/execution
 toc_max_heading_level: 3
@@ -50,10 +50,14 @@ also retry an Activity if it fails or times out. For this reason, you should wri
 [idempotent](/encyclopedia/activities/activity-definition.mdx#idempotency): calling them multiple times with the
 same input should have the same effect as calling them once.
 
-:::tip Every Activity call you make is recorded in the Workflow’s execution history, including the parameters you pass
+:::tip
+
+Every Activity call you make is recorded in the Workflow’s execution history, including the parameters you pass
 in and the value that comes back. This history is what allows Temporal to recover a Workflow after a failure. Because
 the entire history must be stored and replayed, avoid passing large objects as Activity inputs or return values. Keeping
-payloads small will help your Workflows replay and recover efficiently. :::
+payloads small will help your Workflows replay and recover efficiently.
+
+:::
 
 ## Set the required Activity Timeouts {/* #required-timeout */}
 

--- a/docs/develop/typescript/activities/execution.mdx
+++ b/docs/develop/typescript/activities/execution.mdx
@@ -1,17 +1,17 @@
 ---
 id: execution
 title: Activity execution - TypeScript SDK
-description: Shows how to perform Activity execution with the TypeScript SDK
+description: Spawn an Activity Execution from a Workflow with the Temporal TypeScript SDK, set the required Activity Timeouts, and get the Activity's result.
 sidebar_label: Activity execution
 slug: /develop/typescript/activities/execution
 toc_max_heading_level: 3
 tags:
+  - Activities
   - TypeScript SDK
   - Temporal SDKs
-  - Activity
 ---
 
-## How to start an Activity Execution {/* #activity-execution */}
+## Start an Activity Execution {/* #activity-execution */}
 
 Calls to spawn [Activity Executions](/activity-execution) are written within a
 [Workflow Definition](/workflow-definition). In TypeScript, you never call an Activity function directly. Instead, you
@@ -55,14 +55,14 @@ in and the value that comes back. This history is what allows Temporal to recove
 the entire history must be stored and replayed, avoid passing large objects as Activity inputs or return values. Keeping
 payloads small will help your Workflows replay and recover efficiently. :::
 
-## How to set the required Activity Timeouts {/* #required-timeout */}
+## Set the required Activity Timeouts {/* #required-timeout */}
 
 Activity Execution semantics rely on several parameters. The only required value that needs to be set is either a
 [Schedule-To-Close Timeout](/encyclopedia/detecting-activity-failures#schedule-to-close-timeout) or a
 [Start-To-Close Timeout](/encyclopedia/detecting-activity-failures#start-to-close-timeout). These values are set in the
 Activity Options.
 
-## How to get the results of an Activity Execution {/* #get-activity-results */}
+## Get the results of an Activity Execution {/* #get-activity-results */}
 
 The call to spawn an [Activity Execution](/activity-execution) generates the
 [ScheduleActivityTask](/references/commands#scheduleactivitytask) Command and provides the Workflow with an Awaitable.

--- a/docs/develop/typescript/activities/index.mdx
+++ b/docs/develop/typescript/activities/index.mdx
@@ -2,7 +2,7 @@
 id: index
 title: Activities - TypeScript SDK
 sidebar_label: Activities
-description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in TypeScript.
+description: This section explains how to implement Activities with the TypeScript SDK
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -23,7 +23,7 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/typescript/activities/basics)
 - [Activity execution](/develop/typescript/activities/execution)
 - [Standalone Activities Quickstart](/develop/typescript/activities/standalone-activities-quickstart)
-- [Standalone Activities](/develop/typescript/activities/standalone-activities)
+- [Standalone Activities Feature Guide](/develop/typescript/activities/standalone-activities)
 - [Timeouts](/develop/typescript/activities/timeouts)
-- [Asynchronous Activity Completion](/develop/typescript/activities/asynchronous-activity)
+- [Asynchronous Activity](/develop/typescript/activities/asynchronous-activity)
 - [Benign exceptions](/develop/typescript/activities/benign-exceptions)

--- a/docs/develop/typescript/activities/index.mdx
+++ b/docs/develop/typescript/activities/index.mdx
@@ -2,9 +2,10 @@
 id: index
 title: Activities - TypeScript SDK
 sidebar_label: Activities
-description: This section explains how to implement Activities with the TypeScript SDK
+description: Define Activities, spawn Activity Executions, set Timeouts and Retry Policies, run Standalone Activities, and mark benign errors in TypeScript.
 toc_max_heading_level: 4
 tags:
+  - Activities
   - TypeScript SDK
   - Temporal SDKs
 ---
@@ -22,7 +23,7 @@ import * as Components from '@site/src/components';
 - [Activity basics](/develop/typescript/activities/basics)
 - [Activity execution](/develop/typescript/activities/execution)
 - [Standalone Activities Quickstart](/develop/typescript/activities/standalone-activities-quickstart)
-- [Standalone Activities Feature Guide](/develop/typescript/activities/standalone-activities)
+- [Standalone Activities](/develop/typescript/activities/standalone-activities)
 - [Timeouts](/develop/typescript/activities/timeouts)
-- [Asynchronous Activity](/develop/typescript/activities/asynchronous-activity)
+- [Asynchronous Activity Completion](/develop/typescript/activities/asynchronous-activity)
 - [Benign exceptions](/develop/typescript/activities/benign-exceptions)

--- a/docs/develop/typescript/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/typescript/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities Quickstart - TypeScript SDK
+title: Standalone Activities TypeScript Quickstart
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal TypeScript SDK without writing a Workflow.
 tags:

--- a/docs/develop/typescript/activities/standalone-activities-quickstart.mdx
+++ b/docs/develop/typescript/activities/standalone-activities-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities-quickstart
-title: Standalone Activities TypeScript Quickstart
+title: Standalone Activities Quickstart - TypeScript SDK
 sidebar_label: Quickstart
 description: Execute a Standalone Activity with the Temporal TypeScript SDK without writing a Workflow.
 tags:

--- a/docs/develop/typescript/activities/standalone-activities.mdx
+++ b/docs/develop/typescript/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities Feature Guide
+title: Standalone Activities - TypeScript SDK
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/typescript/activities/standalone-activities.mdx
+++ b/docs/develop/typescript/activities/standalone-activities.mdx
@@ -1,6 +1,6 @@
 ---
 id: standalone-activities
-title: Standalone Activities - TypeScript SDK
+title: Standalone Activities Feature Guide
 sidebar_label: Feature Guide
 toc_max_heading_level: 4
 tags:

--- a/docs/develop/typescript/activities/timeouts.mdx
+++ b/docs/develop/typescript/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - TypeScript SDK
 sidebar_label: Timeouts
-description: Set Activity Timeouts and a Retry Policy with the Temporal TypeScript SDK, override the next retry delay, and Heartbeat long-running Activities.
+description: Set the Schedule-To-Close, Start-To-Close, and Heartbeat Timeouts on a TypeScript Activity, tune its Retry Policy, and override the next retry delay.
 toc_max_heading_level: 4
 tags:
   - Activities

--- a/docs/develop/typescript/activities/timeouts.mdx
+++ b/docs/develop/typescript/activities/timeouts.mdx
@@ -2,7 +2,7 @@
 id: timeouts
 title: Activity Timeouts - TypeScript SDK
 sidebar_label: Timeouts
-description: Optimize Workflow Execution with Temporal TypeScript SDK - Set Activity Timeouts and Retry Policies efficiently.
+description: Set Activity Timeouts and a Retry Policy with the Temporal TypeScript SDK, override the next retry delay, and Heartbeat long-running Activities.
 toc_max_heading_level: 4
 tags:
   - Activities
@@ -17,7 +17,7 @@ This page shows how to do the following:
 
 - [Activity Timeouts](#activity-timeouts)
 - [Activity Retry Policy](#activity-retries)
-- [Activity next Retry delay](#activity-next-retry-delay)
+- [Activity next retry delay](#activity-next-retry-delay)
 - [Heartbeat an Activity](#activity-heartbeats)
 - [Activity Heartbeat Timeout](#activity-heartbeat-timeout)
 
@@ -69,7 +69,7 @@ const { myActivity } = proxyActivities<typeof activities>({
 });
 ```
 
-## Activity next Retry delay {/* #activity-next-retry-delay */}
+## Activity next retry delay {/* #activity-next-retry-delay */}
 
 **How to override the next Retry delay following an Activity failure using the Temporal TypeScript SDK**
 


### PR DESCRIPTION
## What does this PR do?
- stray ([Temporal Docs][3]) citation in rust/activities/timeouts.mdx is gone
- Activities tag is now present on all 41 pages under docs/develop/*/activities/ with the timeouts pages carrying an identical tag set across all eight SDK 
- "How to" heading cleanup 
## Notes to reviewers

<!-- delete if n/a -->
