### PR TITLE
Update AGENTS.md and STYLE.md to reflect use of ID in preference to Id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,10 @@ Exceptions: **Multi-Cluster Replication**, code/config identifiers, and CLI comm
 
 ### Identifier abbreviation
 
-Outside Temporal core terms, spell out "identifier." For core terms, use `Id` (not `ID` or `id`).
+Outside Temporal core terms, spell out "identifier." For core terms, use `ID` (not `Id` or `id`).
 
-- Correct: "Provide an order identifier as a Workflow Id."
-- Incorrect: "Provide an order ID as a Workflow ID."
+- Correct: "Provide an order identifier as a Workflow ID."
+- Incorrect: "Provide an order Id as a Workflow Id."
 
 In code blocks, follow each language's conventions.
 
@@ -264,7 +264,7 @@ Generated register:
 - Operational shorthand that names a technique without stating the action the reader must take. For example, replace
   "move the data out of band" with "store the data in external storage and pass a reference through Event History."
 - In procedural or triage guidance, lead with the reader's action and then give the reason or constraint. For example,
-  prefer "Find the Workflow Id and Run Id in Worker logs because the metric does not carry a Workflow Id" over
+  prefer "Find the Workflow ID and Run ID in Worker logs because the metric does not carry a Workflow ID" over
   describing the metric's limitation before saying what the reader should do.
 - "Quietly" or similar words added to a sentence that does not need them.
 - Junk drawer lists, meaning bullets collected under one heading with no shared idea holding them

--- a/readme/STYLE.md
+++ b/readme/STYLE.md
@@ -51,11 +51,11 @@ Prefer common, concrete verbs and nouns.
 
 #### Abbreviation of "identifier"
 
-Do not abbreviate the word "identifier" as "ID", "Id", or "id" unless it's part of a Temporal core term. For core terms, the correct abbreviation is "Id", such as in "Workflow Id" or "Activity Id".
+Do not abbreviate the word "identifier" as "ID", "Id", or "id" unless it's part of a Temporal core term. For core terms, the correct abbreviation is "ID", such as in "Workflow ID" or "Activity ID".
 
-- Correct: "You can provide an order identifier or customer identifier as a Workflow Id."
+- Correct: "You can provide an order identifier or customer identifier as a Workflow ID."
 
-- Incorrect: "You can provide an order ID or customer id as a Workflow Id."
+- Incorrect: "You can provide an order Id or customer id as a Workflow Id."
 
 In code (and when quoting or referring to code in text), follow the conventions of each language.
 


### PR DESCRIPTION
## What does this PR do?

Updates AGENTS.md and STYLE.md to reflect correct usage of ID instead of Id

## Notes to reviewers

Per our [Word Usage](https://app.notion.com/p/temporalio/Word-Usage-2438fc567738805e9e26f55242e0672b) page, Temporal style prefers using "ID" to refer to Temporal entities such as "Account ID" or "User ID." This PR updates AGENTS.md and STYLE.md to reflect that usage.

<!-- delete if n/a -->
